### PR TITLE
Fixed: update in example/lib/queued_interceptor_csrftoken.dart

### DIFF
--- a/dio/lib/src/response.dart
+++ b/dio/lib/src/response.dart
@@ -32,16 +32,6 @@ class Response<T> {
   /// Http status code.
   int? statusCode;
 
-  /// Returns if the response has an error
-  ///
-  /// `hasError` is true when status code is not between 200 and 299
-  bool get hasError => statusCode != null && statusCode! ~/ 100 != 2;
-
-  /// Returns if the response has succeed
-  ///
-  /// `hasSucceed` is true when status code is between 200 and 299
-  bool get hasSucceed => !hasError;
-
   /// Returns the reason phrase associated with the status code.
   /// The reason phrase must be set before the body is written
   /// to. Setting the reason phrase after writing to the body.

--- a/dio/lib/src/response.dart
+++ b/dio/lib/src/response.dart
@@ -32,6 +32,16 @@ class Response<T> {
   /// Http status code.
   int? statusCode;
 
+  /// Returns if the response has an error
+  ///
+  /// `hasError` is true when status code is not between 200 and 299
+  bool get hasError => statusCode != null && statusCode! ~/ 100 != 2;
+
+  /// Returns if the response has succeed
+  ///
+  /// `hasSucceed` is true when status code is between 200 and 299
+  bool get hasSucceed => !hasError;
+
   /// Returns the reason phrase associated with the status code.
   /// The reason phrase must be set before the body is written
   /// to. Setting the reason phrase after writing to the body.

--- a/example/lib/queued_interceptor_crsftoken.dart
+++ b/example/lib/queued_interceptor_crsftoken.dart
@@ -19,7 +19,7 @@ void main() async {
 
         final result = await tokenDio.get('/token');
 
-        if (result.hasSucceed) {
+        if (result.statusCode != null && result.statusCode! ~/ 100 == 2) {
           /// assume `token` is in response body
           final body = jsonDecode(result.data) as Map<String, dynamic>?;
 
@@ -64,7 +64,7 @@ void main() async {
           /// since the api has no state, force to pass the 401 error
           /// by adding query parameter
           final originResult = await dio.fetch(options..path += '&pass=true');
-          if (originResult.hasSucceed) {
+          if (originResult.statusCode != null && originResult.statusCode! ~/ 100 == 2) {
             return handler.resolve(originResult);
           }
         }

--- a/example/lib/queued_interceptor_crsftoken.dart
+++ b/example/lib/queued_interceptor_crsftoken.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
@@ -7,57 +8,70 @@ void main() async {
   //  dio instance to request token
   var tokenDio = Dio();
   String? csrfToken;
-  dio.options.baseUrl = 'http://www.dtworkroom.com/doris/1/2.0.0/';
+  dio.options.baseUrl = 'https://seunghwanlytest.mocklab.io/';
   tokenDio.options = dio.options;
   dio.interceptors.add(QueuedInterceptorsWrapper(
-    onRequest: (options, handler) {
+    onRequest: (options, handler) async {
       print('send request：path:${options.path}，baseURL:${options.baseUrl}');
+
       if (csrfToken == null) {
         print('no token，request token firstly...');
-        tokenDio.get('/token').then((d) {
-          options.headers['csrfToken'] = csrfToken = d.data['data']['token'];
-          print('request token succeed, value: ' + d.data['data']['token']);
-          print(
-              'continue to perform request：path:${options.path}，baseURL:${options.path}');
-          handler.next(options);
-        }).catchError((error, stackTrace) {
-          handler.reject(error, true);
-        });
-      } else {
-        options.headers['csrfToken'] = csrfToken;
-        return handler.next(options);
-      }
-    },
-    onError: (error, handler) {
-      //print(error);
-      // Assume 401 stands for token expired
-      if (error.response?.statusCode == 401) {
-        var options = error.response!.requestOptions;
-        // If the token has been updated, repeat directly.
-        if (csrfToken != options.headers['csrfToken']) {
-          options.headers['csrfToken'] = csrfToken;
-          //repeat
-          dio.fetch(options).then(
-            (r) => handler.resolve(r),
-            onError: (e) {
-              handler.reject(e);
-            },
-          );
-          return;
+
+        final result = await tokenDio.get('/token');
+
+        if (result.hasSucceed) {
+          /// assume `token` is in response body
+          final body = jsonDecode(result.data) as Map<String, dynamic>?;
+
+          if (body != null && body.containsKey('data')) {
+            options.headers['csrfToken'] = csrfToken = body['data']['token'];
+            print('request token succeed, value: $csrfToken');
+            print(
+              'continue to perform request：path:${options.path}，baseURL:${options.path}',
+            );
+            return handler.next(options);
+          }
         }
-        tokenDio.get('/token').then((d) {
-          //update csrfToken
-          options.headers['csrfToken'] = csrfToken = d.data['data']['token'];
-        }).then((e) {
-          //repeat
-          dio.fetch(options).then(
-            (r) => handler.resolve(r),
-            onError: (e) {
-              handler.reject(e);
-            },
-          );
-        });
-        return;
+
+        return handler.reject(
+          DioError(requestOptions: result.requestOptions),
+          true,
+        );
+      }
+
+      options.headers['csrfToken'] = csrfToken;
+      return handler.next(options);
+    },
+    onError: (error, handler) async {
+      /// Assume 401 stands for token expired
+      if (error.response?.statusCode == 401) {
+        print('the token has expired, need to receive new token');
+        final options = error.response!.requestOptions;
+
+        /// assume receiving the token has no errors
+        /// to check `null-safety` and error handling
+        /// please check inside the [onRequest] closure
+        final tokenResult = await tokenDio.get('/token');
+
+        /// update [csrfToken]
+        /// assume `token` is in response body
+        final body = jsonDecode(tokenResult.data) as Map<String, dynamic>?;
+        options.headers['csrfToken'] = csrfToken = body!['data']['token'];
+
+        if (options.headers['csrfToken'] != null) {
+          print('the token has been updated');
+
+          /// since the api has no state, force to pass the 401 error
+          /// by adding query parameter
+          final originResult = await dio.fetch(options..path += '&pass=true');
+          if (originResult.hasSucceed) {
+            return handler.resolve(originResult);
+          }
+        }
+        print('the token has not been updated');
+        return handler.reject(
+          DioError(requestOptions: options),
+        );
       }
       return handler.next(error);
     },
@@ -67,9 +81,9 @@ void main() async {
     print('request ok!');
   }
 
-  await Future.wait([
-    dio.get('/test?tag=1').then(_onResult),
-    dio.get('/test?tag=2').then(_onResult),
-    dio.get('/test?tag=3').then(_onResult)
-  ]);
+  /// assume `/test?tag=2` path occurs the authorization error (401)
+  /// and token to be updated
+  await dio.get('/test?tag=1').then(_onResult);
+  await dio.get('/test?tag=2').then(_onResult);
+  await dio.get('/test?tag=3').then(_onResult);
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: example/interceptor_lock.dart

### Pull Request Description

In my case, the example code had keep occurring the infinite requests to the server
So, I changed the callback functions to `await` and it worked :)

Here is the code that I run
#### `options`
``` dart
dio.options.connectTimeout = 5000;
dio.options.maxRedirects = 3;
dio.options.responseType = ResponseType.bytes;
```
#### `onRequest`, if the token is null 
``` dart
           tokenDio
              .post('/obtain-token/', data: jsonEncode(requestBody))
              .then((res) {
            /// response will be different by server
            final parsedResult = jsonDecode(utf8.decode(res.data as Uint8List));
            accessToken = parsedResult['result']['access'];
            refreshToken = parsedResult['result']['refresh'];
            options.headers['Authorization'] = 'Bearer $accessToken';

            /// save to [SharedPrefernces], it can be null
            prefs.setString('accessToken', accessToken!);
            prefs.setString('refreshToken', refreshToken!);

            /// go on to next operation
            handler.next(options);
          }).catchError((error, stackTrace) {
            log(error.toString());
            handler.reject(error, true);
          }).whenComplete(
                  () => dio.unlock()); // unlock after all the task is done
```

#### `onError`, if the status code is 401
``` dart
     if ('Bearer $accessToken' != options.headers['Authorization']) {
            log('Bearer ${accessToken!}', name: 'string');
            log(options.headers['Authorization'], name: 'option');
            options.headers['Authorization'] = 'Bearer $accessToken';

            final response = await dio.fetch(options);
            return handler.resolve(response);
          }
```
### Summary

What I recommend is that avoid using too many callback functions in a single task 
I think nested callback functions can occur some conflicts and are hard to debug as well 👍 

