### PR TITLE
wait on checkIfNeedEnqueue function

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -664,7 +664,7 @@ abstract class DioMixin implements Dio {
       }
       checkCancelled(cancelToken);
       if (statusOk) {
-        return checkIfNeedEnqueue(interceptors.responseLock, () => ret)
+        return await checkIfNeedEnqueue(interceptors.responseLock, () => ret)
             as Response<T>;
       } else {
         throw DioError(


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

I experienced this issue 
`An error occurred. type 'Future<Response<dynamic>>' is not a subtype of type 'Response<dynamic>'` 
which is very much similar to Issue #1.

I realized the `_checkIfNeedEnqueue` function was returning a `FutureOr` type which wasn't awaited in the `_dispatchRequest` method. 