### PR TITLE
refine http2_adapter/test/http2_test.dart

### DIFF
--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -3,13 +3,13 @@ import 'package:test/test.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 
 void main() {
-  test('adds one to input values', () async {
+  test('get requests', () async {
     var dio = Dio()
       ..options.baseUrl = 'https://www.ustc.edu.cn/'
       ..interceptors.add(LogInterceptor())
       ..httpClientAdapter = Http2Adapter(
         ConnectionManager(
-          idleTimeout: 10,
+          idleTimeout: 10000,
           onClientCreate: (_, config) => config.onBadCertificate = (_) => true,
         ),
       );
@@ -19,19 +19,73 @@ void main() {
     assert(response.statusCode == 200);
     response = await dio.get(
       'nkjnjknjn.html',
-      options: Options(validateStatus: (status) => true),
+      options: Options(validateStatus: (status) => true), // stop DioError
     );
     assert(response.statusCode == 404);
   });
 
-  test('request with payload', () async {
+  test('post request', () async {
     final dio = Dio()
       ..options.baseUrl = 'https://postman-echo.com/'
-      ..httpClientAdapter = Http2Adapter(ConnectionManager(
-        idleTimeout: 10,
-      ));
+      ..httpClientAdapter = Http2Adapter(ConnectionManager());
 
     final res = await dio.post('post', data: 'TEST');
     assert(res.data['data'] == 'TEST');
+  });
+
+  test('catch badssl', () async {
+    dynamic error;
+    try {
+      final dio = Dio()
+        ..options.baseUrl = 'https://wrong.host.badssl.com/'
+        ..httpClientAdapter = Http2Adapter(ConnectionManager());
+      await dio.get('');
+
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+
+    assert(error.error.osError.toString().contains("Hostname mismatch"));
+  });
+
+  test('allow badssl', () async {
+    dynamic error;
+    try {
+      final dio = Dio()
+        ..options.baseUrl = 'https://wrong.host.badssl.com/'
+        ..httpClientAdapter = Http2Adapter(ConnectionManager(
+          onClientCreate: (_, config) =>
+              config..onBadCertificate = ((_) => true),
+        ));
+      await dio.get('');
+
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+
+    // badssl.com not support HTTP/2 as of now, and no failback in dio_http2_adapter.
+    assert(error.message.contains("HTTP/2 error"));
+  });
+
+  test('request with bad proxy server', () async {
+    dynamic error;
+    final dio = Dio()
+      ..options.baseUrl = 'https://httpbin.org/'
+      ..httpClientAdapter = Http2Adapter(ConnectionManager(
+        onClientCreate: (_, config) =>
+            config..proxy = Uri.parse('http://localhost:45678'),
+      ));
+    try {
+      final res = await dio.get(
+        'response-headers?freeform=TEST',
+      );
+      fail('The connection should have been timed out or rejected.');
+    } on DioError catch (e) {
+      error = e;
+    }
+
+    assert(error.toString().contains("SocketException"));
   });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

Dependency on #1386.

### Pull Request Description
Add the necessary tests as well as an example (undocumented).

1. I'm confused about the `Http2Adapter` not having a fallback to HTTP 1.1.
2. Tried but failed to set up a mock proxy server locally or a free proxy provider for automated testing.