### PR TITLE
Browser adapter time out

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -36,12 +36,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       ..responseType = 'arraybuffer';
 
     final _withCredentials = options.extra['withCredentials'];
-
-    if (_withCredentials != null) {
-      xhr.withCredentials = _withCredentials == true;
-    } else {
-      xhr.withCredentials = withCredentials;
-    }
+    xhr.withCredentials = _withCredentials == true ? true : withCredentials;
 
     options.headers.remove(Headers.contentLengthHeader);
     options.headers.forEach((key, v) => xhr.setRequestHeader(key, '$v'));
@@ -165,8 +160,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     if (options.connectTimeout <= 0) return null;
 
     return Completer<void>()
-      ..future.timeout(Duration(milliseconds: options.connectTimeout)).then(
-        (value) {
+      ..future.timeout(
+        Duration(milliseconds: options.connectTimeout),
+        onTimeout: () {
           if (!completer.isCompleted) {
             completer.completeError(
               DioError(
@@ -190,8 +186,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     if (options.sendTimeout <= 0) return null;
 
     return Completer<void>()
-      ..future.timeout(Duration(milliseconds: options.sendTimeout)).then(
-        (value) {
+      ..future.timeout(
+        Duration(milliseconds: options.sendTimeout),
+        onTimeout: () {
           if (!completer.isCompleted) {
             completer.completeError(
               DioError(
@@ -215,8 +212,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     if (options.receiveTimeout <= 0) return null;
 
     return Completer<void>()
-      ..future.timeout(Duration(milliseconds: options.receiveTimeout)).then(
-        (value) {
+      ..future.timeout(
+        Duration(milliseconds: options.receiveTimeout),
+        onTimeout: () {
           if (!completer.isCompleted) {
             completer.completeError(
               DioError(


### PR DESCRIPTION
### New Pull Request Checklist

- [X ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [X ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [X ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [X ] I have updated the documentation (if necessary)
- [X ] I have run the tests and they pass

This merge request fixes the browser adapter time outs broken from since 4.0.4.

### Pull Request Description

Since version 4.0.4, browser adapter is a bit broken regarding time outs and the 'response' completer.
Using cache, for example, may lead to already completed future.
Connect timeout is launch without any control, etc.

This PR applies the following changes:
- Complete the time outs in every situation.
- Ensure that we do NOT complete more than once the completer.
- Cleanup `fetch` method to be more readable regarding time outs.
- Remove XHR timeout which is wrongly configured and not really used anyway (because of completer)
- Some more tiny cleanups (print, format 80 cols, final, ...).

