### PR TITLE
Fix for "Future already completed" error in web

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -66,7 +66,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     if (options.connectTimeout > 0) {
       Future.delayed(Duration(milliseconds: options.connectTimeout)).then(
         (value) {
-          if (!haveSent) {
+          if (!completer.isCompleted && !haveSent) {
             completer.completeError(
               DioError(
                 requestOptions: options,


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: 
https://github.com/flutterchina/dio/issues/1497

### Pull Request Description
The completer is called without checking if it is already complete, so a "Bad State" completer already completed error is thrown.

