### PR TITLE
Interceptors now gets the StackTrace in the DioError objects

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -554,7 +554,7 @@ abstract class DioMixin implements Dio {
     // we can handle the return value of interceptor callback.
     FutureOr<dynamic> Function(dynamic, StackTrace) _errorInterceptorWrapper(
         InterceptorErrorCallback interceptor) {
-      return (err, stackTrace) {
+      return (err, _) {
         if (err is! InterceptorState) {
           err = InterceptorState(
             assureDioError(
@@ -571,7 +571,8 @@ abstract class DioMixin implements Dio {
             Future(() {
               return checkIfNeedEnqueue(interceptors.errorLock, () {
                 var errorHandler = ErrorInterceptorHandler();
-                interceptor(err.data as DioError, errorHandler);
+                var dioError = (err.data as DioError)..stackTrace = stackTrace;
+                interceptor(dioError, errorHandler);
                 return errorHandler.future;
               });
             }),


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #1173 

### Pull Request Description
The StackTrace will be the same one as you get when surrounding the request with try-catch