### PR TITLE
fix connection timeout runtime

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -44,10 +44,8 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
     late HttpClientRequest request;
     try {
-      request = await reqFuture;
       if (options.connectTimeout > 0) {
-        request = await reqFuture
-            .timeout(Duration(milliseconds: options.connectTimeout));
+        request = await reqFuture.timeout(Duration(milliseconds: options.connectTimeout));
       } else {
         request = await reqFuture;
       }
@@ -173,9 +171,8 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
         _defaultHttpClient =
             onHttpClientCreate!(_defaultHttpClient!) ?? _defaultHttpClient;
       }
-      _defaultHttpClient!.connectionTimeout = _connectionTimeout;
     }
-    return _defaultHttpClient!;
+    return _defaultHttpClient!..connectionTimeout = _connectionTimeout;
   }
 
   @override

--- a/dio/test/readtimeout_test.dart
+++ b/dio/test/readtimeout_test.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
@@ -96,5 +97,36 @@ void main() {
     }
 
     expect(error, isNull);
+  });
+
+  test('#read_timeout - change connectTimeout in run time ', () async {
+
+    var dio = Dio();
+    final adapter = DefaultHttpClientAdapter();
+    final http = HttpClient();
+
+    adapter.onHttpClientCreate = (_) => http;
+    dio.httpClientAdapter = adapter;
+
+    dio.options
+      ..baseUrl = serverUrl.toString()
+      ..connectTimeout = 200;
+
+    try {
+      await dio.get('/');
+    } on DioError catch (e) {
+      //ignore
+    }
+
+    expect(http.connectionTimeout?.inMilliseconds == 200, isTrue);
+
+    try {
+      dio.options.connectTimeout = 1000;
+      await dio.get('/');
+    } on DioError catch (e) {
+      //ignore
+    }
+    expect(http.connectionTimeout?.inMilliseconds == 1000, isTrue);
+
   });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Bug : 
when changing the connection timeout in run time ,its being ignore
this cus by this lines :
loot at the comment

```
 HttpClient _configHttpClient(Future? cancelFuture, int connectionTimeout) {
    var _connectionTimeout = connectionTimeout > 0
        ? Duration(milliseconds: connectionTimeout)
        : null;

    if (cancelFuture != null) {
      var _httpClient = HttpClient();
      _httpClient.userAgent = null;
      if (onHttpClientCreate != null) {
        //user can return a HttpClient instance
        _httpClient = onHttpClientCreate!(_httpClient) ?? _httpClient;
      }
      _httpClient.idleTimeout = Duration(seconds: 0);
      cancelFuture.whenComplete(() {
        Future.delayed(Duration(seconds: 0)).then((e) {
          try {
            _httpClient.close(force: true);
          } catch (e) {
            //...
          }
        });
      });
      return _httpClient..connectionTimeout = _connectionTimeout;
    }
    if (_defaultHttpClient == null) {
      _defaultHttpClient = HttpClient();
      _defaultHttpClient!.idleTimeout = Duration(seconds: 3);
      if (onHttpClientCreate != null) {
        //user can return a HttpClient instance
        _defaultHttpClient =
            onHttpClientCreate!(_defaultHttpClient!) ?? _defaultHttpClient;
      }
      _defaultHttpClient!.connectionTimeout = _connectionTimeout; // --> this line never calls when changing timeout connection
    }
    return _defaultHttpClient!;
  }
```
so i remove this line and set the new connection timeout in the return
