### PR TITLE
fix(pinning): add callback for leaf certificate for better pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ dio/.exampl
 dio/coverage
 dio/test/_download_test.md
 dio/test/_pinning.txt
+dio/test/_good_pinning.txt
+dio/test/_bad_pinning.txt
 
 # plugins
 plugins/cookie_manager/.packages

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dio/.idea/
 dio/.exampl
 dio/coverage
 dio/test/_download_test.md
+dio/test/_pinning.txt
 
 # plugins
 plugins/cookie_manager/.packages

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 Language: [English](README.md) | [中文简体](README-ZH.md)
 
 # dio
+
 [![Pub](https://img.shields.io/pub/v/dio.svg?style=flat-square)](https://pub.dartlang.org/packages/dio)
 [![support](https://img.shields.io/badge/platform-flutter%7Cflutter%20web%7Cdart%20vm-ff69b4.svg?style=flat-square)](https://github.com/flutterchina/dio)
 
-A powerful Http client for Dart, which supports Interceptors, Global configuration, FormData, Request Cancellation, File downloading, Timeout etc. 
+A powerful Http client for Dart, which supports Interceptors, Global configuration, FormData, Request Cancellation, File downloading, Timeout etc.
 
 ## Get started
 
@@ -14,6 +15,7 @@ A powerful Http client for Dart, which supports Interceptors, Global configurati
 dependencies:
   dio: ^4.0.6
 ```
+
 > Already know Dio 3 and just want to learn about what's new in Dio 4? Check out the [Migration Guide](./migration_to_4.x.md)!
 
 ### Super simple to use
@@ -36,17 +38,16 @@ void getHttp() async {
 
 ### Plugins (support 4.x)
 
-| Plugins                                                      | Status                                                       | Description                                                  |
-| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| [dio_cookie_manager](https://github.com/flutterchina/dio/tree/master/plugins/cookie_manager) | [![Pub](https://img.shields.io/pub/v/dio_cookie_manager.svg?style=flat-square)](https://pub.dartlang.org/packages/dio_cookie_manager) | A cookie manager for Dio                                     |
-| [dio_http2_adapter](https://github.com/flutterchina/dio/tree/master/plugins/http2_adapter) | [![Pub](https://img.shields.io/pub/v/dio_http2_adapter.svg?style=flat-square)](https://pub.dartlang.org/packages/dio_http2_adapter) | A Dio HttpClientAdapter which support Http/2.0               |
-| [dio_smart_retry](https://github.com/rodion-m/dio_smart_retry) | [![Pub](https://img.shields.io/pub/v/dio_smart_retry.svg?style=flat-square)](https://pub.dev/packages/dio_smart_retry) | Flexible retry library for Dio               |
-| [http_certificate_pinning](https://github.com/diefferson/http_certificate_pinning) | [![Pub](https://img.shields.io/pub/v/http_certificate_pinning.svg?style=flat-square)](https://pub.dev/packages/http_certificate_pinning) | Https Certificate pinning for Flutter             |
-| [curl_logger_dio_interceptor](https://github.com/OwnWeb/curl_logger_dio_interceptor) | [![Pub](https://img.shields.io/pub/v/curl_logger_dio_interceptor.svg?style=flat-square)](https://pub.dev/packages/curl_logger_dio_interceptor) | A Flutter curl-command generator for Dio.             |
-| [dio_cache_interceptor](https://github.com/llfbandit/dio_cache_interceptor) | [![Pub](https://img.shields.io/pub/v/dio_cache_interceptor.svg?style=flat-square)](https://pub.dev/packages/dio_cache_interceptor) | Dio HTTP cache interceptor with multiple stores respecting HTTP directives (or not)             |
-| [dio_http_cache](https://github.com/hurshi/dio-http-cache) | [![Pub](https://img.shields.io/pub/v/dio_http_cache.svg?style=flat-square)](https://pub.dev/packages/dio_http_cache) | A simple cache library for Dio like Rxcache in Android             |
-| [pretty_dio_logger](https://github.com/Milad-Akarie/pretty_dio_logger) | [![Pub](https://img.shields.io/pub/v/pretty_dio_logger.svg?style=flat-square)](https://pub.dev/packages/pretty_dio_logger) | Pretty Dio logger is a Dio interceptor that logs network calls in a pretty, easy to read format.            |
-
+| Plugins                                                                                      | Status                                                                                                                                         | Description                                                                                      |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [dio_cookie_manager](https://github.com/flutterchina/dio/tree/master/plugins/cookie_manager) | [![Pub](https://img.shields.io/pub/v/dio_cookie_manager.svg?style=flat-square)](https://pub.dartlang.org/packages/dio_cookie_manager)          | A cookie manager for Dio                                                                         |
+| [dio_http2_adapter](https://github.com/flutterchina/dio/tree/master/plugins/http2_adapter)   | [![Pub](https://img.shields.io/pub/v/dio_http2_adapter.svg?style=flat-square)](https://pub.dartlang.org/packages/dio_http2_adapter)            | A Dio HttpClientAdapter which support Http/2.0                                                   |
+| [dio_smart_retry](https://github.com/rodion-m/dio_smart_retry)                               | [![Pub](https://img.shields.io/pub/v/dio_smart_retry.svg?style=flat-square)](https://pub.dev/packages/dio_smart_retry)                         | Flexible retry library for Dio                                                                   |
+| [http_certificate_pinning](https://github.com/diefferson/http_certificate_pinning)           | [![Pub](https://img.shields.io/pub/v/http_certificate_pinning.svg?style=flat-square)](https://pub.dev/packages/http_certificate_pinning)       | Https Certificate pinning for Flutter                                                            |
+| [curl_logger_dio_interceptor](https://github.com/OwnWeb/curl_logger_dio_interceptor)         | [![Pub](https://img.shields.io/pub/v/curl_logger_dio_interceptor.svg?style=flat-square)](https://pub.dev/packages/curl_logger_dio_interceptor) | A Flutter curl-command generator for Dio.                                                        |
+| [dio_cache_interceptor](https://github.com/llfbandit/dio_cache_interceptor)                  | [![Pub](https://img.shields.io/pub/v/dio_cache_interceptor.svg?style=flat-square)](https://pub.dev/packages/dio_cache_interceptor)             | Dio HTTP cache interceptor with multiple stores respecting HTTP directives (or not)              |
+| [dio_http_cache](https://github.com/hurshi/dio-http-cache)                                   | [![Pub](https://img.shields.io/pub/v/dio_http_cache.svg?style=flat-square)](https://pub.dev/packages/dio_http_cache)                           | A simple cache library for Dio like Rxcache in Android                                           |
+| [pretty_dio_logger](https://github.com/Milad-Akarie/pretty_dio_logger)                       | [![Pub](https://img.shields.io/pub/v/pretty_dio_logger.svg?style=flat-square)](https://pub.dev/packages/pretty_dio_logger)                     | Pretty Dio logger is a Dio interceptor that logs network calls in a pretty, easy to read format. |
 
 ### Related Projects
 
@@ -78,17 +79,15 @@ Welcome to submit Dio's third-party plugins and related libraries [here](https:/
 
 - [Https certificate verification](#https-certificate-verification)
 
-- [HttpClientAdapter](#httpclientadapter )
+- [HttpClientAdapter](#httpclientadapter)
 
 - [Cancellation](#cancellation)
 
 - [Extends Dio class](#extends-dio-class)
 
-- [Http2 support](#http2-support )
+- [Http2 support](#http2-support)
 
 - [Features and bugs](#features-and-bugs)
-
-  
 
 ## Examples
 
@@ -135,7 +134,7 @@ print(rs.data.stream); //response stream
 Get response with bytes:
 
 ```dart
-Response<List<int>> rs 
+Response<List<int>> rs
 rs = await Dio().get<List<int>>(url,
  options: Options(responseType: ResponseType.bytes), // set responseType to `bytes`
 );
@@ -178,6 +177,7 @@ response = await dio.post(
   },
 );
 ```
+
 Post binary data by Stream:
 
 ```dart
@@ -195,8 +195,6 @@ await dio.post(
 ```
 
 …you can find all examples code [here](https://github.com/flutterchina/dio/tree/master/example).
-
-
 
 ## Dio APIs
 
@@ -224,7 +222,7 @@ Dio dio = Dio(options);
 The core API in Dio instance is:
 
 **Future<Response> request(String path, {data,Map queryParameters, Options options,CancelToken cancelToken, ProgressCallback onSendProgress,
-    ProgressCallback onReceiveProgress)**
+ProgressCallback onReceiveProgress)**
 
 ```dart
 response = await dio.request(
@@ -258,10 +256,9 @@ Future<Response> download(...)
 Future<Response> fetch(RequestOptions)
 ```
 
-
 ## Request Options
 
-The Options class describes the http request information and configuration. Each Dio instance has a base config for all requests maked by itself, and we can override the base config with [Options] when make a single request.  The  [BaseOptions] declaration as follows:
+The Options class describes the http request information and configuration. Each Dio instance has a base config for all requests maked by itself, and we can override the base config with [Options] when make a single request. The [BaseOptions] declaration as follows:
 
 ```dart
 {
@@ -314,10 +311,10 @@ The Options class describes the http request information and configuration. Each
 
   /// Custom field that you can retrieve it later in [Interceptor]、[Transformer] and the   [Response] object.
   Map<String, dynamic> extra;
-  
+
   /// Common query parameters
-  Map<String, dynamic /*String|Iterable<String>*/ > queryParameters;  
-  
+  Map<String, dynamic /*String|Iterable<String>*/ > queryParameters;
+
    /// [collectionFormat] indicates the format of collection data in request
   /// options which defined in [CollectionFormat] are `csv`, `ssv`, `tsv`, `pipes`, `multi`,`multiCompatible`.
   /// The default value is `multiCompatible`
@@ -343,12 +340,12 @@ The response for a request contains the following information.
   /// Http status code.
   int? statusCode;
   String? statusMessage;
-  /// Whether redirect 
-  bool? isRedirect;  
-  /// redirect info    
+  /// Whether redirect
+  bool? isRedirect;
+  /// redirect info
   List<RedirectInfo> redirects ;
-  /// Returns the final real request uri (maybe redirect). 
-  Uri realUri;    
+  /// Returns the final real request uri (maybe redirect).
+  Uri realUri;
   /// Custom field that you can retrieve it later in `then`.
   Map<String, dynamic> extra;
 }
@@ -382,13 +379,13 @@ dio.interceptors.add(InterceptorsWrapper(
      // Do something with response data
      return handler.next(response); // continue
      // If you want to reject the request with a error message,
-     // you can reject a `DioError` object eg: `handler.reject(dioError)` 
+     // you can reject a `DioError` object eg: `handler.reject(dioError)`
     },
     onError: (DioError e, handler) {
      // Do something with response error
      return  handler.next(e);//continue
      // If you want to resolve the request with some custom data，
-     // you can resolve a `Response` object eg: `handler.resolve(response)`.  
+     // you can resolve a `Response` object eg: `handler.resolve(response)`.
     }
 ));
 
@@ -417,10 +414,9 @@ class CustomInterceptors extends Interceptor {
 }
 ```
 
-
 ### Resolve and reject the request
 
-In all interceptors, you can interfere with their execution flow. If you want to resolve the request/response with some custom data，you can call `handler.resolve(Response)`.  If you want to reject the request/response with a error message, you can call `handler.reject(dioError)` .
+In all interceptors, you can interfere with their execution flow. If you want to resolve the request/response with some custom data，you can call `handler.resolve(Response)`. If you want to reject the request/response with a error message, you can call `handler.reject(dioError)` .
 
 ```dart
 dio.interceptors.add(InterceptorsWrapper(
@@ -434,7 +430,7 @@ print(response.data);//'fake data'
 
 ### QueuedInterceptor
 
-`Interceptor` can be executed concurrently, that is, all of the requests enter the interceptor at once, rather than executing sequentially.  However, in some cases we expect that requests enter the interceptor sequentially like #590 。 Therefore, we need to provide a mechanism for sequential access（one by one） to interceptors  and `QueuedInterceptor` can solve this problem.
+`Interceptor` can be executed concurrently, that is, all of the requests enter the interceptor at once, rather than executing sequentially. However, in some cases we expect that requests enter the interceptor sequentially like #590 。 Therefore, we need to provide a mechanism for sequential access（one by one） to interceptors and `QueuedInterceptor` can solve this problem.
 
 #### Example
 
@@ -466,7 +462,7 @@ Because of security reasons, we need all the requests to set up a csrfToken in t
         return handler.next(options);
       }
     },
-   ); 
+   );
 ```
 
 You can clean the waiting queue by calling `clear()`;
@@ -475,7 +471,7 @@ For complete codes click [here](https://github.com/flutterchina/dio/blob/develop
 
 ### Log
 
-You can set  `LogInterceptor` to  print request/response log automaticlly, for example:
+You can set `LogInterceptor` to print request/response log automaticlly, for example:
 
 ```dart
 dio.interceptors.add(LogInterceptor(responseBody: false)); //开启请求日志
@@ -487,7 +483,7 @@ You can custom interceptor by extending the `Interceptor/QueuedInterceptor` clas
 
 ## Cookie Manager
 
-[dio_cookie_manager](https://github.com/flutterchina/dio/tree/master/plugins/cookie_manager) package is a cookie manager for Dio.  
+[dio_cookie_manager](https://github.com/flutterchina/dio/tree/master/plugins/cookie_manager) package is a cookie manager for Dio.
 
 ## Handling Errors
 
@@ -556,8 +552,6 @@ enum DioErrorType {
 }
 ```
 
-
-
 ## Using application/x-www-form-urlencoded format
 
 By default, Dio serializes request data(except String type) to `JSON`. To send data in the `application/x-www-form-urlencoded` format instead, you can :
@@ -621,7 +615,7 @@ formData.files.addAll([
 
 ### In flutter
 
-If you use dio in flutter development, you'd better to decode json   in background with [compute] function.
+If you use dio in flutter development, you'd better to decode json in background with [compute] function.
 
 ```dart
 
@@ -650,17 +644,17 @@ There is an example for [customizing Transformer](https://github.com/flutterchin
 
 HttpClientAdapter is a bridge between Dio and HttpClient.
 
-Dio implements standard and friendly API  for developer.
+Dio implements standard and friendly API for developer.
 
 HttpClient: It is the real object that makes Http requests.
 
-We can use any HttpClient not just `dart:io:HttpClient` to make the Http request.  And  all we need is providing a `HttpClientAdapter`. The default HttpClientAdapter for Dio is `DefaultHttpClientAdapter`.
+We can use any HttpClient not just `dart:io:HttpClient` to make the Http request. And all we need is providing a `HttpClientAdapter`. The default HttpClientAdapter for Dio is `DefaultHttpClientAdapter`.
 
 ```dart
 dio.httpClientAdapter = new DefaultHttpClientAdapter();
 ```
 
-[Here](https://github.com/flutterchina/dio/blob/master/example/adapter.dart) is a simple example to custom adapter. 
+[Here](https://github.com/flutterchina/dio/blob/master/example/adapter.dart) is a simple example to custom adapter.
 
 ### Using proxy
 
@@ -685,13 +679,39 @@ There is a complete example [here](https://github.com/flutterchina/dio/blob/mast
 
 ### Https certificate verification
 
-There are two ways  to verify the https certificate. Suppose the certificate format is PEM, the code like:
+HTTPS certificate verification (or public key pinning) refers to the process of ensuring that the certificates protecting the TLS connection to the server are the ones you expect them to be. The intention is to reduce the chance of a man-in-the-middle attack. The theory is covered by [OWASP](https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning).
+
+_Server Response Certificate_
+
+Unlike other methods, this one works with the certificate of the server itself.
 
 ```dart
-String PEM='XXXXX'; // certificate content
+String fingerprint = 'ada6403f6c1b9bd35b1699970f0abe792cd7c5353348aedb15b925bcf67562c3';
+(dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+    (cert, host) => fingerprint == sha256.convert(cert!.der).toString();
+```
+
+You can use openssl to read the SHA256 value of a certificate:
+
+```sh
+openssl s_client -servername mozilla-intermediate.badssl.com -connect mozilla-intermediate.badssl.com:443 < /dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256
+
+# SHA256 Fingerprint=EE:5C:E1:DF:A7:A5:36:57:C5:45:C6:2B:65:80:2E:42:72:87:8D:AB:D6:5C:0A:AD:CF:85:78:3E:BB:0B:4D:5C
+# (remove the formatting, keep only lower case hex characters to match the `sha256` above)
+```
+
+_Certificate Authority Verification_
+
+These methods work well when your server has a self-signed certificate, but they don't work for certificates issued by a 3rd party like AWS or Let's Encrypt.
+
+There are two ways to verify the root of the https certificate chain provided by the server. Suppose the certificate format is PEM, the code like:
+
+```dart
+String PEM='XXXXX'; // root certificate content
 (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate  = (client) {
   client.badCertificateCallback=(X509Certificate cert, String host, int port){
-    if(cert.pem==PEM){ // Verify the certificate
+    if(cert.pem==PEM){ // Verify the root certificate
       return true;
     }
     return false;
@@ -704,14 +724,14 @@ Another way is creating a `SecurityContext` when create the `HttpClient`:
 ```dart
 (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate  = (client) {
   SecurityContext sc = SecurityContext();
-  //file is the path of certificate
+  //file is the path of root certificate
   sc.setTrustedCertificates(file);
   HttpClient httpClient = HttpClient(context: sc);
   return httpClient;
 };
 ```
 
-In this way,  the format of certificate must be PEM or PKCS12.
+In this way, the format of certificate must be PEM or PKCS12.
 
 ## Http2 support
 
@@ -719,7 +739,7 @@ In this way,  the format of certificate must be PEM or PKCS12.
 
 ## Cancellation
 
-You can cancel a request using a *cancel token*. One token can be shared with multiple requests. When a token's  `cancel` method invoked, all requests with this token will be cancelled.
+You can cancel a request using a _cancel token_. One token can be shared with multiple requests. When a token's `cancel` method invoked, all requests with this token will be cancelled.
 
 ```dart
 CancelToken token = CancelToken();
@@ -739,7 +759,7 @@ There is a complete example [here](https://github.com/flutterchina/dio/blob/mast
 
 ## Extends Dio class
 
-`Dio` is a abstract class with factory constructor，so we don't extend `Dio` class directy. For this purpose,  we can extend `DioForNative` or `DioForBrowser` instead, for example:
+`Dio` is a abstract class with factory constructor，so we don't extend `Dio` class directy. For this purpose, we can extend `DioForNative` or `DioForBrowser` instead, for example:
 
 ```dart
 import 'package:dio/dio.dart';

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -20,6 +20,11 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
   OnHttpClientCreate? onHttpClientCreate;
 
   /// Allows the user to decide if the response certificate is good.
+  /// If this function is missing, then the certificate is allowed.
+  /// This method is called only if both the [SecurityContext] and
+  /// [badCertificateCallback] accept the certificate chain. Those
+  /// methods evaluate the root or intermediate certificate, while
+  /// [responseCertApprover] evaluates the leaf certificate.
   ResponseCertApprover? responseCertApprover;
 
   HttpClient? _defaultHttpClient;

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -14,3 +14,4 @@ dev_dependencies:
   lints: ^1.0.1
   test: ^1.5.1
   coverage: ^1.0.3
+  crypto: ^3.0.2

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 import 'package:dio/adapter.dart';
@@ -44,6 +45,66 @@ void main() {
     expect(error, isNotNull);
     expect(error is Exception, isTrue);
   });
+
+  test('catch sslerror: certificate not allowed', () async {
+    dynamic error;
+
+    try {
+      var dio = Dio();
+      (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+          (certificate, host, port) => false;
+      await dio.get('https://mozilla-intermediate.badssl.com/');
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  }, testOn: "!browser");
+
+  test('pinning: certificate allowed', () async {
+    // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
+    final lines = File('test/_pinning.txt').readAsLinesSync();
+    final fingerprint =
+        lines.first.split('=').last.toLowerCase().replaceAll(':', '');
+
+    var dio = Dio();
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+        (cert, host, port) =>
+            fingerprint == sha256.convert(cert!.der).toString();
+    final response = await dio.get('https://mozilla-intermediate.badssl.com/',
+        options: Options(validateStatus: (status) => true));
+    expect(response, isNotNull);
+  }, testOn: "!browser");
+
+  test('bad pinning: badCertCallback does not use leaf certificate', () async {
+    // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
+    final lines = File('test/_pinning.txt').readAsLinesSync();
+    final fingerprint =
+        lines.first.split('=').last.toLowerCase().replaceAll(':', '');
+
+    dynamic error;
+
+    try {
+      var dio = Dio();
+      (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+          (HttpClient client) {
+        final effectiveClient =
+            HttpClient(context: SecurityContext(withTrustedRoots: false));
+        effectiveClient.badCertificateCallback =
+            (X509Certificate cert, String host, int port) =>
+                fingerprint == sha256.convert(cert.der).toString();
+        return effectiveClient;
+      };
+      await dio.get('https://mozilla-intermediate.badssl.com/',
+          options: Options(validateStatus: (status) => true));
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  }, testOn: "!browser");
 
   test('allow badssl', () async {
     var dio = Dio();

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -5,6 +5,19 @@ import 'package:test/test.dart';
 import 'package:dio/adapter.dart';
 
 void main() {
+  final trustedCertUrl = 'https://sha256.badssl.com/';
+  final untrustedCertUrl = 'https://wrong.host.badssl.com/';
+
+  // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
+  final trustedLines = File('test/_pinning.txt').readAsLinesSync();
+  final trustedFingerprint =
+      trustedLines.first.split('=').last.toLowerCase().replaceAll(':', '');
+
+  // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
+  final untrustedLines = File('test/_pinning.txt').readAsLinesSync();
+  final untrustedFingerprint =
+      untrustedLines.first.split('=').last.toLowerCase().replaceAll(':', '');
+
   test('catch DioError', () async {
     dynamic error;
 
@@ -46,14 +59,18 @@ void main() {
     expect(error is Exception, isTrue);
   });
 
-  test('catch sslerror: certificate not allowed', () async {
+  test('pinning: valid host allowed with no approver', () async {
+    await Dio().get(trustedCertUrl);
+  });
+
+  test('pinning: every certificate tested and rejected', () async {
     dynamic error;
 
     try {
       var dio = Dio();
       (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
           (certificate, host, port) => false;
-      await dio.get('https://mozilla-intermediate.badssl.com/');
+      await dio.get(trustedCertUrl);
       fail('did not throw');
     } on DioError catch (e) {
       error = e;
@@ -62,27 +79,53 @@ void main() {
     expect(error is Exception, isTrue);
   }, testOn: "!browser");
 
-  test('pinning: certificate allowed', () async {
-    // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
-    final lines = File('test/_pinning.txt').readAsLinesSync();
-    final fingerprint =
-        lines.first.split('=').last.toLowerCase().replaceAll(':', '');
-
+  test('pinning: trusted certificate tested and allowed', () async {
     var dio = Dio();
+    // badCertificateCallback never called for trusted certificate
     (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
         (cert, host, port) =>
-            fingerprint == sha256.convert(cert!.der).toString();
-    final response = await dio.get('https://mozilla-intermediate.badssl.com/',
+            trustedFingerprint == sha256.convert(cert!.der).toString();
+    final response = await dio.get(trustedCertUrl,
         options: Options(validateStatus: (status) => true));
     expect(response, isNotNull);
   }, testOn: "!browser");
 
-  test('bad pinning: badCertCallback does not use leaf certificate', () async {
-    // OpenSSL output like: SHA256 Fingerprint=EE:5C:E1:DF:A7:A4...
-    final lines = File('test/_pinning.txt').readAsLinesSync();
-    final fingerprint =
-        lines.first.split('=').last.toLowerCase().replaceAll(':', '');
+  test('pinning: untrusted certificate tested and allowed', () async {
+    var dio = Dio();
+    // badCertificateCallback must allow the untrusted certificate through
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (_) {
+      _.badCertificateCallback = (cert, host, port) => true;
+    };
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+        (cert, host, port) =>
+            trustedFingerprint == sha256.convert(cert!.der).toString();
+    final response = await dio.get(untrustedCertUrl,
+        options: Options(validateStatus: (status) => true));
+    expect(response, isNotNull);
+  }, testOn: "!browser");
 
+  test('pinning: untrusted certificate rejected before responseCertApprover',
+      () async {
+    dynamic error;
+
+    try {
+      var dio = Dio();
+      (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+          (_) => HttpClient(context: SecurityContext(withTrustedRoots: false));
+      (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+          (cert, host, port) => fail('Should not be evaluated');
+      await dio.get(untrustedCertUrl,
+          options: Options(validateStatus: (status) => true));
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  }, testOn: "!browser");
+
+  test('bad pinning: badCertCallback does not use leaf certificate', () async {
     dynamic error;
 
     try {
@@ -93,10 +136,10 @@ void main() {
             HttpClient(context: SecurityContext(withTrustedRoots: false));
         effectiveClient.badCertificateCallback =
             (X509Certificate cert, String host, int port) =>
-                fingerprint == sha256.convert(cert.der).toString();
+                trustedFingerprint == sha256.convert(cert.der).toString();
         return effectiveClient;
       };
-      await dio.get('https://mozilla-intermediate.badssl.com/',
+      await dio.get(trustedCertUrl,
           options: Options(validateStatus: (status) => true));
       fail('did not throw');
     } on DioError catch (e) {

--- a/example/lib/certificate_pinning.dart
+++ b/example/lib/certificate_pinning.dart
@@ -1,0 +1,61 @@
+import 'package:crypto/crypto.dart';
+import 'dart:io';
+import 'package:dio/adapter.dart';
+import 'package:dio/dio.dart';
+
+void main() async {
+  var dio = Dio();
+
+  // TODO: always update to the latest fingerprint.
+  // openssl s_client -servername pinning-test.badssl.com \
+  //    -connect pinning-test.badssl.com:443 < /dev/null 2>/dev/null \
+  //    | openssl x509 -noout -fingerprint -sha256
+  String fingerprint =
+      // 'update-with-latest-sha256-hex-ee5ce1dfa7a53657c545c62b65802e4272';
+      // should look like this:
+      'ee5ce1dfa7a53657c545c62b65802e4272878dabd65c0aadcf85783ebb0b4d5c';
+
+  // Don't trust any certificate just because their root cert is trusted
+  (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate = (_) {
+    final client =
+        HttpClient(context: SecurityContext(withTrustedRoots: false));
+    // You can test the intermediate / root cert here. We just ignore it.
+    client.badCertificateCallback = (cert, host, port) => true;
+    return client;
+  };
+
+  // Check that the cert fingerprint matches the one we expect
+  (dio.httpClientAdapter as DefaultHttpClientAdapter).responseCertApprover =
+      (cert, host, port) {
+    // We definitely require _some_ certificate
+    if (cert == null) return false;
+    // Validate it any way you want. Here we only check that
+    // the fingerprint matches the OpenSSL SHA256.
+    final f = sha256.convert(cert.der).toString();
+    print(f);
+    return fingerprint == f;
+  };
+
+  Response? response;
+
+  // Normally this certificate would normally be accepted, but all
+  // certs are refused initially, and it is still checked.
+  response = await dio.get('https://sha256.badssl.com/');
+  print(response.data);
+  response = null;
+
+  // Normally this certificate would be rejected because its host isn't covered in the certificate.
+  response = await dio.get('https://wrong.host.badssl.com/');
+  print(response.data);
+  response = null;
+
+  try {
+    // This certificate doesn't have the same fingerprint.
+    response = await dio.get('https://bad.host.badssl.com/');
+    print(response.data);
+  } on DioError catch (e) {
+    print(e.message);
+    print(response?.data);
+    dio.close(force: true);
+  }
+}

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,8 @@
 cd dio
 openssl s_client \
-  -servername wrong.host.badssl.com \
-  -connect wrong.host.badssl.com:443 < /dev/null 2>/dev/null \
-  | openssl x509 -noout -fingerprint -sha256 > test/_bad_pinning.txt 2>/dev/null
-openssl s_client \
   -servername sha256.badssl.com \
   -connect sha256.badssl.com:443 < /dev/null 2>/dev/null \
-  | openssl x509 -noout -fingerprint -sha256 > test/_good_pinning.txt 2>/dev/null
+  | openssl x509 -noout -fingerprint -sha256 > test/_pinning.txt 2>/dev/null
 dart test --coverage=coverage .
 pub run coverage:format_coverage --packages=.packages -i coverage -o coverage/lcov.info --lcov
 genhtml -o coverage coverage/lcov.info

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,8 @@
 cd dio
+openssl s_client \
+  -servername mozilla-intermediate.badssl.com \
+  -connect mozilla-intermediate.badssl.com:443 < /dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 > test/_pinning.txt 2>/dev/null
 dart test --coverage=coverage .
 pub run coverage:format_coverage --packages=.packages -i coverage -o coverage/lcov.info --lcov
 genhtml -o coverage coverage/lcov.info

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,12 @@
 cd dio
 openssl s_client \
-  -servername mozilla-intermediate.badssl.com \
-  -connect mozilla-intermediate.badssl.com:443 < /dev/null 2>/dev/null \
-  | openssl x509 -noout -fingerprint -sha256 > test/_pinning.txt 2>/dev/null
+  -servername wrong.host.badssl.com \
+  -connect wrong.host.badssl.com:443 < /dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 > test/_bad_pinning.txt 2>/dev/null
+openssl s_client \
+  -servername sha256.badssl.com \
+  -connect sha256.badssl.com:443 < /dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 > test/_good_pinning.txt 2>/dev/null
 dart test --coverage=coverage .
 pub run coverage:format_coverage --packages=.packages -i coverage -o coverage/lcov.info --lcov
 genhtml -o coverage coverage/lcov.info


### PR DESCRIPTION
### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [X] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [X] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [X] I have added the required tests to prove the fix/feature I am adding
- [X] I have updated the documentation (if necessary)
- [X] I have run the tests and they pass

### Pull Request Description

There are debates about the usefulness of certificate or public key pinning. It is required at many major companies. If someone chooses to do it then they need access to a leaf certificate.

**The existing recommendations on certificate verification don't provide a leaf certificate for the request.**

All of the following are insufficient.

1. Add a certificate to the `SecureContext`
2. Use `badCertificateCallback`
3. Use the `http_cert_pinning` package

First. When you add a cert to the `SecureContext`, it will only check it against the root certificate. This means that you're going to declare trust in DigiCert or AWS or your self-signed cert. This works for a self-signed cert, but for all others this means that any middle man with a cert from your same provider can hijack your traffic.

Second. As my new test shows, `badCertificateCallback` does not return a leaf certificate. Instead it returns one higher up the chain. That often means that you're pinning to an AWS or other authority, and not the leaf certificate made specifically for your server.

Third. The `http_cert_pinning` package doesn't actually do anything with the certificates that Dio is handling. Instead, it maintains a cache of domains which it has separately tested against a list of certificate fingerprints it was given. When a request comes in, the plugin looks at the requested host, and simply asks the package if it ever checked that domain to see if _the package_ got the correct certificates. It doesn't actually look at the certificates from _this_ connection in Dio.

**The problem stems from Dart itself.**

As you can see, there is an open issue for Dart complaining that [the `badCertificateCallback` doesn't return a leaf certificate](https://github.com/dart-lang/sdk/issues/39425). But one of the commenters found a workaround, and [left some instructions on how to get the correct certificate](https://github.com/dart-lang/sdk/issues/39425#issuecomment-680830653).

That comment was _very_ easy to apply to the `DefaultHttpRequestAdapter`. It simply adds one more callback at the right place in the response processing.  If it isn't used, the request continues as expected. As my tests show, it properly delivers the leaf certificate to the callback where users can decide on the methods they want to use to approve or reject a certificate. The tests also show that `badCertificateCallback` does not return the leaf certificate.

Please consider adding this so that we may get one step closer to implementing full certificate pinning in pure Dart.