### PR TITLE
fix(web): fix 'Future already completed' error when connectTimeout was set.

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -61,12 +61,13 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       );
     });
 
-    bool haveSent = false;
+    Timer? connectTimeoutTimer;
 
     if (options.connectTimeout > 0) {
-      Future.delayed(Duration(milliseconds: options.connectTimeout)).then(
-        (value) {
-          if (!haveSent) {
+      connectTimeoutTimer = Timer(
+        Duration(milliseconds: options.connectTimeout),
+        () {
+          if (!completer.isCompleted) {
             completer.completeError(
               DioError(
                 requestOptions: options,
@@ -76,6 +77,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
               StackTrace.current,
             );
             xhr.abort();
+          } else {
+            print(
+                'Warn: connectTimeout is triggered after fetch has completed.');
           }
         },
       );
@@ -83,7 +87,12 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
 
     int sendStart = 0;
     xhr.upload.onProgress.listen((event) {
-      haveSent = true;
+      // This event will only be triggered if a request body exists.
+      if (connectTimeoutTimer != null) {
+        connectTimeoutTimer!.cancel();
+        connectTimeoutTimer = null;
+      }
+
       if (options.sendTimeout > 0) {
         if (sendStart == 0) {
           sendStart = DateTime.now().millisecondsSinceEpoch;
@@ -111,6 +120,11 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
 
     int receiveStart = 0;
     xhr.onProgress.listen((event) {
+      if (connectTimeoutTimer != null) {
+        connectTimeoutTimer!.cancel();
+        connectTimeoutTimer = null;
+      }
+
       if (options.receiveTimeout > 0) {
         if (receiveStart == 0) {
           receiveStart = DateTime.now().millisecondsSinceEpoch;
@@ -136,6 +150,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     });
 
     xhr.onError.first.then((_) {
+      connectTimeoutTimer?.cancel();
       // Unfortunately, the underlying XMLHttpRequest API doesn't expose any
       // specific information about the error itself.
       completer.completeError(
@@ -150,6 +165,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
 
     cancelFuture?.then((err) {
       if (xhr.readyState < 4 && xhr.readyState > 0) {
+        connectTimeoutTimer?.cancel();
         try {
           xhr.abort();
         } catch (e) {

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -78,8 +78,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
             );
             xhr.abort();
           } else {
-            print(
-                'Warn: connectTimeout is triggered after fetch has completed.');
+            // connectTimeout is triggered after fetch has completed.
           }
         },
       );
@@ -97,8 +96,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
         if (sendStart == 0) {
           sendStart = DateTime.now().millisecondsSinceEpoch;
         }
-        var t = DateTime.now().millisecondsSinceEpoch;
-        print(t - sendStart);
+        final t = DateTime.now().millisecondsSinceEpoch;
         if (t - sendStart > options.sendTimeout) {
           completer.completeError(
             DioError(

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -78,7 +78,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
             );
             xhr.abort();
           } else {
-            // connectTimeout is triggered after fetch has completed.
+            // connectTimeout is triggered after the fetch has been completed.
           }
         },
       );

--- a/example_flutter_app/lib/http.dart
+++ b/example_flutter_app/lib/http.dart
@@ -1,3 +1,5 @@
 import 'package:dio/dio.dart';
 
-var dio = Dio();
+var dio = Dio(BaseOptions(
+  connectTimeout: 3000,
+));


### PR DESCRIPTION
fix 'Future already completed' error when connectTimeout was set.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
  - #1496 
  - #1470
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: 
- #1536
- #1497

### Pull Request Description

Use `Timer` instead of `Future.delay` to implement connectTimeout on Web.

