### PR TITLE
解决 WEB 端BUG

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -47,8 +47,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     }
 
     var completer = Completer<ResponseBody>();
-
+    bool haveSent = false;
     xhr.onLoad.first.then((_) {
+      haveSent = true;
       Uint8List body = (xhr.response as ByteBuffer).asUint8List();
       completer.complete(
         ResponseBody.fromBytes(
@@ -60,8 +61,6 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
         ),
       );
     });
-
-    bool haveSent = false;
 
     if (options.connectTimeout > 0) {
       Future.delayed(Duration(milliseconds: options.connectTimeout)).then(


### PR DESCRIPTION
errors.dart:266 Uncaught (in promise) Error: Bad state: Future already completed
    at Object.throw_ [as throw] (errors.dart:266:49)
    at _AsyncCompleter.new.completeError (future_impl.dart:15:79)
    at browser_adapter.dart:70:22
    at _RootZone.runUnary (zone.dart:1653:54)
    at _FutureListener.then.handleValue (future_impl.dart:147:18)
    at handleValueCallback (future_impl.dart:766:44)
    at _Future._propagateToListeners (future_impl.dart:795:13)
    at [_complete] (future_impl.dart:557:7)
    at future.dart:421:15
    at internalCallback (isolate_helper.dart:48:19)

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

