### PR TITLE
WIP: docs: Remove onBadCertificate in http2_adapter example

### DIFF
--- a/plugins/http2_adapter/example/example.dart
+++ b/plugins/http2_adapter/example/example.dart
@@ -8,8 +8,6 @@ void main() async {
     ..httpClientAdapter = Http2Adapter(
       ConnectionManager(
         idleTimeout: 10000,
-        // Ignore bad certificate
-        onClientCreate: (_, config) => config.onBadCertificate = (_) => true,
       ),
     );
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description

`config.onBadCertificate = (_) => true` makes dio accept **ALL** https certificates,  even those not signed by trusted CAs.
This configuration makes the example insecure and vulnerable to MITM attacks.

Remove this to give a sane default and example for new users.