### PR TITLE
when response.statusCode equal 204,unnecessary to transformResponse

### DIFF
--- a/dio/lib/src/transformer.dart
+++ b/dio/lib/src/transformer.dart
@@ -89,7 +89,7 @@ class DefaultTransformer extends Transformer {
   @override
   Future transformResponse(
       RequestOptions options, ResponseBody response) async {
-    if (options.responseType == ResponseType.stream) {
+    if (options.responseType == ResponseType.stream || response.statusCode==204) {
       return response;
     }
     var length = 0;


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
I use restful api,
     have data : response data with statusCode 200,
     no data: i response data with statusCode 204
flutter use nullable object receive ，but An error occurred：
   DioError [DioErrorType.other]: type 'String' is not a subtype of type 'Map<String, dynamic>?' in type cast

when response.statusCode with 204,the response.data should be set to null（current is empty string）.

