### PR TITLE
Make ResponseDecoder return nullable String type

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -72,7 +72,7 @@ enum ListFormat {
 
 typedef ValidateStatus = bool Function(int? status);
 
-typedef ResponseDecoder = String Function(
+typedef ResponseDecoder = String? Function(
     List<int> responseBytes, RequestOptions options, ResponseBody responseBody);
 typedef RequestEncoder = List<int> Function(
     String request, RequestOptions options);

--- a/dio/lib/src/transformer.dart
+++ b/dio/lib/src/transformer.dart
@@ -160,10 +160,11 @@ class DefaultTransformer extends Transformer {
         options,
         response..stream = Stream.empty(),
       );
-    } else {
+    } else if (responseBytes.isNotEmpty) {
       responseBody = utf8.decode(responseBytes, allowMalformed: true);
     }
-    if (responseBody !=null && responseBody.isNotEmpty &&
+    if (responseBody != null &&
+        responseBody.isNotEmpty &&
         options.responseType == ResponseType.json &&
         Transformer.isJsonMimeType(
             response.headers[Headers.contentTypeHeader]?.first)) {

--- a/dio/lib/src/transformer.dart
+++ b/dio/lib/src/transformer.dart
@@ -163,7 +163,7 @@ class DefaultTransformer extends Transformer {
     } else {
       responseBody = utf8.decode(responseBytes, allowMalformed: true);
     }
-    if (responseBody.isNotEmpty &&
+    if (responseBody !=null && responseBody.isNotEmpty &&
         options.responseType == ResponseType.json &&
         Transformer.isJsonMimeType(
             response.headers[Headers.contentTypeHeader]?.first)) {

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -270,4 +270,15 @@ void main() {
     assert(r3.uri.toString() == 'https://www.example.com/test');
     assert(r3.headers[Headers.contentTypeHeader] == null);
   });
+
+  test("#test responseDecoder return null", () async {
+    final dio = Dio();
+    dio.options.responseDecoder = (_,__,___) => null;
+    dio.options.baseUrl = EchoAdapter.mockBase;
+    dio.httpClientAdapter = EchoAdapter();
+
+    final Response response = await dio.get("");
+
+    expect(response.data, null);
+  });
 }


### PR DESCRIPTION
This PR make the ResponseDecoder return nullable String
 
In options.dart:
```dart
typedef ResponseDecoder = String Function(
    List<int> responseBytes, RequestOptions options, ResponseBody responseBody);
```

The usage of this function: src/transformer.dart
```dart
String? responseBody;
if (options.responseDecoder != null) {
  responseBody = options.responseDecoder!(
    responseBytes,
    options,
    response..stream = Stream.empty(),
  );
} else {
  responseBody = utf8.decode(responseBytes, allowMalformed: true);
}
```
As we can see the responseBody is nullable, it means `ResponseDecoder` function return String? may be make sense.

