### PR TITLE
Add persistentConnection option

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -67,6 +67,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
     request.followRedirects = options.followRedirects;
     request.maxRedirects = options.maxRedirects;
+    request.persistentConnection = options.persistentConnection;
 
     if (requestStream != null) {
       // Transform the request data

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -59,6 +59,7 @@ class LogInterceptor extends Interceptor {
       _printKV('method', options.method);
       _printKV('responseType', options.responseType.toString());
       _printKV('followRedirects', options.followRedirects);
+      _printKV('persistentConnection', options.persistentConnection);
       _printKV('connectTimeout', options.connectTimeout);
       _printKV('sendTimeout', options.sendTimeout);
       _printKV('receiveTimeout', options.receiveTimeout);

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -95,6 +95,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     bool? receiveDataWhenStatusError,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
@@ -111,6 +112,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
           receiveDataWhenStatusError: receiveDataWhenStatusError,
           followRedirects: followRedirects,
           maxRedirects: maxRedirects,
+          persistentConnection: persistentConnection,
           requestEncoder: requestEncoder,
           responseDecoder: responseDecoder,
           listFormat: listFormat,
@@ -137,6 +139,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     bool? receiveDataWhenStatusError,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
@@ -158,6 +161,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
           receiveDataWhenStatusError ?? this.receiveDataWhenStatusError,
       followRedirects: followRedirects ?? this.followRedirects,
       maxRedirects: maxRedirects ?? this.maxRedirects,
+      persistentConnection: persistentConnection ?? this.persistentConnection,
       requestEncoder: requestEncoder ?? this.requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
       listFormat: listFormat ?? this.listFormat,
@@ -212,6 +216,7 @@ class Options {
     this.receiveDataWhenStatusError,
     this.followRedirects,
     this.maxRedirects,
+    this.persistentConnection,
     this.requestEncoder,
     this.responseDecoder,
     this.listFormat,
@@ -230,6 +235,7 @@ class Options {
     bool? receiveDataWhenStatusError,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
@@ -266,6 +272,7 @@ class Options {
           receiveDataWhenStatusError ?? this.receiveDataWhenStatusError,
       followRedirects: followRedirects ?? this.followRedirects,
       maxRedirects: maxRedirects ?? this.maxRedirects,
+      persistentConnection: persistentConnection ?? this.persistentConnection,
       requestEncoder: requestEncoder ?? this.requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
       listFormat: listFormat ?? this.listFormat,
@@ -317,6 +324,7 @@ class Options {
           receiveDataWhenStatusError ?? baseOpt.receiveDataWhenStatusError,
       followRedirects: followRedirects ?? baseOpt.followRedirects,
       maxRedirects: maxRedirects ?? baseOpt.maxRedirects,
+      persistentConnection: persistentConnection ?? baseOpt.persistentConnection,
       queryParameters: query,
       requestEncoder: requestEncoder ?? baseOpt.requestEncoder,
       responseDecoder: responseDecoder ?? baseOpt.responseDecoder,
@@ -400,6 +408,10 @@ class Options {
   /// The default value is 5.
   int? maxRedirects;
 
+  /// see [HttpClientRequest.persistentConnection],
+  /// The default value is true
+  bool? persistentConnection;
+
   /// The default request encoder is utf8encoder, you can set custom
   /// encoder by this option.
   RequestEncoder? requestEncoder;
@@ -436,6 +448,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     bool? receiveDataWhenStatusError,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
@@ -452,6 +465,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
           receiveDataWhenStatusError: receiveDataWhenStatusError,
           followRedirects: followRedirects,
           maxRedirects: maxRedirects,
+          persistentConnection: persistentConnection,
           requestEncoder: requestEncoder,
           responseDecoder: responseDecoder,
           listFormat: listFormat,
@@ -482,6 +496,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     bool? receiveDataWhenStatusError,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
@@ -517,6 +532,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
           receiveDataWhenStatusError ?? this.receiveDataWhenStatusError,
       followRedirects: followRedirects ?? this.followRedirects,
       maxRedirects: maxRedirects ?? this.maxRedirects,
+      persistentConnection: persistentConnection ?? this.persistentConnection,
       requestEncoder: requestEncoder ?? this.requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
       listFormat: listFormat ?? this.listFormat,
@@ -582,6 +598,7 @@ class _RequestConfig {
     ListFormat? listFormat,
     bool? followRedirects,
     int? maxRedirects,
+    bool? persistentConnection,
     bool? receiveDataWhenStatusError,
     ValidateStatus? validateStatus,
     ResponseType? responseType,
@@ -605,6 +622,7 @@ class _RequestConfig {
     this.extra = extra ?? {};
     this.followRedirects = followRedirects ?? true;
     this.maxRedirects = maxRedirects ?? 5;
+    this.persistentConnection = persistentConnection ?? true;
     this.receiveDataWhenStatusError = receiveDataWhenStatusError ?? true;
     this.validateStatus = validateStatus ??
         (int? status) {
@@ -704,6 +722,10 @@ class _RequestConfig {
   ///
   /// The default value is 5.
   late int maxRedirects;
+
+  /// see [HttpClientRequest.persistentConnection],
+  /// The default value is true
+  late bool persistentConnection;
 
   /// The default request encoder is utf8encoder, you can set custom
   /// encoder by this option.

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -21,6 +21,7 @@ void main() {
       headers: map,
       contentType: 'application/json',
       followRedirects: false,
+      persistentConnection: false,
     );
     var opt1 = baseOptions.copyWith(
       method: 'post',
@@ -35,6 +36,7 @@ void main() {
     assert(opt1.receiveTimeout == 3000);
     assert(opt1.connectTimeout == 2000);
     assert(opt1.followRedirects == false);
+    assert(opt1.persistentConnection == false);
     assert(opt1.baseUrl == 'https://flutterchina.club');
     assert(opt1.headers['b'] == '6');
     assert(opt1.extra['b'] == '6');
@@ -49,6 +51,7 @@ void main() {
       headers: map,
       contentType: 'application/json',
       followRedirects: false,
+      persistentConnection: false,
     );
 
     var opt3 = opt2.copyWith(
@@ -63,6 +66,7 @@ void main() {
     assert(opt3.method == 'post');
     assert(opt3.receiveTimeout == 3000);
     assert(opt3.followRedirects == false);
+    assert(opt3.persistentConnection == false);
     assert(opt3.headers!['b'] == '6');
     assert(opt3.extra!['b'] == '6');
     assert(opt3.contentType == 'text/html');
@@ -71,6 +75,7 @@ void main() {
       path: '/xxx',
       sendTimeout: 2000,
       followRedirects: false,
+      persistentConnection: false,
     );
     var opt5 = opt4.copyWith(
       method: 'post',
@@ -85,6 +90,7 @@ void main() {
     assert(opt5.method == 'post');
     assert(opt5.receiveTimeout == 3000);
     assert(opt5.followRedirects == false);
+    assert(opt5.persistentConnection == false);
     assert(opt5.contentType == 'text/html');
     assert(opt5.headers['b'] == '6');
     assert(opt5.extra['b'] == '6');


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description

This PR adds the "persistentConnection" options (which is backed by HttpClientRequest.persistentConnection). If you chain lot of requests it can be necessary to disable this option to avoid a connection close.

