### PR TITLE
Remove redundant connection opening call

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -44,7 +44,6 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
     late HttpClientRequest request;
     try {
-      request = await reqFuture;
       if (options.connectTimeout > 0) {
         request = await reqFuture
             .timeout(Duration(milliseconds: options.connectTimeout));


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description
The http connection is opened twice because of redundant `openUrl` call since it was called either [here](https://github.com/flutterchina/dio/blob/8dbf3183ca31b085ad8468162872a64c529f67c6/dio/lib/src/adapters/io_adapter.dart#L48) or [here](https://github.com/flutterchina/dio/blob/8dbf3183ca31b085ad8468162872a64c529f67c6/dio/lib/src/adapters/io_adapter.dart#L51)
...

