### PR TITLE
Feature/many multipart file

### DIFF
--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -68,6 +68,22 @@ class FormData {
         random.nextInt(4294967296).toString().padLeft(10, '0');
   }
 
+  void addField(String key, String value) {
+    fields.add(MapEntry(key, value));
+  }
+
+  void addMultipartFile(String key, MultipartFile file) {
+    files.add(MapEntry(key, file));
+  }
+
+  void removeField(String key) {
+    fields.removeWhere((e) => e.key == key);
+  }
+
+  void removeMultipartFiles(String key) {
+    files.removeWhere((entry) => entry.key == key);
+  }
+
   /// Returns the header string for a field. The return value is guaranteed to
   /// contain only ASCII characters.
   String _headerForField(String name, String value) {

--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -47,6 +47,10 @@ class FormData {
         if (value == null) return null;
         if (value is MultipartFile) {
           files.add(MapEntry(key, value));
+        } else if (value is List<MultipartFile>) {
+          value.forEach((file) {
+            files.add(MapEntry(key, file));
+          });
         } else {
           fields.add(MapEntry(key, value.toString()));
         }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: there is no way to upload many multipart-file in the same form key in `fromMap` function, support to adding a list of 

### Pull Request Description
Support many multipart-file in the same form key in `fromMap` function you can see this feature in postman, I mean you can select many files in one field, I write and test my code without writing a unit test and it's working correctly, and added functions that help with adding & removing values from FormData.

