### PR TITLE
Fix "unsupported operation" error on web platform

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix "unsupported operation" error on web platform.
+
 ## 5.0.1
 
 - Add `ImplyContentTypeInterceptor` as a default interceptor.
@@ -69,7 +71,7 @@ stable version
 
 ## 4.0.0-prev3
 
-- fix #1091 , #1089 , #1087 
+- fix #1091 , #1089 , #1087
 
 ## 4.0.0-prev2
 

--- a/dio/lib/src/interceptors/imply_content_type.dart
+++ b/dio/lib/src/interceptors/imply_content_type.dart
@@ -5,6 +5,13 @@ import '../form_data.dart';
 import '../headers.dart';
 import '../options.dart';
 
+// For the web platform, an inline `bool.fromEnvironment` translates to
+// `core.bool.fromEnvironment` instead of correctly being replaced by the
+// constant value found in the environment at build time.
+//
+// See https://github.com/flutter/flutter/issues/51186.
+const _kReleaseMode = bool.fromEnvironment('dart.vm.product');
+
 /// {@template dio.interceptors.ImplyContentTypeInterceptor}
 /// The default `content-type` for requests will be implied by the
 /// [ImplyContentTypeInterceptor] according to the type of the request payload.
@@ -28,7 +35,7 @@ class ImplyContentTypeInterceptor extends Interceptor {
         contentType = Headers.jsonContentType;
       } else {
         // Do not log in the release mode.
-        if (!bool.fromEnvironment('dart.vm.product')) {
+        if (!_kReleaseMode) {
           dev.log(
             '${data.runtimeType} cannot be used'
             'to imply a default content-type, '


### PR DESCRIPTION
For the web platform, an inline `bool.fromEnvironment` translates to `core.bool.fromEnvironment` instead of correctly being replaced by the constant value found in the environment at build time.

See https://github.com/flutter/flutter/issues/51186.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package (if necessary)

### Additional context and info (if any)

This fix is unfortunately not something we can test for as far as I can tell. I've tried numerous methods of automating the detection of the issue (and thus the fix), but it seems to only appear when running the Flutter example in a browser.