### PR TITLE
🐛 Fix `DioErrorType.cancel` in `Interceptors`

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `DioErrorType.cancel` in `Interceptors`.
 - Fix "unsupported operation" error on web platform.
 
 ## 5.0.1

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -463,7 +463,7 @@ abstract class DioMixin implements Dio {
         // The request has already been canceled,
         // there is no need to listen for another cancellation.
         if (err.data is DioError && err.data.type == DioErrorType.cancel) {
-          handleError();
+          return handleError();
         } else if (err.type == InterceptorResultType.next ||
             err.type == InterceptorResultType.rejectCallFollowing) {
           return listenCancelForAsyncTask(

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -454,7 +454,13 @@ abstract class DioMixin implements Dio {
           );
         }
 
-        if (err.type == InterceptorResultType.next ||
+        // The request has already been canceled,
+        // there is no need to listen for another cancellation.
+        if (err.data is DioError && err.data.type == DioErrorType.cancel) {
+          final errorHandler = ErrorInterceptorHandler();
+          interceptor(err.data, errorHandler);
+          return errorHandler.future;
+        } else if (err.type == InterceptorResultType.next ||
             err.type == InterceptorResultType.rejectCallFollowing) {
           return listenCancelForAsyncTask(
             requestOptions.cancelToken,

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -454,21 +454,21 @@ abstract class DioMixin implements Dio {
           );
         }
 
-        // The request has already been canceled,
-        // there is no need to listen for another cancellation.
-        if (err.data is DioError && err.data.type == DioErrorType.cancel) {
+        Future<InterceptorState> handleError() async {
           final errorHandler = ErrorInterceptorHandler();
           interceptor(err.data, errorHandler);
           return errorHandler.future;
+        }
+
+        // The request has already been canceled,
+        // there is no need to listen for another cancellation.
+        if (err.data is DioError && err.data.type == DioErrorType.cancel) {
+          handleError();
         } else if (err.type == InterceptorResultType.next ||
             err.type == InterceptorResultType.rejectCallFollowing) {
           return listenCancelForAsyncTask(
             requestOptions.cancelToken,
-            Future(() {
-              final errorHandler = ErrorInterceptorHandler();
-              interceptor(err.data as DioError, errorHandler);
-              return errorHandler.future;
-            }),
+            Future(handleError),
           );
         } else {
           throw err;

--- a/dio/test/basic_test.dart
+++ b/dio/test/basic_test.dart
@@ -46,16 +46,17 @@ void main() {
   }, testOn: "vm");
 
   test('cancellation', () async {
-    final dio = Dio();
+    final dio = Dio()
+      ..httpClientAdapter = MockAdapter()
+      ..options.baseUrl = MockAdapter.mockBase;
     final token = CancelToken();
     Future.delayed(const Duration(milliseconds: 10), () {
       token.cancel('cancelled');
       dio.httpClientAdapter.close(force: true);
     });
 
-    final url = 'https://pub.dev';
     await expectLater(
-      dio.get(url, cancelToken: token),
+      dio.get('/test-timeout', cancelToken: token),
       throwsA((e) => e is DioError && CancelToken.isCancel(e)),
     );
   });

--- a/dio/test/mock/adapters.dart
+++ b/dio/test/mock/adapters.dart
@@ -32,32 +32,30 @@ class MockAdapter implements HttpClientAdapter {
             },
           );
         case '/test-auth':
-          {
-            return Future.delayed(Duration(milliseconds: 300), () {
-              if (options.headers['csrfToken'] == null) {
-                return ResponseBody.fromString(
-                  jsonEncode({
-                    'errCode': -1,
-                    'data': {'path': uri.path}
-                  }),
-                  401,
-                  headers: {
-                    Headers.contentTypeHeader: [Headers.jsonContentType],
-                  },
-                );
-              }
+          return Future.delayed(Duration(milliseconds: 300), () {
+            if (options.headers['csrfToken'] == null) {
               return ResponseBody.fromString(
                 jsonEncode({
-                  'errCode': 0,
+                  'errCode': -1,
                   'data': {'path': uri.path}
                 }),
-                200,
+                401,
                 headers: {
                   Headers.contentTypeHeader: [Headers.jsonContentType],
                 },
               );
-            });
-          }
+            }
+            return ResponseBody.fromString(
+              jsonEncode({
+                'errCode': 0,
+                'data': {'path': uri.path}
+              }),
+              200,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+              },
+            );
+          });
         case '/download':
           return Future.delayed(Duration(milliseconds: 300), () {
             return ResponseBody(
@@ -70,23 +68,23 @@ class MockAdapter implements HttpClientAdapter {
               },
             );
           });
-
         case '/token':
-          {
-            final t = 'ABCDEFGHIJKLMN'.split('')..shuffle();
-            return ResponseBody.fromBytes(
-              utf8.encode(jsonEncode({
-                'errCode': 0,
-                'data': {'token': t.join()}
-              })),
-              200,
-              headers: {
-                Headers.contentTypeHeader: [Headers.jsonContentType],
-              },
-            );
-          }
+          final t = 'ABCDEFGHIJKLMN'.split('')..shuffle();
+          return ResponseBody.fromBytes(
+            utf8.encode(jsonEncode({
+              'errCode': 0,
+              'data': {'token': t.join()}
+            })),
+            200,
+            headers: {
+              Headers.contentTypeHeader: [Headers.jsonContentType],
+            },
+          );
         case '/test-force-convert':
           return ResponseBody.fromString('{"code":0,"result":"ok"}', 200);
+        case '/test-timeout':
+          await Future.delayed(const Duration(days: 365));
+          return ResponseBody.fromString('', 200);
         default:
           return ResponseBody.fromString('', 404);
       }


### PR DESCRIPTION
Fixes #1512.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

Previously, `listenCancelForAsyncTask` will wait for `CancelToken.whenCancel` in certain scenarios:
https://github.com/cfug/dio/blob/6544701ed370e6ceaf81576f393459605e9a612f/dio/lib/src/dio_mixin.dart#L457-L466

These scenarios include `DioErrorType.cancel`, in which the error handler has been put into the event loop rather than executed immediately, which means the handler will handle the exception after the request is completed.