### PR TITLE
Interceptors now gets the StackTrace in the DioError objects

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -12,11 +12,12 @@ import 'form_data.dart';
 import 'headers.dart';
 import 'interceptors/imply_content_type.dart';
 import 'options.dart';
-import 'progress_stream/io_progress_stream.dart'
-    if (dart.library.html) 'progress_stream/browser_progress_stream.dart';
 import 'response.dart';
 import 'transformer.dart';
 import 'transformers/background_transformer.dart';
+
+import 'progress_stream/io_progress_stream.dart'
+    if (dart.library.html) 'progress_stream/browser_progress_stream.dart';
 
 part 'interceptor.dart';
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -447,6 +447,7 @@ abstract class DioMixin implements Dio {
     FutureOr<dynamic> Function(dynamic, StackTrace) errorInterceptorWrapper(
       InterceptorErrorCallback interceptor,
     ) {
+      // Fetches and exposes the current stack trace when using interceptors.
       final stackTrace = StackTrace.current;
       return (err, _) {
         final dioError = assureDioError(err, requestOptions, stackTrace);

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -449,17 +449,14 @@ abstract class DioMixin implements Dio {
     ) {
       final stackTrace = StackTrace.current;
       return (err, _) {
+        final dioError = assureDioError(err, requestOptions, stackTrace);
+
         if (err is! InterceptorState) {
-          err = InterceptorState(
-            assureDioError(err, requestOptions, stackTrace),
-          );
+          err = InterceptorState(dioError);
         }
 
         Future<InterceptorState> handleError() async {
           final errorHandler = ErrorInterceptorHandler();
-          final dioError = (err.data as DioError).copyWith(
-            stackTrace: stackTrace,
-          );
           interceptor(dioError, errorHandler);
           return errorHandler.future;
         }

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -373,12 +373,12 @@ void main() {
 
         await expectLater(
           dio.get('/error'),
-          throwsA(predicate(
-            (error) {
-              return error is DioError &&
-                  caughtStackTrace.toString() == error.stackTrace.toString();
+          throwsA(
+            (e) {
+              return e is DioError &&
+                  caughtStackTrace.toString() == e.stackTrace.toString();
             },
-          )),
+          ),
           reason: 'Stacktrace should be available in onError',
         );
       });
@@ -670,11 +670,12 @@ void main() {
 
       await expectLater(
         dio.get('/error'),
-        throwsA(predicate(
-          (error) =>
-              error is DioError &&
-              caughtStackTrace.toString() == error.stackTrace.toString(),
-        )),
+        throwsA(
+          (e) {
+            return e is DioError &&
+                caughtStackTrace.toString() == e.stackTrace.toString();
+          },
+        ),
         reason: 'Stacktrace should be available in onError',
       );
     });

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -349,7 +349,7 @@ void main() {
         expect(response.requestOptions.contentType, isNull);
       });
 
-      test("Interceptor gets stacktrace in onError", () async {
+      test('Interceptor gets stacktrace in onError', () async {
         final dio = Dio();
         dio.options.baseUrl = EchoAdapter.mockBase;
         dio.httpClientAdapter = EchoAdapter();
@@ -379,7 +379,7 @@ void main() {
                   caughtStackTrace.toString() == error.stackTrace.toString();
             },
           )),
-          reason: "Stacktrace should be available in onError",
+          reason: 'Stacktrace should be available in onError',
         );
       });
 
@@ -646,7 +646,7 @@ void main() {
       expect(result, 3);
     });
 
-    test("QueuedInterceptor gets stacktrace in onError", () async {
+    test('QueuedInterceptor gets stacktrace in onError', () async {
       final dio = Dio();
       dio.options.baseUrl = EchoAdapter.mockBase;
       dio.httpClientAdapter = EchoAdapter();
@@ -675,7 +675,7 @@ void main() {
               error is DioError &&
               caughtStackTrace.toString() == error.stackTrace.toString(),
         )),
-        reason: "Stacktrace should be available in onError",
+        reason: 'Stacktrace should be available in onError',
       );
     });
   });

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -354,7 +354,7 @@ void main() {
         dio.options.baseUrl = EchoAdapter.mockBase;
         dio.httpClientAdapter = EchoAdapter();
 
-        late final StackTrace caughtStackTrace;
+        StackTrace? caughtStackTrace;
         dio.interceptors.addAll([
           InterceptorsWrapper(
             onError: (err, handler) {
@@ -376,6 +376,7 @@ void main() {
           throwsA(
             (e) {
               return e is DioError &&
+                  caughtStackTrace != null &&
                   caughtStackTrace.toString() == e.stackTrace.toString();
             },
           ),
@@ -651,7 +652,7 @@ void main() {
       dio.options.baseUrl = EchoAdapter.mockBase;
       dio.httpClientAdapter = EchoAdapter();
 
-      late final StackTrace caughtStackTrace;
+      StackTrace? caughtStackTrace;
       dio.interceptors.addAll([
         QueuedInterceptorsWrapper(
           onError: (err, handler) {
@@ -673,6 +674,7 @@ void main() {
         throwsA(
           (e) {
             return e is DioError &&
+                caughtStackTrace != null &&
                 caughtStackTrace.toString() == e.stackTrace.toString();
           },
         ),


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

The StackTrace will be the same one as you get when surrounding the request with try-catch.

Fixes #1173.

<!-- Provide more context and info about the PR. -->
