### PR TITLE
🚀 Allow defining adapter methods through their constructors

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Allow defining adapter methods through their constructors.
 
 ## 5.0.3
 

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -13,6 +13,8 @@ HttpClientAdapter createAdapter() => BrowserHttpClientAdapter();
 
 /// The default [HttpClientAdapter] for Web platforms.
 class BrowserHttpClientAdapter implements HttpClientAdapter {
+  BrowserHttpClientAdapter({this.withCredentials = false});
+
   /// These are aborted if the client is closed.
   @visibleForTesting
   final xhrs = <HttpRequest>{};
@@ -23,7 +25,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
   /// Defaults to `false`.
   ///
   /// You can also override this value in Options.extra['withCredentials'] for each request
-  bool withCredentials = false;
+  bool withCredentials;
 
   @override
   Future<ResponseBody> fetch(

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -21,9 +21,10 @@ HttpClientAdapter createAdapter() => IOHttpClientAdapter();
 
 /// The default [HttpClientAdapter] for native platforms.
 class IOHttpClientAdapter implements HttpClientAdapter {
-  /// [Dio] will create HttpClient when it is needed.
-  /// If [onHttpClientCreate] is provided, [Dio] will call
-  /// it when a HttpClient created.
+  IOHttpClientAdapter({this.onHttpClientCreate, this.validateCertificate});
+
+  /// [Dio] will create [HttpClient] when it is needed. If [onHttpClientCreate]
+  /// has provided, [Dio] will call it when a [HttpClient] created.
   OnHttpClientCreate? onHttpClientCreate;
 
   /// Allows the user to decide if the response certificate is good.

--- a/dio/test/browser_test.dart
+++ b/dio/test/browser_test.dart
@@ -7,11 +7,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('with credentials', () async {
-    final browserAdapter = BrowserHttpClientAdapter();
-    browserAdapter.withCredentials = true;
+    final browserAdapter = BrowserHttpClientAdapter(withCredentials: true);
     final opts = RequestOptions();
-    final testStream =
-        Stream<Uint8List>.periodic(Duration(seconds: 1), (x) => Uint8List(x));
+    final testStream = Stream<Uint8List>.periodic(
+      Duration(seconds: 1),
+      (x) => Uint8List(x),
+    );
     final cancelFuture = opts.cancelToken?.whenCancel;
 
     browserAdapter.fetch(opts, testStream, cancelFuture);

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -55,10 +55,11 @@ void main() {
     'allow badssl',
     () async {
       final dio = Dio();
-      dio.httpClientAdapter = IOHttpClientAdapter()
-        ..onHttpClientCreate = (client) {
+      dio.httpClientAdapter = IOHttpClientAdapter(
+        onHttpClientCreate: (client) {
           return client..badCertificateCallback = (cert, host, port) => true;
-        };
+        },
+      );
       Response response = await dio.get('https://wrong.host.badssl.com/');
       expect(response.statusCode, 200);
       response = await dio.get('https://expired.badssl.com/');

--- a/dio/test/pinning_test.dart
+++ b/dio/test/pinning_test.dart
@@ -38,8 +38,9 @@ void main() {
     DioError? error;
     try {
       final dio = Dio();
-      dio.httpClientAdapter = IOHttpClientAdapter()
-        ..validateCertificate = (certificate, host, port) => false;
+      dio.httpClientAdapter = IOHttpClientAdapter(
+        validateCertificate: (certificate, host, port) => false,
+      );
       await dio.get(trustedCertUrl);
       fail('did not throw');
     } on DioError catch (e) {
@@ -51,9 +52,10 @@ void main() {
   test('pinning: trusted certificate tested and allowed', () async {
     final dio = Dio();
     // badCertificateCallback never called for trusted certificate
-    dio.httpClientAdapter = IOHttpClientAdapter()
-      ..validateCertificate = (cert, host, port) =>
-          fingerprint == sha256.convert(cert!.der).toString();
+    dio.httpClientAdapter = IOHttpClientAdapter(
+      validateCertificate: (cert, host, port) =>
+          fingerprint == sha256.convert(cert!.der).toString(),
+    );
     final response = await dio.get(
       trustedCertUrl,
       options: Options(validateStatus: (status) => true),
@@ -64,12 +66,14 @@ void main() {
   test('pinning: untrusted certificate tested and allowed', () async {
     final dio = Dio();
     // badCertificateCallback must allow the untrusted certificate through
-    dio.httpClientAdapter = IOHttpClientAdapter()
-      ..onHttpClientCreate = (client) {
+    dio.httpClientAdapter = IOHttpClientAdapter(
+      onHttpClientCreate: (client) {
         return client..badCertificateCallback = (cert, host, port) => true;
-      }
-      ..validateCertificate = (cert, host, port) =>
-          fingerprint == sha256.convert(cert!.der).toString();
+      },
+      validateCertificate: (cert, host, port) {
+        return fingerprint == sha256.convert(cert!.der).toString();
+      },
+    );
     final response = await dio.get(
       untrustedCertUrl,
       options: Options(validateStatus: (status) => true),
@@ -77,35 +81,39 @@ void main() {
     expect(response, isNotNull);
   });
 
-  test('pinning: untrusted certificate rejected before validateCertificate',
-      () async {
-    DioError? error;
-
-    try {
-      final dio = Dio();
-      dio.httpClientAdapter = IOHttpClientAdapter()
-        ..onHttpClientCreate = (_) {
-          return HttpClient(context: SecurityContext(withTrustedRoots: false));
-        }
-        ..validateCertificate =
-            (cert, host, port) => fail('Should not be evaluated');
-      await dio.get(
-        untrustedCertUrl,
-        options: Options(validateStatus: (status) => true),
-      );
-      fail('did not throw');
-    } on DioError catch (e) {
-      error = e;
-    }
-    expect(error, isNotNull);
-  });
+  test(
+    'pinning: untrusted certificate rejected before validateCertificate',
+    () async {
+      DioError? error;
+      try {
+        final dio = Dio();
+        dio.httpClientAdapter = IOHttpClientAdapter(
+          onHttpClientCreate: (client) {
+            return HttpClient(
+              context: SecurityContext(withTrustedRoots: false),
+            );
+          },
+          validateCertificate: (cert, host, port) =>
+              fail('Should not be evaluated'),
+        );
+        await dio.get(
+          untrustedCertUrl,
+          options: Options(validateStatus: (status) => true),
+        );
+        fail('did not throw');
+      } on DioError catch (e) {
+        error = e;
+      }
+      expect(error, isNotNull);
+    },
+  );
 
   test('bad pinning: badCertCallback does not use leaf certificate', () async {
     DioError? error;
     try {
       final dio = Dio();
-      dio.httpClientAdapter = IOHttpClientAdapter()
-        ..onHttpClientCreate = (HttpClient client) {
+      dio.httpClientAdapter = IOHttpClientAdapter(
+        onHttpClientCreate: (HttpClient client) {
           final effectiveClient = HttpClient(
             context: SecurityContext(withTrustedRoots: false),
           );
@@ -114,7 +122,8 @@ void main() {
           effectiveClient.badCertificateCallback = (cert, host, port) =>
               fingerprint == sha256.convert(cert.der).toString();
           return effectiveClient;
-        };
+        },
+      );
       await dio.get(
         trustedCertUrl,
         options: Options(validateStatus: (status) => true),
@@ -130,11 +139,12 @@ void main() {
     int approvalCount = 0;
     final dio = Dio();
     // badCertificateCallback never called for trusted certificate
-    dio.httpClientAdapter = IOHttpClientAdapter()
-      ..validateCertificate = (cert, host, port) {
+    dio.httpClientAdapter = IOHttpClientAdapter(
+      validateCertificate: (cert, host, port) {
         approvalCount++;
         return fingerprint == sha256.convert(cert!.der).toString();
-      };
+      },
+    );
     Response response = await dio.get(
       trustedCertUrl,
       options: Options(validateStatus: (status) => true),

--- a/example/lib/certificate_pinning.dart
+++ b/example/lib/certificate_pinning.dart
@@ -17,16 +17,16 @@ void main() async {
       'ee5ce1dfa7a53657c545c62b65802e4272878dabd65c0aadcf85783ebb0b4d5c';
 
   // Don't trust any certificate just because their root cert is trusted
-  dio.httpClientAdapter = IOHttpClientAdapter()
-    ..onHttpClientCreate = (_) {
+  dio.httpClientAdapter = IOHttpClientAdapter(
+    onHttpClientCreate: (_) {
       final client = HttpClient(
         context: SecurityContext(withTrustedRoots: false),
       );
       // You can test the intermediate / root cert here. We just ignore it.
       client.badCertificateCallback = (cert, host, port) => true;
       return client;
-    }
-    ..validateCertificate = (cert, host, port) {
+    },
+    validateCertificate: (cert, host, port) {
       // Check that the cert fingerprint matches the one we expect
       // We definitely require _some_ certificate
       if (cert == null) return false;
@@ -35,7 +35,8 @@ void main() async {
       final f = sha256.convert(cert.der).toString();
       print(f);
       return fingerprint == f;
-    };
+    },
+  );
 
   Response? response;
 

--- a/example/lib/formdata.dart
+++ b/example/lib/formdata.dart
@@ -92,15 +92,16 @@ void main() async {
   dio.options.baseUrl = 'http://localhost:3000/';
   dio.interceptors.add(LogInterceptor());
   // dio.interceptors.add(LogInterceptor(requestBody: true));
-  dio.httpClientAdapter = IOHttpClientAdapter()
-    ..onHttpClientCreate = (client) {
+  dio.httpClientAdapter = IOHttpClientAdapter(
+    onHttpClientCreate: (client) {
       client.findProxy = (uri) {
         // Proxy all request to localhost:8888
         return 'PROXY localhost:8888';
       };
       client.badCertificateCallback = (cert, host, port) => true;
       return client;
-    };
+    },
+  );
   Response response;
 
   final data1 = await formData1();

--- a/example/lib/proxy.dart
+++ b/example/lib/proxy.dart
@@ -8,18 +8,19 @@ void main() async {
   dio.options
     ..headers['user-agent'] = 'xxx'
     ..contentType = 'text';
-  // dio.options.connectTimeout = 2000;
-  // More about HttpClient proxy topic please refer to Dart SDK doc.
-  dio.httpClientAdapter = IOHttpClientAdapter()
-    ..onHttpClientCreate = (HttpClient client) {
+  dio.httpClientAdapter = IOHttpClientAdapter(
+    onHttpClientCreate: (HttpClient client) {
       client.findProxy = (uri) {
-        //proxy all request to localhost:8888
+        // Proxy all request to localhost:8888.
+        // Be aware, the proxy should went through you running device,
+        // not the host platform.
         return 'PROXY localhost:8888';
       };
       client.badCertificateCallback =
           (X509Certificate cert, String host, int port) => true;
       return client;
-    };
+    },
+  );
 
   Response<String> response;
   response = await dio.get('https://www.baidu.com');


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

Methods in `BrowserHttpClientAdapter` and `IOHttpClientAdapter` can be defined directly through their constructor instead of updates after the creation.