### PR TITLE
[dio] Fix wrong default encoding being used for lists

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-*None.*
+- Fix wrong `ListFormat` being used for comparison during encoding of `FormData`
+  and `application/x-www-form-urlencoded`, resulting in potential wrong output encoding
+  for `ListFormat.multi` and `ListFormat.multiCompatible` since Dio 4.0.x.
 
 ## 5.1.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix wrong `ListFormat` being used for comparison during encoding of `FormData`
   and `application/x-www-form-urlencoded`, resulting in potential wrong output encoding
   for `ListFormat.multi` and `ListFormat.multiCompatible` since Dio 4.0.x.
+- Respect `Options.listFormat` when encoding `x-www-url-encoded` content.
 
 ## 5.1.0
 

--- a/dio/lib/src/transformers/sync_transformer.dart
+++ b/dio/lib/src/transformers/sync_transformer.dart
@@ -36,7 +36,7 @@ class SyncTransformer extends Transformer {
     if (data is! String && Transformer.isJsonMimeType(options.contentType)) {
       return jsonEncodeCallback(data);
     } else if (data is Map<String, dynamic>) {
-      return Transformer.urlEncodeMap(data);
+      return Transformer.urlEncodeMap(data, options.listFormat);
     } else {
       return data.toString();
     }

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -66,7 +66,7 @@ String encodeMap(
         for (int i = 0; i < sub.length; i++) {
           final isCollection =
               sub[i] is Map || sub[i] is List || sub[i] is ListParam;
-          if (listFormat == ListFormat.multi) {
+          if (format == ListFormat.multi) {
             urlEncode(
               maybeEncode(sub[i]),
               '$path${isCollection ? '$leftBracket$i$rightBracket' : ''}',

--- a/dio/test/encoding_test.dart
+++ b/dio/test/encoding_test.dart
@@ -71,7 +71,7 @@ void main() {
 
     test('custom', () {
       final result =
-          'a=%E4%BD%A0%E5%A5%BD&b=5%7C6&c%5Bd%5D=8&c%5Be%5D%5Ba%5D=5&c%5Be%5D%5Bb%5D=foo%2Cbar&c%5Be%5D%5Bc%5D=foo+bar&c%5Be%5D%5Bd%5D%5B%5D=foo&c%5Be%5D%5Bd%5D%5B%5D=bar&c%5Be%5D%5Be%5D=foo%5Ctbar';
+          'a=%E4%BD%A0%E5%A5%BD&b=5%7C6&c%5Bd%5D=8&c%5Be%5D%5Ba%5D=5&c%5Be%5D%5Bb%5D=foo%2Cbar&c%5Be%5D%5Bc%5D=foo+bar&c%5Be%5D%5Bd%5D=foo&c%5Be%5D%5Bd%5D=bar&c%5Be%5D%5Be%5D=foo%5Ctbar&c%5Be%5D%5Bf%5D%5B%5D=foo&c%5Be%5D%5Bf%5D%5B%5D=bar';
       expect(
         Transformer.urlEncodeMap(
           {
@@ -85,6 +85,10 @@ void main() {
                 'c': ListParam<String>(['foo', 'bar'], ListFormat.ssv),
                 'd': ListParam<String>(['foo', 'bar'], ListFormat.multi),
                 'e': ListParam<String>(['foo', 'bar'], ListFormat.tsv),
+                'f': [
+                  'foo',
+                  'bar'
+                ], // this uses ListFormat.multiCompatible set below
               },
             },
           },
@@ -115,17 +119,34 @@ void main() {
               'd': 8,
               'e': {
                 'a': 5,
-                'b': ListParam<Object>(['foo', 'bar', 1, 2.2], ListFormat.csv),
-                'c': ListParam<Object>(['foo', 'bar', 1, 2.2], ListFormat.ssv),
-                'd':
-                    ListParam<Object>(['foo', 'bar', 1, 2.2], ListFormat.multi),
-                'e': ListParam<Object>(['foo', 'bar', 1, 2.2], ListFormat.tsv),
+                'b': ListParam<Object>(
+                  ['foo', 'bar', 1, 2.2],
+                  ListFormat.csv,
+                ),
+                'c': ListParam<Object>(
+                  ['foo', 'bar', 1, 2.2],
+                  ListFormat.ssv,
+                ),
+                'd': ListParam<Object>(
+                  ['foo', 'bar', 1, 2.2],
+                  ListFormat.multi,
+                ),
+                'e': ListParam<Object>(
+                  ['foo', 'bar', 1, 2.2],
+                  ListFormat.tsv,
+                ),
+                'f': [
+                  'foo',
+                  'bar',
+                  1,
+                  2.2
+                ], // this uses ListFormat.multiCompatible set below
               },
             },
           },
           ListFormat.multiCompatible,
         ),
-        'a=%E4%BD%A0%E5%A5%BD&b=5|6&c[d]=8&c[e][a]=5&c[e][b]=foo,bar,1,2.2&c[e][c]=foo%20bar%201%202.2&c[e][d][]=foo&c[e][d][]=bar&c[e][d][]=1&c[e][d][]=2.2&c[e][e]=foo\\tbar\\t1\\t2.2',
+        'a=%E4%BD%A0%E5%A5%BD&b=5|6&c[d]=8&c[e][a]=5&c[e][b]=foo,bar,1,2.2&c[e][c]=foo%20bar%201%202.2&c[e][d]=foo&c[e][d]=bar&c[e][d]=1&c[e][d]=2.2&c[e][e]=foo\\tbar\\t1\\t2.2&c[e][f][]=foo&c[e][f][]=bar&c[e][f][]=1&c[e][f][]=2.2',
       );
     });
   });

--- a/dio/test/encoding_test.dart
+++ b/dio/test/encoding_test.dart
@@ -149,5 +149,24 @@ void main() {
         'a=%E4%BD%A0%E5%A5%BD&b=5|6&c[d]=8&c[e][a]=5&c[e][b]=foo,bar,1,2.2&c[e][c]=foo%20bar%201%202.2&c[e][d]=foo&c[e][d]=bar&c[e][d]=1&c[e][d]=2.2&c[e][e]=foo\\tbar\\t1\\t2.2&c[e][f][]=foo&c[e][f][]=bar&c[e][f][]=1&c[e][f][]=2.2',
       );
     });
+
+    test('InOption', () async {
+      final data = {
+        'key1': 'value1',
+        'spec': [6],
+      };
+
+      await Dio()
+          .post<Map<String, dynamic>>('https://postman-echo.com/post',
+              data: data,
+              options: Options(
+                  contentType: Headers.formUrlEncodedContentType,
+                  method: 'post',
+                  listFormat: ListFormat.multiCompatible))
+          .then((result) {
+        print('===<Response>---\n$result');
+        expect(result.toString(), contains('spec[]'));
+      });
+    });
   });
 }

--- a/dio/test/encoding_test.dart
+++ b/dio/test/encoding_test.dart
@@ -149,24 +149,5 @@ void main() {
         'a=%E4%BD%A0%E5%A5%BD&b=5|6&c[d]=8&c[e][a]=5&c[e][b]=foo,bar,1,2.2&c[e][c]=foo%20bar%201%202.2&c[e][d]=foo&c[e][d]=bar&c[e][d]=1&c[e][d]=2.2&c[e][e]=foo\\tbar\\t1\\t2.2&c[e][f][]=foo&c[e][f][]=bar&c[e][f][]=1&c[e][f][]=2.2',
       );
     });
-
-    test('InOption', () async {
-      final data = {
-        'key1': 'value1',
-        'spec': [6],
-      };
-
-      await Dio()
-          .post<Map<String, dynamic>>('https://postman-echo.com/post',
-              data: data,
-              options: Options(
-                  contentType: Headers.formUrlEncodedContentType,
-                  method: 'post',
-                  listFormat: ListFormat.multiCompatible))
-          .then((result) {
-        print('===<Response>---\n$result');
-        expect(result.toString(), contains('spec[]'));
-      });
-    });
   });
 }

--- a/dio/test/url_encoded_test.dart
+++ b/dio/test/url_encoded_test.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 

--- a/dio/test/url_encoded_test.dart
+++ b/dio/test/url_encoded_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+import 'mock/adapters.dart';
+
+void main() async {
+  group('x-www-url-encoded', () {
+    test('posts maps correctly', () async {
+      final data = {
+        'spec': [6],
+        'items': [
+          {'name': 'foo', 'value': 1},
+          {'name': 'bar', 'value': 2},
+        ],
+        'api': {
+          'dest': '/',
+          'data': {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+          },
+        },
+      };
+
+      final dio = Dio()
+        ..options.baseUrl = EchoAdapter.mockBase
+        ..httpClientAdapter = EchoAdapter();
+
+      final response = await dio.post(
+        '/post',
+        data: data,
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          listFormat: ListFormat.multiCompatible,
+        ),
+      );
+
+      final expected =
+          'spec%5B%5D=6&items%5B0%5D%5Bname%5D=foo&items%5B0%5D%5Bvalue%5D=1&items%5B1%5D%5Bname%5D=bar&items%5B1%5D%5Bvalue%5D=2&api%5Bdest%5D=%2F&api%5Bdata%5D%5Ba%5D=1&api%5Bdata%5D%5Bb%5D=2&api%5Bdata%5D%5Bc%5D=3';
+      final expectedDecoded =
+          'spec[]=6&items[0][name]=foo&items[0][value]=1&items[1][name]=bar&items[1][value]=2&api[dest]=/&api[data][a]=1&api[data][b]=2&api[data][c]=3';
+      expect(
+        response.data,
+        expected,
+      );
+      expect(
+        Uri.decodeQueryComponent(response.data),
+        expectedDecoded,
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->
Fixes wrong default format used for comparison during encoding.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)
This should fix #1758
