### PR TITLE
🚨 Analyze repos with fatal infos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           sdk: stable
       - name: Analyze
-        run: dart pub get && dart analyze
+        run: dart pub get && dart analyze --fatal-infos
 
   analyze_flutter:
     needs: format
@@ -73,7 +73,7 @@ jobs:
           cache: true
           channel: stable
       - name: Analyze
-        run: flutter pub get && flutter analyze
+        run: flutter pub get && flutter analyze --fatal-infos
 
   test_dio:
     needs: [analyze, analyze_flutter]

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -169,7 +169,7 @@ class _ConnectionManager implements ConnectionManager {
 
     final completerProxyInitialization = Completer<void>();
 
-    Never _onProxyError(Object? error, StackTrace stackTrace) {
+    Never onProxyError(Object? error, StackTrace stackTrace) {
       throw DioError(
         requestOptions: options,
         error: error,
@@ -178,7 +178,7 @@ class _ConnectionManager implements ConnectionManager {
       );
     }
 
-    completerProxyInitialization.future.onError(_onProxyError);
+    completerProxyInitialization.future.onError(onProxyError);
 
     final proxySubscription = proxySocket.listen(
       (event) {


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

In a recent release of `http2_adapter`, the publishing job failed because our CI didn't raise lint warnings about the `info` level. Adding `--fatal-infos` will let the analyze step raises warnings for all type of lint exceptions.