### PR TITLE
improve log interceptor

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 *None.*
 
+## 5.1.2
+ - In the interceptor log, add by default that requests are only printed in debug mode
+
 ## 5.1.1
 
 - Revert changes to `CancelToken.cancel()` behavior, as a result the `DioError`

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@
 *None.*
 
 ## 5.1.2
- - In the interceptor log, add by default that requests are only printed in debug mode
+ - BREAKING CHANGE: Logging is only done in debug builds. Previously, it was also enabled in release builds. See the readme for instructions on how to revert to the old behavior 
 
 ## 5.1.1
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Make `LogInterceptor` prints in DEBUG mode (when the assertion is enabled) by default.
 
 ## 5.1.2
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 *None.*
 
-## 5.1.2
- - BREAKING CHANGE: Logging is only done in debug builds. Previously, it was also enabled in release builds. See the readme for instructions on how to revert to the old behavior 
-
 ## 5.1.1
 
 - Revert changes to `CancelToken.cancel()` behavior, as a result the `DioError`

--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -485,7 +485,9 @@ print(response.data); // 'fake data'
 dio.interceptors.add(LogInterceptor(responseBody: false)); // 不输出响应内容体
 ```
 
-注意：由于拦截器队列是先进先出，`LogInterceptor` 应当在最后添加至 `Dio` 实例。
+**注意：** 由于拦截器队列是先进先出，`LogInterceptor` 应当在最后添加至 `Dio` 实例。
+
+**注意：** 日志默认仅在 DEBUG 模式（启用了断言）下打印。
 
 ### 自定义拦截器
 

--- a/dio/README.md
+++ b/dio/README.md
@@ -513,16 +513,9 @@ You can apply the `LogInterceptor` to log requests and responses automatically i
 dio.interceptors.add(LogInterceptor(responseBody: false)); // Do not output responses body.
 ```
 
-Note: `LogInterceptor` should be the last to add since the interceptors are FIFO.
+**Note:** `LogInterceptor` should be the last to add since the interceptors are FIFO.
 
-### Note: By default, request logs will only be printed in debug mode, to change this customize the print mode: 
-
-LogInterceptor:
-```dart 
-dio.interceptors.add(LogInterceptor(
-  logPrint: print
-));
-```
+**Note:** Logs will only be printed in the DEBUG mode (when the assertion is enabled).
 
 #### Custom Interceptor
 

--- a/dio/README.md
+++ b/dio/README.md
@@ -515,6 +515,15 @@ dio.interceptors.add(LogInterceptor(responseBody: false)); // Do not output resp
 
 Note: `LogInterceptor` should be the last to add since the interceptors are FIFO.
 
+### Note: As of version 5.1.2, by default, request logs will only be printed in debug mode, to change this customize the print mode: 
+
+LogInterceptor:
+```dart 
+dio.interceptors.add(LogInterceptor(
+  logPrint: print
+));
+```
+
 #### Custom Interceptor
 
 You can customize interceptor by extending the `Interceptor/QueuedInterceptor` class.

--- a/dio/README.md
+++ b/dio/README.md
@@ -507,7 +507,7 @@ For the complete code see [here](../example/lib/queued_interceptor_crsftoken.dar
 
 #### LogInterceptor
 
-You can apply the `LogInterceptor` to log requests and responses automatically:
+You can apply the `LogInterceptor` to log requests and responses automatically in the DEBUG mode:
 
 ```dart
 dio.interceptors.add(LogInterceptor(responseBody: false)); // Do not output responses body.

--- a/dio/README.md
+++ b/dio/README.md
@@ -515,7 +515,7 @@ dio.interceptors.add(LogInterceptor(responseBody: false)); // Do not output resp
 
 Note: `LogInterceptor` should be the last to add since the interceptors are FIFO.
 
-### Note: As of version 5.1.2, by default, request logs will only be printed in debug mode, to change this customize the print mode: 
+### Note: By default, request logs will only be printed in debug mode, to change this customize the print mode: 
 
 LogInterceptor:
 ```dart 

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -15,7 +15,7 @@ class LogInterceptor extends Interceptor {
     this.responseHeader = true,
     this.responseBody = false,
     this.error = true,
-    this.logPrint = printOnlyDebug,
+    this.logPrint = debugPrint,
   });
 
   /// Print request [Options]
@@ -133,7 +133,7 @@ class LogInterceptor extends Interceptor {
   }
 }
 
-void printOnlyDebug(Object? object) {
+void debugPrint(Object? object) {
   assert(() {
     print(object);
     return true;

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -15,7 +15,7 @@ class LogInterceptor extends Interceptor {
     this.responseHeader = true,
     this.responseBody = false,
     this.error = true,
-    this.logPrint = print,
+    this.logPrint = printOnlyDebug,
   });
 
   /// Print request [Options]
@@ -131,4 +131,11 @@ class LogInterceptor extends Interceptor {
   void _printAll(msg) {
     msg.toString().split('\n').forEach(logPrint);
   }
+}
+
+void printOnlyDebug(Object? object) {
+  assert(() {
+    print(object);
+    return true;
+  }());
 }

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -15,7 +15,7 @@ class LogInterceptor extends Interceptor {
     this.responseHeader = true,
     this.responseBody = false,
     this.error = true,
-    this.logPrint = debugPrint,
+    this.logPrint = _debugPrint,
   });
 
   /// Print request [Options]
@@ -133,7 +133,7 @@ class LogInterceptor extends Interceptor {
   }
 }
 
-void debugPrint(Object? object) {
+void _debugPrint(Object? object) {
   assert(() {
     print(object);
     return true;


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package


### Motivation 
When running the app on systems focused on application analysis, such as [BrowserStack](https://www.browserstack.com) , same in profile mode , the request logs can leak unwanted information, even if the developer has the option to remove the print, most of them are not aware of these "leaks" of requests.

This opens the way for an attacker who has an apk , aab or any other file that the browserStack
accept, be able to run the app on the website and view the logs

So I suggest the inclusion of this little code that by default only executes the prints in debug mode
<!-- Provide more context and info about the PR. -->
