### PR TITLE
Add async to CustomInterceptors.onError in dio/README.md.

### DIFF
--- a/dio/README.md
+++ b/dio/README.md
@@ -458,7 +458,7 @@ class CustomInterceptors extends Interceptor {
   }
 
   @override
-  Future onError(DioError err, ErrorInterceptorHandler handler) {
+  Future onError(DioError err, ErrorInterceptorHandler handler) async {
     print('ERROR[${err.response?.statusCode}] => PATH: ${err.requestOptions.path}');
     super.onError(err, handler);
   }


### PR DESCRIPTION
⚠ This is my first pull request to OSS. Sorry if I made a mistake.
I just added async to CustomInterceptors.onError in dio/README.md.
async may not be necessary, but without it, "body_might_complete_normally" will occur.

Currently it is an error. I think the solution is either.
1. remove Future.
2. add "async".

If 1 is better, I will modify it.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package
