### PR TITLE
Fix return type of OnHttpClientCreate

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 - Make `LogInterceptor` prints in DEBUG mode (when the assertion is enabled) by default.
 - Fix `IOHttpClientAdapter.onHttpClientCreate` Repeated calls
-- `IOHttpClientAdapter.onHttpClientCreate` has been deprecated because of unclear handling
-  when the provided client was modified but not returned. This is scheduled for removal in
+- `IOHttpClientAdapter.onHttpClientCreate` has been deprecated and is scheduled for removal in
   Dio 6.0.0 - Please use the replacement `IOHttpClientAdapter.createHttpClient` instead.
 
 ## 5.1.2

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Make `LogInterceptor` prints in DEBUG mode (when the assertion is enabled) by default.
 - Fix `IOHttpClientAdapter.onHttpClientCreate` Repeated calls
+- `IOHttpClientAdapter.onHttpClientCreate` has been deprecated because of unclear handling
+  when the provided client was modified but not returned. This is scheduled for removal in
+  Dio 6.0.0 - Please use the replacement `IOHttpClientAdapter.createHttpClient` instead.
 
 ## 5.1.2
 

--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -698,14 +698,15 @@ dio.httpClientAdapter = HttpClientAdapter();
 
 ### 设置代理
 
-`IOHttpClientAdapter` 提供了一个 `onHttpClientCreate` 回调来设置底层 `HttpClient` 的代理：
+`IOHttpClientAdapter` 提供了一个 `createHttpClient` 回调来设置底层 `HttpClient` 的代理：
 
 ```dart
 import 'package:dio/io.dart';
 
 void initAdapter() {
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (client) {
+    createHttpClient: () {
+      final client = HttpClient();
       client.findProxy = (uri) {
         // 将请求代理至 localhost:8888。
         // 请注意，代理会在你正在运行应用的设备上生效，而不是在宿主平台生效。
@@ -776,7 +777,8 @@ openssl s_client -servername pinning-test.badssl.com -connect pinning-test.badss
 void initAdapter() {
   String PEM = 'XXXXX'; // root certificate content
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (client) {
+    createHttpClient: () {
+      final client = HttpClient();
       client.badCertificateCallback = (X509Certificate cert, String host, int port) {
         return cert.pem == PEM; // Verify the certificate.
       };

--- a/dio/README.md
+++ b/dio/README.md
@@ -746,7 +746,8 @@ import 'package:dio/io.dart';
 
 void initAdapter() {
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (client) {
+    createHttpClient: () {
+      final client = HttpClient();
       // Config the client.
       client.findProxy = (uri) {
         // Forward all request to proxy "localhost:8888".
@@ -824,7 +825,8 @@ Suppose the certificate format is PEM, the code like:
 void initAdapter() {
   String PEM = 'XXXXX'; // root certificate content
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (client) {
+    createHttpClient: () {
+      final client = HttpClient();
       client.badCertificateCallback = (X509Certificate cert, String host, int port) {
         return cert.pem == PEM; // Verify the certificate.
       };

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 import 'options.dart';
 import 'parameter.dart';
 
-/// Pipes all data and errors from [stream] into [sink]. Completes [Future] once
+/// Pipes all data and errors from [stream] into [sink]. Completes [Future]HttpClonce
 /// [stream] is done. Unlike [store], [sink] remains open after [stream] is
 /// done.
 Future writeStreamToSink(Stream stream, EventSink sink) {

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 import 'options.dart';
 import 'parameter.dart';
 
-/// Pipes all data and errors from [stream] into [sink]. Completes [Future]HttpClonce
+/// Pipes all data and errors from [stream] into [sink]. Completes [Future] once
 /// [stream] is done. Unlike [store], [sink] remains open after [stream] is
 /// done.
 Future writeStreamToSink(Stream stream, EventSink sink) {

--- a/dio/test/adapters_test.dart
+++ b/dio/test/adapters_test.dart
@@ -1,20 +1,39 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(HttpClientAdapter, () {
-    test(
-        'IOHttpClientAdapter.onHttpClientCreate is only executed once per request',
-        () async {
-      int onHttpClientCreateInvokeCount = 0;
-      final dio = Dio();
-      dio.httpClientAdapter = IOHttpClientAdapter(onHttpClientCreate: (client) {
-        onHttpClientCreateInvokeCount++;
-        return client;
+  group(
+    IOHttpClientAdapter,
+    () {
+      test('onHttpClientCreate is only executed once per request', () async {
+        int onHttpClientCreateInvokeCount = 0;
+        final dio = Dio();
+        dio.httpClientAdapter = IOHttpClientAdapter(
+          onHttpClientCreate: (client) {
+            onHttpClientCreateInvokeCount++;
+            return client;
+          },
+        );
+        await dio.get('https://pub.dev');
+        expect(onHttpClientCreateInvokeCount, 1);
       });
-      await dio.get('https://pub.dev');
-      expect(onHttpClientCreateInvokeCount, 1);
-    });
-  });
+
+      test('createHttpClientCount is only executed once per request', () async {
+        int createHttpClientCount = 0;
+        final dio = Dio();
+        dio.httpClientAdapter = IOHttpClientAdapter(
+          createHttpClient: () {
+            createHttpClientCount++;
+            return HttpClient();
+          },
+        );
+        await dio.get('https://pub.dev');
+        expect(createHttpClientCount, 1);
+      });
+    },
+    testOn: 'vm',
+  );
 }

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -56,8 +56,9 @@ void main() {
     () async {
       final dio = Dio();
       dio.httpClientAdapter = IOHttpClientAdapter(
-        onHttpClientCreate: (client) {
-          return client..badCertificateCallback = (cert, host, port) => true;
+        createHttpClient: () {
+          return HttpClient()
+            ..badCertificateCallback = (cert, host, port) => true;
         },
       );
       Response response = await dio.get('https://wrong.host.badssl.com/');

--- a/dio/test/pinning_test.dart
+++ b/dio/test/pinning_test.dart
@@ -67,8 +67,9 @@ void main() {
     final dio = Dio();
     // badCertificateCallback must allow the untrusted certificate through
     dio.httpClientAdapter = IOHttpClientAdapter(
-      onHttpClientCreate: (client) {
-        return client..badCertificateCallback = (cert, host, port) => true;
+      createHttpClient: () {
+        return HttpClient()
+          ..badCertificateCallback = (cert, host, port) => true;
       },
       validateCertificate: (cert, host, port) {
         return fingerprint == sha256.convert(cert!.der).toString();
@@ -88,7 +89,7 @@ void main() {
       try {
         final dio = Dio();
         dio.httpClientAdapter = IOHttpClientAdapter(
-          onHttpClientCreate: (client) {
+          createHttpClient: () {
             return HttpClient(
               context: SecurityContext(withTrustedRoots: false),
             );
@@ -113,7 +114,7 @@ void main() {
     try {
       final dio = Dio();
       dio.httpClientAdapter = IOHttpClientAdapter(
-        onHttpClientCreate: (HttpClient client) {
+        createHttpClient: () {
           final effectiveClient = HttpClient(
             context: SecurityContext(withTrustedRoots: false),
           );

--- a/dio/test/readtimeout_test.dart
+++ b/dio/test/readtimeout_test.dart
@@ -105,7 +105,7 @@ void main() {
     final adapter = IOHttpClientAdapter();
     final http = HttpClient();
 
-    adapter.onHttpClientCreate = (_) => http;
+    adapter.createHttpClient = () => http;
     dio.httpClientAdapter = adapter;
     dio.options
       ..baseUrl = serverUrl.toString()

--- a/example/lib/certificate_pinning.dart
+++ b/example/lib/certificate_pinning.dart
@@ -18,7 +18,7 @@ void main() async {
 
   // Don't trust any certificate just because their root cert is trusted
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (_) {
+    createHttpClient: () {
       final client = HttpClient(
         context: SecurityContext(withTrustedRoots: false),
       );

--- a/example/lib/formdata.dart
+++ b/example/lib/formdata.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
@@ -93,7 +94,8 @@ void main() async {
   dio.interceptors.add(LogInterceptor());
   // dio.interceptors.add(LogInterceptor(requestBody: true));
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (client) {
+    createHttpClient: () {
+      final client = HttpClient();
       client.findProxy = (uri) {
         // Proxy all request to localhost:8888
         return 'PROXY localhost:8888';

--- a/example/lib/proxy.dart
+++ b/example/lib/proxy.dart
@@ -9,7 +9,8 @@ void main() async {
     ..headers['user-agent'] = 'xxx'
     ..contentType = 'text';
   dio.httpClientAdapter = IOHttpClientAdapter(
-    onHttpClientCreate: (HttpClient client) {
+    createHttpClient: () {
+      final client = HttpClient();
       client.findProxy = (uri) {
         // Proxy all request to localhost:8888.
         // Be aware, the proxy should went through you running device,


### PR DESCRIPTION
The return type of `OnHttpClientCreate` has been changed from `HttpClient?` to `HttpClient`.
While technically a breaking change, it is considered a bug because the callback was actually
a no-op when the provided client was modified but not returned.

Fixes 1. of #1811

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
