### PR TITLE
Remove custom idleTimeout in IOHttpClientAdapter

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Remove `IOHttpClientAdapter.onHttpClientCreate` which was deprecated in `5.2.0`
 - Remove `DioError` and `DioErrorType` which was deprecated in `5.2.0`.
 - Remove `DefaultTransformer` which was deprecated in `5.0.0`.
+- `IOHttpClientAdapter` no longer sets a custom `HttpClient.idleTimeout`. A custom `HttpClient` can be provided via
+  `IOHttpClientAdapter.createHttpClient` if customisation is required.
 
 ## Unreleased
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -222,6 +222,6 @@ class IOHttpClientAdapter implements HttpClientAdapter {
     if (createHttpClient != null) {
       return createHttpClient!();
     }
-    return HttpClient()..idleTimeout = Duration(seconds: 3);
+    return HttpClient();
   }
 }


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->
* fixes #1801 - I think we should not provide a customisation option directly, all customisation can be done via `createHttpClient` instead. I also don't understand why we did default to 3 seconds.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
