### PR TITLE
Bump min Dart version to 2.17.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.15.0, stable, beta ]
+        sdk: [ 2.16.0, stable, beta ]
         platform: [ vm, chrome ]
     steps:
       - uses: actions/checkout@v3
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.15.0, stable, beta ]
+        sdk: [ 2.16.0, stable, beta ]
         directory: ["plugins/cookie_manager", "plugins/http2_adapter"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.16.0, stable, beta ]
+        sdk: [ 2.17.0, stable, beta ]
         platform: [ vm, chrome ]
     steps:
       - uses: actions/checkout@v3
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.16.0, stable, beta ]
+        sdk: [ 2.17.0, stable, beta ]
         directory: ["plugins/cookie_manager", "plugins/http2_adapter"]
     steps:
       - uses: actions/checkout@v3

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased 6.0.0
 
+- The minimum supported Dart version has been bumped from `2.15.0` to `2.16.0`.
 - Remove `DefaultHttpClientAdapter` which was deprecated in `5.0.0`.
 - Remove `IOHttpClientAdapter.onHttpClientCreate` which was deprecated in `5.2.0`
 - Remove `DioError` and `DioErrorType` which was deprecated in `5.2.0`.

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/cfug/dio/issues
 version: 5.1.2
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   async: ^2.8.2

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/cfug/dio/issues
 version: 5.1.2
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   async: ^2.8.2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   cookie_jar:

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   cookie_jar: ^4.0.0

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   cookie_jar: ^4.0.0

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   http2: ^2.0.0

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   http2: ^2.0.0


### PR DESCRIPTION
I suggest we raise the min Dart version to 2.17.0 in 6.0.0

* support of `pubspec_overrides.yaml` in min Dart version tests
* support of `Error. throwWithStackTrace`
* required for mockitos `@GenerateNiceMocks`

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
