### PR TITLE
fix(dio): make DioError deprecation non-breaking.

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Make `DioError` deprecation non-breaking.
 
 ## 5.2.0
 

--- a/dio/lib/dio.dart
+++ b/dio/lib/dio.dart
@@ -6,6 +6,7 @@ library dio;
 export 'src/adapter.dart';
 export 'src/cancel_token.dart';
 export 'src/dio.dart';
+export 'src/dio_error.dart';
 export 'src/dio_exception.dart';
 export 'src/dio_mixin.dart' hide InterceptorState, InterceptorResultType;
 export 'src/form_data.dart';

--- a/dio/lib/src/dio_error.dart
+++ b/dio/lib/src/dio_error.dart
@@ -1,0 +1,10 @@
+import 'dio_exception.dart';
+
+/// Deprecated in favor of [DioExceptionType] and will be removed in future major versions.
+@Deprecated('Use DioException instead. This will be removed in 6.0.0')
+typedef DioErrorType = DioExceptionType;
+
+/// [DioError] describes the exception info when a request failed.
+/// Deprecated in favor of [DioException] and will be removed in future major versions.
+@Deprecated('Use DioException instead. This will be removed in 6.0.0')
+typedef DioError = DioException;

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -1,15 +1,6 @@
 import 'options.dart';
 import 'response.dart';
 
-/// Deprecated in favor of [DioExceptionType] and will be removed in future major versions.
-@Deprecated('Use DioException instead. This will be removed in 6.0.0')
-typedef DioErrorType = DioExceptionType;
-
-/// [DioError] describes the exception info when a request failed.
-/// Deprecated in favor of [DioException] and will be removed in future major versions.
-@Deprecated('Use DioException instead. This will be removed in 6.0.0')
-typedef DioError = DioException;
-
 enum DioExceptionType {
   /// Caused by a connection timeout.
   connectionTimeout,


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
Removing the `dio_error.dart` export is a breaking change, and shouln't be done. This PR reverts that deletion to make it non-breaking.
