### PR TITLE
Revert changes to List<int> body data handling

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,6 +7,10 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 *None.*
 
+## 5.2.0+2
+
+- Revert changes to handling of `List<int>` body data.
+
 ## 5.2.0+1
 
 - Fix `DioErrorType` deprecation hint.
@@ -20,7 +24,6 @@ See the [Migration Guide][] for the complete breaking changes list.**
   Dio 6.0.0 - Please use the replacement `IOHttpClientAdapter.createHttpClient` instead.
 - Using `CancelToken` no longer closes and re-creates `HttpClient` for each request when `IOHttpClientAdapter` is used.
 - Fix timeout handling for browser `receiveTimeout`.
-- Using `CancelToken` no longer closes and re-creates `HttpClient` for each request when `IOHttpClientAdapter` is used. 
 - Improve performance when sending binary data (`List<int>`/`Uint8List`). 
 
 ## 5.1.2

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -640,9 +640,6 @@ abstract class DioMixin implements Dio {
         if (data is Uint8List) {
           // Handle binary data which does not need to be transformed
           bytes = data;
-        } else if (data is List<int>) {
-          // Handle binary data which does not need to be transformed
-          bytes = Uint8List.fromList(data);
         } else {
           // Call request transformer for anything else
           final transformed = await transformer.transformRequest(options);


### PR DESCRIPTION
A previous change to improve the performance of binary uploads accidentally broke the functionality of uploading `List<int>` json bodies.
Fixes #1858 

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
