### PR TITLE
[dio] Ensure consistent handling of "/" in concatenation of baseUrl with path

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Fix url concatenation '/' handling
 
 ## 5.2.1+1
 

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:meta/meta.dart';
 
 import 'adapter.dart';
@@ -585,20 +587,21 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
 
   /// generate uri
   Uri get uri {
-    String url = path;
-    if (!url.startsWith(RegExp(r'https?:'))) {
-      url = '$baseUrl/$url';
-      final s = url.split(':/');
-      if (s.length == 2) {
-        url = '${s[0]}:/${s[1].replaceAll(RegExp(r'///?'), '/')}';
-      }
+    Uri uri = Uri.parse(path);
+
+    if (!uri.isAbsolute) {
+      uri = Uri.parse(baseUrl).resolveUri(uri);
     }
+
     final query = Transformer.urlEncodeQueryMap(queryParameters, listFormat);
     if (query.isNotEmpty) {
-      url += (url.contains('?') ? '&' : '?') + query;
+      final separator = uri.query.isNotEmpty ? '&' : '';
+      final mergedQuery = uri.query + separator + query;
+      uri = uri.replace(query: mergedQuery);
     }
+
     // Normalize the url.
-    return Uri.parse(url).normalizePath();
+    return uri.normalizePath();
   }
 
   /// Request data, can be any type.

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -587,10 +587,10 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
   Uri get uri {
     String url = path;
     if (!url.startsWith(RegExp(r'https?:'))) {
-      url = baseUrl + url;
+      url = '$baseUrl/$url';
       final s = url.split(':/');
       if (s.length == 2) {
-        url = '${s[0]}:/${s[1].replaceAll('//', '/')}';
+        url = '${s[0]}:/${s[1].replaceAll(RegExp(r'///?'), '/')}';
       }
     }
     final query = Transformer.urlEncodeQueryMap(queryParameters, listFormat);

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -380,6 +380,24 @@ void main() {
     expect(r3.headers[Headers.contentTypeHeader], null);
   });
 
+  test('Ensure consistent slash handling', () {
+    final dio = Dio();
+    final inputs = [
+      ['https://www.example.com', 'path'],
+      ['https://www.example.com/', 'path'],
+      ['https://www.example.com', '/path'],
+      ['https://www.example.com/', '/path'],
+    ];
+
+    for (final input in inputs) {
+      final baseUrl = input[0];
+      final path = input[1];
+      dio.options.baseUrl = baseUrl;
+      final actual = Options().compose(dio.options, path).uri.toString();
+      expect(actual, 'https://www.example.com/path');
+    }
+  });
+
   test('responseDecoder return null', () async {
     final dio = Dio();
     dio.options.responseDecoder = (_, __, ___) => null;

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -534,20 +534,23 @@ void main() {
     );
   });
 
-  test('Should handle query parameters with list format', () {
+  test('Should preserve path query parameters to the URI', () {
     final baseUrl = 'https://www.example.com';
-    final path = '/path/to/resource';
+    final path = '/path/to/resource?param1=value1';
     final baseOptions = BaseOptions(baseUrl: baseUrl);
-    final expectedUri = Uri.parse('$baseUrl$path?param=value1,value2');
 
     final actual = Options(listFormat: ListFormat.csv).compose(
       baseOptions,
       path,
-      queryParameters: {
-        'param': ['value1', 'value2']
-      },
+      queryParameters: {'param2': 'value2'},
     ).uri;
 
-    expect(actual.toString(), equals(expectedUri.toString()));
+    expect(
+      actual.queryParameters,
+      equals({
+        'param1': 'value1',
+        'param2': 'value2',
+      }),
+    );
   });
 }


### PR DESCRIPTION
This PR ensures consistent handling of "/" when concatenating the baseUrl with the path.
Previously, if the baseUrl had a trailing "/" or the path had a leading "/", the resulting URL would contain duplicate slashes.
To address this issue, the algorithm has been modified to insert only a single "/" regardless of whether the baseUrl has a trailing slash or the path has a leading slash. This improvement enhance the reliability and correctness of the concatenation process, providing a more robust solution.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
