### PR TITLE
fix(http2_adapter):request by http2 without network once,the same domain request will never success.

### DIFF
--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Fix cached `initFuture` not remove when throw exception.
 
 ## 2.3.0
 

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -45,12 +45,13 @@ class _ConnectionManager implements ConnectionManager {
       if (initFuture == null) {
         _connectFutures[domain] = initFuture = _connect(options);
       }
-      transportState = await initFuture;
+      transportState = await initFuture.whenComplete(() {
+         _connectFutures.remove(domain);
+      });
       if (_forceClosed) {
         transportState.dispose();
       } else {
         _transportsMap[domain] = transportState;
-        final _ = _connectFutures.remove(domain);
       }
     } else {
       // Check whether the connection is terminated, if it is, reconnecting.

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -45,13 +45,17 @@ class _ConnectionManager implements ConnectionManager {
       if (initFuture == null) {
         _connectFutures[domain] = initFuture = _connect(options);
       }
-      transportState = await initFuture.whenComplete(() {
-         _connectFutures.remove(domain);
-      });
+      try {
+        transportState = await initFuture;
+      } catch (e) {
+        _connectFutures.remove(domain);
+        rethrow;
+      }
       if (_forceClosed) {
         transportState.dispose();
       } else {
         _transportsMap[domain] = transportState;
+        final _ = _connectFutures.remove(domain);
       }
     } else {
       // Check whether the connection is terminated, if it is, reconnecting.

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -70,7 +70,7 @@ void main() {
     try {
       // will throw SocketException
       await dio.post('post', data: 'TEST');
-    } on DioException catch (e) {
+    } on DioException {
       // ignore
     }
     final res = await dio.post('post', data: 'TEST');

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -49,4 +49,31 @@ void main() {
     final res = await dio.post('post', data: 'TEST');
     expect(res.data.toString(), contains('TEST'));
   });
+
+  test('request without network and restore', () async {
+    bool needProxy = true;
+    final dio = Dio()
+      ..options.baseUrl = 'https://httpbun.com/'
+      ..httpClientAdapter = Http2Adapter(ConnectionManager(
+        idleTimeout: Duration(milliseconds: 10),
+        onClientCreate: (uri, settings) {
+          if (needProxy) {
+            // first request use bad proxy to simulate network error
+            settings.proxy = Uri.parse('http://localhost:1234');
+            needProxy = false;
+          } else {
+            // remove proxy to restore network
+            settings.proxy = null;
+          }
+        },
+      ));
+    try {
+      // will throw SocketException
+      await dio.post('post', data: 'TEST');
+    } on DioException catch (e) {
+      // ignore
+    }
+    final res = await dio.post('post', data: 'TEST');
+    expect(res.data.toString(), contains('TEST'));
+  });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

`_ConnectionManager._connect` may throw SocketException when call `await initFuture`,if it occurs, even if the network is restored, subsequent requests with the same domain will still obtain the cached initFuture, and it will still fail
