### PR TITLE
Revert removed `download` for `DioMixin`

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Revert removed `download` for `DioMixin`.
 
 ## 5.3.1
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -294,6 +294,21 @@ abstract class DioMixin implements Dio {
   }
 
   @override
+  Future<Response> download(
+    String urlPath,
+    dynamic savePath, {
+    ProgressCallback? onReceiveProgress,
+    Map<String, dynamic>? queryParameters,
+    CancelToken? cancelToken,
+    bool deleteOnError = true,
+    String lengthHeader = Headers.contentLengthHeader,
+    Object? data,
+    Options? options,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<Response<T>> requestUri<T>(
     Uri uri, {
     Object? data,

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -16,4 +16,10 @@ void main() {
     );
     expect(typedResponse.data, isNull);
   });
+
+  test('throws UnimplementedError when calling download', () {
+    expectLater(() => _TextDioMixin().download(), throwsA<UnimplementedError>();
+  });
 }
+
+class _TestDioMixin with DioMixin implements Dio {}

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -17,10 +17,10 @@ void main() {
     expect(typedResponse.data, isNull);
   });
 
-  test('throws UnimplementedError when calling download', () {
-    expectLater(
-      () => _TestDioMixin().download('a', 'b'),
-      throwsA<UnimplementedError>(),
+  test('throws UnimplementedError when calling download', () async {
+    await expectLater(
+      _TestDioMixin().download('a', 'b'),
+      throwsA((e) => e is UnimplementedError),
     );
   });
 }

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -19,7 +19,7 @@ void main() {
 
   test('throws UnimplementedError when calling download', () {
     expectLater(
-      () => _TextDioMixin().download('a', 'b'),
+      () => _TestDioMixin().download('a', 'b'),
       throwsA<UnimplementedError>(),
     );
   });

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   test('throws UnimplementedError when calling download', () {
-    expectLater(() => _TextDioMixin().download(), throwsA<UnimplementedError>();
+    expectLater(() => _TextDioMixin().download('a', 'b'), throwsA<UnimplementedError>();
   });
 }
 

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -17,10 +17,10 @@ void main() {
     expect(typedResponse.data, isNull);
   });
 
-  test('throws UnimplementedError when calling download', () async {
-    await expectLater(
-      _TestDioMixin().download('a', 'b'),
-      throwsA((e) => e is UnimplementedError),
+  test('throws UnimplementedError when calling download', () {
+    expectLater(
+      () => _TestDioMixin().download('a', 'b'),
+      throwsA(TypeMatcher<UnimplementedError>()),
     );
   });
 }

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -18,7 +18,10 @@ void main() {
   });
 
   test('throws UnimplementedError when calling download', () {
-    expectLater(() => _TextDioMixin().download('a', 'b'), throwsA<UnimplementedError>());
+    expectLater(
+      () => _TextDioMixin().download('a', 'b'),
+      throwsA<UnimplementedError>(),
+    );
   });
 }
 

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   test('throws UnimplementedError when calling download', () {
-    expectLater(() => _TextDioMixin().download('a', 'b'), throwsA<UnimplementedError>();
+    expectLater(() => _TextDioMixin().download('a', 'b'), throwsA<UnimplementedError>());
   });
 }
 


### PR DESCRIPTION
See https://github.com/cfug/dio/pull/1772/files#r1281588318.

Fixes https://github.com/parse-community/Parse-SDK-Flutter/issues/958.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
