### PR TITLE
Improve usage example and tests

### DIFF
--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -230,7 +230,7 @@ abstract class Dio {
   ///   ),
   ///   onReceiveProgress: (received, total) {
   ///     if (total != -1) {
-  ///       print((received / total * 100).toStringAsFixed(0) + '%');
+  ///       print('${(received / total * 100).toStringAsFixed(0)}%');
   ///     }
   ///   },
   /// );

--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -229,9 +229,8 @@ abstract class Dio {
   ///     headers: {HttpHeaders.acceptEncodingHeader: '*'}, // Disable gzip
   ///   ),
   ///   onReceiveProgress: (received, total) {
-  ///     if (total != -1) {
-  ///       print('${(received / total * 100).toStringAsFixed(0)}%');
-  ///     }
+  ///     if (total <= 0) return;
+  ///     print('percentage: ${(received / total * 100).toStringAsFixed(0)}%');
   ///   },
   /// );
   /// ```

--- a/dio/test/download_test.dart
+++ b/dio/test/download_test.dart
@@ -13,14 +13,8 @@ void main() {
   tearDown(stopServer);
   test('download1', () async {
     const savePath = 'test/_download_test.md';
-    final dio = Dio();
-    dio.options.baseUrl = serverUrl.toString();
-    await dio.download(
-      '/download', savePath, // disable gzip
-      onReceiveProgress: (received, total) {
-        // ignore progress
-      },
-    );
+    final dio = Dio()..options.baseUrl = serverUrl.toString();
+    await dio.download('/download', savePath);
 
     final f = File(savePath);
     expect(f.readAsStringSync(), equals('I am a text file'));
@@ -29,11 +23,10 @@ void main() {
 
   test('download2', () async {
     const savePath = 'test/_download_test.md';
-    final dio = Dio();
-    dio.options.baseUrl = serverUrl.toString();
+    final dio = Dio()..options.baseUrl = serverUrl.toString();
     await dio.downloadUri(
       serverUrl.replace(path: '/download'),
-      (header) => savePath, // disable gzip
+      (header) => savePath,
     );
 
     final f = File(savePath);
@@ -43,8 +36,7 @@ void main() {
 
   test('download error', () async {
     const savePath = 'test/_download_test.md';
-    final dio = Dio();
-    dio.options.baseUrl = serverUrl.toString();
+    final dio = Dio()..options.baseUrl = serverUrl.toString();
     Response response = await dio
         .download('/error', savePath)
         .catchError((e) => (e as DioException).response!);
@@ -73,7 +65,6 @@ void main() {
           .catchError((e) => throw (e as DioException).type),
       throwsA(DioExceptionType.receiveTimeout),
     );
-    //print(r);
   });
 
   test('download cancellation', () async {

--- a/dio/test/request_test.dart
+++ b/dio/test/request_test.dart
@@ -84,12 +84,7 @@ void main() {
       );
 
       // redirect test
-      response = await dio.get(
-        '/redirect',
-        onReceiveProgress: (received, total) {
-          // ignore progress
-        },
-      );
+      response = await dio.get('/redirect');
       expect(response.isRedirect, true);
       expect(response.redirects.length, 1);
       final ri = response.redirects.first;

--- a/dio/test/utils.dart
+++ b/dio/test/utils.dart
@@ -96,9 +96,7 @@ Future<void> startServer() async {
           ..contentLength = content.length
           ..write(content);
 
-        Future.delayed(Duration(milliseconds: 300), () {
-          response.close();
-        });
+        Future.delayed(Duration(milliseconds: 300), () => response.close());
         return;
       }
 

--- a/example/lib/dio.dart
+++ b/example/lib/dio.dart
@@ -46,9 +46,7 @@ void main() async {
     './example/xx.html',
     queryParameters: {'a': 1},
     onReceiveProgress: (received, total) {
-      if (total != -1) {
-        print('$received,$total');
-      }
+      print('received: $received, total: $total');
     },
   );
 

--- a/example/lib/download.dart
+++ b/example/lib/download.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 void main() async {
   final dio = Dio();
   dio.interceptors.add(LogInterceptor());
+  dio.options.headers = {HttpHeaders.acceptEncodingHeader: '*'};
   final url = 'https://pub.dev/static/hash-rhob5slb/img/pub-dev-logo.svg';
   await download1(dio, url, './example/pub-dev-logo.svg');
   await download1(dio, url, (headers) => './example/pub-dev-logo-1.svg');
@@ -52,7 +53,6 @@ Future download2(Dio dio, String url, String savePath) async {
 }
 
 void showDownloadProgress(int received, int total) {
-  if (total != -1) {
-    print('${(received / total * 100).toStringAsFixed(0)}%');
-  }
+  if (total <= 0) return;
+  print('percentage: ${(received / total * 100).toStringAsFixed(0)}%');
 }

--- a/example/lib/download.dart
+++ b/example/lib/download.dart
@@ -51,8 +51,8 @@ Future download2(Dio dio, String url, String savePath) async {
   }
 }
 
-void showDownloadProgress(received, total) {
+void showDownloadProgress(int received, int total) {
   if (total != -1) {
-    print((received / total * 100).toStringAsFixed(0) + '%');
+    print('${(received / total * 100).toStringAsFixed(0)}%');
   }
 }

--- a/example/lib/download.dart
+++ b/example/lib/download.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 void main() async {
   final dio = Dio();
   dio.interceptors.add(LogInterceptor());
+  // Assure the value of total argument of onReceiveProgress is not -1.
   dio.options.headers = {HttpHeaders.acceptEncodingHeader: '*'};
   final url = 'https://pub.dev/static/hash-rhob5slb/img/pub-dev-logo.svg';
   await download1(dio, url, './example/pub-dev-logo.svg');

--- a/example/lib/download_with_trunks.dart
+++ b/example/lib/download_with_trunks.dart
@@ -4,24 +4,20 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 
 void main() async {
-  final url = 'http://download.dcloud.net.cn/HBuilder.9.0.2.macosx_64.dmg';
-  final savePath = './example/HBuilder.9.0.2.macosx_64.dmg';
-
-//  final url = "https://www.baidu.com/img/bdlogo.gif";
-//  final savePath = "./example/bg.gif";
+  final url = 'https://avatars.githubusercontent.com/u/0';
+  final savePath = './example/avatar.png';
 
   await downloadWithChunks(
     url,
     savePath,
     onReceiveProgress: (received, total) {
-      if (total != -1) {
-        print('${(received / total * 100).floor()}%');
-      }
+      if (total <= 0) return;
+      print('${(received / total * 100).floor()}%');
     },
   );
 }
 
-/// Downloading by spiting as file in chunks
+/// Downloading by splitting as file in chunks
 Future downloadWithChunks(
   url,
   savePath, {

--- a/example/lib/formdata.dart
+++ b/example/lib/formdata.dart
@@ -111,10 +111,9 @@ void main() async {
   response = await dio.post(
     'http://localhost:3000/upload',
     data: data3,
-    onSendProgress: (received, total) {
-      if (total != -1) {
-        print('${(received / total * 100).toStringAsFixed(0)}%');
-      }
+    onSendProgress: (sent, total) {
+      if (total <= 0) return;
+      print('percentage: ${(sent / total * 100).toStringAsFixed(0)}%');
     },
   );
   print(response);

--- a/example/lib/formdata.dart
+++ b/example/lib/formdata.dart
@@ -4,12 +4,6 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 
-void showProgress(received, total) {
-  if (total != -1) {
-    print((received / total * 100).toStringAsFixed(0) + '%');
-  }
-}
-
 Future<FormData> formData1() async {
   return FormData.fromMap({
     'name': 'wendux',
@@ -92,7 +86,6 @@ void main() async {
   final dio = Dio();
   dio.options.baseUrl = 'http://localhost:3000/';
   dio.interceptors.add(LogInterceptor());
-  // dio.interceptors.add(LogInterceptor(requestBody: true));
   dio.httpClientAdapter = IOHttpClientAdapter(
     createHttpClient: () {
       final client = HttpClient();
@@ -116,7 +109,6 @@ void main() async {
   print(utf8.decode(await data3.readAsBytes()));
 
   response = await dio.post(
-    //"/upload",
     'http://localhost:3000/upload',
     data: data3,
     onSendProgress: (received, total) {

--- a/example_flutter_app/lib/main.dart
+++ b/example_flutter_app/lib/main.dart
@@ -1,20 +1,8 @@
-import 'dart:convert';
-
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'http.dart'; // make dio as global top-level variable
 import 'routes/request.dart';
-
-// Must be top-level function
-_parseAndDecode(String response) {
-  return jsonDecode(response);
-}
-
-parseJson(String text) {
-  return compute(_parseAndDecode, text);
-}
 
 void main() {
   dio.interceptors.add(LogInterceptor());
@@ -91,7 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: SingleChildScrollView(
                 child: Text(_text),
               ),
-            )
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

- Improve tests.
- Improve usage example for `Dio.download`.
- Remove unused code.
- Fix typo in `example/lib/download_with_trunks`.
- Replace the broken resource: http://download.dcloud.net.cn/HBuilder.9.0.2.macosx_64.dmg.
- Disable the compression to assure the value of `total` argument of `onReceiveProgress` is not `-1` in `example/lib/download`.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->

There was no warning previously due to the default `dynamic` parameter type.
