### PR TITLE
Remove `Options.compose(options)`

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix failing requests throw `DioException`s with `.unknown` instead of `.connectionError` on `SocketException`.
+- Removes the accidentally added `options` argument for `Options.compose`.
 
 ## 5.3.2
 

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -294,7 +294,6 @@ class Options {
     Object? data,
     Map<String, dynamic>? queryParameters,
     CancelToken? cancelToken,
-    Options? options,
     ProgressCallback? onSendProgress,
     ProgressCallback? onReceiveProgress,
     StackTrace? sourceStackTrace,


### PR DESCRIPTION
Removes the accidentally added `options` argument for `Options.compose` by 75cf9166c3d5d159895de123e24a9ce748804a1a.

Resolves #1934.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package