### PR TITLE
[cookie_manager] Fix `FileSystemException` when saving redirect cookies without a proper `host`

### DIFF
--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Fix `FileSystemException: Cannot open file ... (OS Error: Is a directory, errno = 21)`
 
 ## 3.1.0+1
 

--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `FileSystemException: Cannot open file ... (OS Error: Is a directory, errno = 21)`
+- Fix `FileSystemException` when saving redirect cookies without a proper `host`.
 
 ## 3.1.0+1
 

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -123,6 +123,7 @@ class CookieManager extends Interceptor {
     // users will be available to handle cookies themselves.
     final isRedirectRequest = statusCode >= 300 && statusCode < 400;
     // Saving cookies for the original site.
+    // Spec: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2.
     final originalUri = response.requestOptions.uri;
     final realUri = originalUri.resolveUri(response.realUri);
     await cookieJar.saveFromResponse(realUri, cookies);

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -123,9 +123,9 @@ class CookieManager extends Interceptor {
     // users will be available to handle cookies themselves.
     final isRedirectRequest = statusCode >= 300 && statusCode < 400;
     // Saving cookies for the original site.
-    if (response.realUri.toString().isNotEmpty) {
-      await cookieJar.saveFromResponse(response.realUri, cookies);
-    }
+    final originalUri = response.requestOptions.uri;
+    final realUri = originalUri.resolveUri(response.realUri);
+    await cookieJar.saveFromResponse(realUri, cookies);
     if (isRedirectRequest && locations.isNotEmpty) {
       final originalUri = response.realUri;
       await Future.wait(

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -123,7 +123,9 @@ class CookieManager extends Interceptor {
     // users will be available to handle cookies themselves.
     final isRedirectRequest = statusCode >= 300 && statusCode < 400;
     // Saving cookies for the original site.
-    await cookieJar.saveFromResponse(response.realUri, cookies);
+    if (response.realUri.isNotEmpty) {
+      await cookieJar.saveFromResponse(response.realUri, cookies);
+    }
     if (isRedirectRequest && locations.isNotEmpty) {
       final originalUri = response.realUri;
       await Future.wait(

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -123,7 +123,7 @@ class CookieManager extends Interceptor {
     // users will be available to handle cookies themselves.
     final isRedirectRequest = statusCode >= 300 && statusCode < 400;
     // Saving cookies for the original site.
-    if (response.realUri.isNotEmpty) {
+    if (response.realUri.toString().isNotEmpty) {
       await cookieJar.saveFromResponse(response.realUri, cookies);
     }
     if (isRedirectRequest && locations.isNotEmpty) {

--- a/plugins/cookie_manager/test/cookies_persistance_test.dart
+++ b/plugins/cookie_manager/test/cookies_persistance_test.dart
@@ -1,0 +1,115 @@
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+typedef _FetchCallback = Future<ResponseBody> Function(
+  RequestOptions options,
+  Stream<Uint8List>? requestStream,
+  Future<void>? cancelFuture,
+);
+
+class _TestAdapter implements HttpClientAdapter {
+  _TestAdapter({required _FetchCallback fetch}) : _fetch = fetch;
+
+  final _FetchCallback _fetch;
+  final HttpClientAdapter _adapter = IOHttpClientAdapter();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) =>
+      _fetch(options, requestStream, cancelFuture);
+
+  @override
+  void close({bool force = false}) {
+    _adapter.close(force: force);
+  }
+}
+
+class _SaveCall {
+  _SaveCall(this.uri, this.cookies);
+
+  final String uri;
+  final String cookies;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _SaveCall &&
+          runtimeType == other.runtimeType &&
+          uri == other.uri &&
+          cookies == other.cookies;
+
+  @override
+  int get hashCode => uri.hashCode ^ cookies.hashCode;
+
+  @override
+  String toString() {
+    return '_SaveCall{uri: $uri, cookies: $cookies}';
+  }
+}
+
+class _FakeCookieJar extends Fake implements CookieJar {
+  final _saveCalls = <_SaveCall>[];
+  List<_SaveCall> get saveCalls => UnmodifiableListView(_saveCalls);
+
+  @override
+  Future<List<Cookie>> loadForRequest(Uri uri) async {
+    return const [];
+  }
+
+  @override
+  Future<void> saveFromResponse(Uri uri, List<Cookie> cookies) async {
+    _saveCalls.add(_SaveCall(
+      uri.toString(),
+      cookies.join('; '),
+    ));
+  }
+}
+
+void main() {
+  test(
+      'CookieJar.saveFromResponse() is called with a full Uri for requests that had relative redirects',
+      () async {
+    final cookieJar = _FakeCookieJar();
+    final dio = Dio()
+      ..httpClientAdapter = _TestAdapter(
+        fetch: (options, requestStream, cancelFuture) async => ResponseBody(
+          Stream.value(Uint8List.fromList(utf8.encode(''))),
+          HttpStatus.ok,
+          redirects: [
+            RedirectRecord(
+              HttpStatus.found,
+              'GET',
+              Uri(path: 'redirect'),
+            ),
+          ],
+          headers: {
+            HttpHeaders.setCookieHeader: ['Cookie1=value1; Path=/'],
+          },
+        ),
+      )
+      ..interceptors.add(CookieManager(cookieJar))
+      ..options.validateStatus =
+          (status) => status != null && status >= 200 && status < 400;
+
+    await dio.get('https://test.com');
+
+    expect(cookieJar.saveCalls, [
+      _SaveCall(
+        'https://test.com/redirect',
+        'Cookie1=value1; Path=/',
+      ),
+    ]);
+  });
+}


### PR DESCRIPTION
Upon relative redirect, cookies were not saved because the `host` was missing. `resolveUri` provides the proper host info for a redirect Uri in such cases and doesn't affect others.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
