### PR TITLE
💡 Improve `DioException.requestOptions` explanation when it's empty

### DIFF
--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -162,6 +162,9 @@ class DioException implements Exception {
       );
 
   /// The request info for the request that throws exception.
+  ///
+  /// The info can be empty (e.g. `uri` equals to "")
+  /// if the request was never submitted.
   final RequestOptions requestOptions;
 
   /// Response info, it may be `null` if the request can't reach to the


### PR DESCRIPTION
Address https://github.com/cfug/dio/issues/1943#issuecomment-1686275359.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

After some investigation, I think there are two other ways we can resolve this:
1. Apply the latest request options in each interceptor handler, because the options can be modified in any of them.
2. Treat the field as nullable, but this may be worse and I remember that we tried once without any good results.