### PR TITLE
Rework exceptions and stacktraces

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -110,7 +110,6 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
               requestOptions: options,
               timeout: connectionTimeout,
             ),
-            StackTrace.current,
           );
         },
       );
@@ -224,7 +223,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
           completer.completeError(
             DioException.requestCancelled(
               requestOptions: options,
-              reason: 'The XMLHttpRequest was aborted.',
+              cause: 'The XMLHttpRequest was aborted.',
             ),
           );
         }

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -107,13 +107,13 @@ class IOHttpClientAdapter implements HttpClientAdapter {
           timeout: options.connectTimeout ??
               httpClient.connectionTimeout ??
               Duration.zero,
-          error: e,
+          cause: e,
         );
       }
       throw DioException.connectionError(
         requestOptions: options,
         reason: e.message,
-        error: e,
+        cause: e,
       );
     }
 
@@ -169,7 +169,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
         throw DioException(
           requestOptions: options,
           type: DioExceptionType.badCertificate,
-          error: responseStream.certificate,
+          cause: responseStream.certificate,
           message: 'The certificate of the response is not approved.',
         );
       }

--- a/dio/lib/src/cancel_token.dart
+++ b/dio/lib/src/cancel_token.dart
@@ -37,8 +37,8 @@ class CancelToken {
   void cancel([Object? reason]) {
     _cancelError = DioException.requestCancelled(
       requestOptions: requestOptions ?? RequestOptions(),
-      reason: reason,
-      stackTrace: StackTrace.current,
+      cause: reason,
+      causeStackTrace: StackTrace.current,
     );
     if (!_completer.isCompleted) {
       _completer.complete(_cancelError);

--- a/dio/lib/src/dio/dio_for_native.dart
+++ b/dio/lib/src/dio/dio_for_native.dart
@@ -147,7 +147,7 @@ class DioForNative with DioMixin implements Dio {
             }
           } finally {
             completer.completeError(
-              DioMixin.assureDioException(e, response.requestOptions),
+              assureDioException(e, response.requestOptions),
             );
           }
         });
@@ -160,7 +160,7 @@ class DioForNative with DioMixin implements Dio {
           completer.complete(response);
         } catch (e) {
           completer.completeError(
-            DioMixin.assureDioException(e, response.requestOptions),
+            assureDioException(e, response.requestOptions),
           );
         }
       },
@@ -169,7 +169,7 @@ class DioForNative with DioMixin implements Dio {
           await closeAndDelete();
         } finally {
           completer.completeError(
-            DioMixin.assureDioException(e, response.requestOptions),
+            assureDioException(e, response.requestOptions),
           );
         }
       },
@@ -190,10 +190,10 @@ class DioForNative with DioMixin implements Dio {
             throw DioException.receiveTimeout(
               timeout: timeout,
               requestOptions: response.requestOptions,
-              error: e,
+              cause: e,
             );
           } else {
-            throw e;
+            throw assureDioException(e, response.requestOptions);
           }
         },
       );

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -77,7 +77,6 @@ class RequestInterceptorHandler extends _BaseHandler {
             ? InterceptorResultType.rejectCallFollowing
             : InterceptorResultType.reject,
       ),
-      error.stackTrace,
     );
     _processNextInQueue?.call();
   }
@@ -123,7 +122,6 @@ class ResponseInterceptorHandler extends _BaseHandler {
             ? InterceptorResultType.rejectCallFollowing
             : InterceptorResultType.reject,
       ),
-      error.stackTrace,
     );
     _processNextInQueue?.call();
   }
@@ -138,7 +136,6 @@ class ErrorInterceptorHandler extends _BaseHandler {
   void next(DioException error) {
     _completer.completeError(
       InterceptorState<DioException>(error),
-      error.stackTrace,
     );
     _processNextInQueue?.call();
   }
@@ -158,7 +155,6 @@ class ErrorInterceptorHandler extends _BaseHandler {
   void reject(DioException error) {
     _completer.completeError(
       InterceptorState<DioException>(error, InterceptorResultType.reject),
-      error.stackTrace,
     );
     _processNextInQueue?.call();
   }
@@ -200,6 +196,8 @@ class Interceptor {
   /// Called when an exception was occurred during the request.
   void onError(
     DioException err,
+
+    /// TODO should the correct StackTrace be handed to the interceptor here?
     ErrorInterceptorHandler handler,
   ) {
     handler.next(err);

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 import 'adapter.dart';
 import 'cancel_token.dart';
 import 'headers.dart';
@@ -296,7 +294,6 @@ class Options {
     CancelToken? cancelToken,
     ProgressCallback? onSendProgress,
     ProgressCallback? onReceiveProgress,
-    StackTrace? sourceStackTrace,
   }) {
     final query = <String, dynamic>{};
     query.addAll(baseOpt.queryParameters);
@@ -322,7 +319,6 @@ class Options {
       baseUrl: baseOpt.baseUrl,
       path: path,
       data: data,
-      sourceStackTrace: sourceStackTrace ?? StackTrace.current,
       connectTimeout: baseOpt.connectTimeout,
       sendTimeout: sendTimeout ?? baseOpt.sendTimeout,
       receiveTimeout: receiveTimeout ?? baseOpt.receiveTimeout,
@@ -483,7 +479,6 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
     bool? setRequestContentTypeWhenNoPayload,
-    StackTrace? sourceStackTrace,
   })  : assert(connectTimeout == null || !connectTimeout.isNegative),
         super(
           method: method,
@@ -502,7 +497,6 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
           responseDecoder: responseDecoder,
           listFormat: listFormat,
         ) {
-    this.sourceStackTrace = sourceStackTrace ?? StackTrace.current;
     this.queryParameters = queryParameters ?? {};
     this.baseUrl = baseUrl ?? '';
     this.connectTimeout = connectTimeout;
@@ -569,7 +563,6 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
       requestEncoder: requestEncoder ?? this.requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
       listFormat: listFormat ?? this.listFormat,
-      sourceStackTrace: sourceStackTrace,
     );
 
     if (contentType != null) {
@@ -581,13 +574,6 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
 
     return ro;
   }
-
-  /// The source [StackTrace] which should always point to the invocation of
-  /// [DioMixin.request] or if not provided, to the construction of the
-  /// [RequestOptions] instance. In both instances the source context should
-  /// still be available before it is lost due to asynchronous operations.
-  @internal
-  StackTrace? sourceStackTrace;
 
   /// Generate the requesting [Uri] from the options.
   Uri get uri {

--- a/dio/test/basic_test.dart
+++ b/dio/test/basic_test.dart
@@ -45,7 +45,7 @@ void main() {
         allOf([
           isA<DioException>(),
           (DioException e) => e.type == (DioExceptionType.connectionError),
-          if (!isWeb) (DioException e) => e.error is SocketException,
+          if (!isWeb) (DioException e) => e.cause is SocketException,
         ]),
       ),
     );

--- a/dio/test/cancel_token_test.dart
+++ b/dio/test/cancel_token_test.dart
@@ -17,7 +17,7 @@ void main() {
           (error) {
             return error is DioException &&
                 error.type == DioExceptionType.cancel &&
-                error.error == reason;
+                error.cause == reason;
           },
         ),
       );
@@ -63,7 +63,7 @@ void main() {
           throwsA((error) =>
               error is DioException &&
               error.type == DioExceptionType.cancel &&
-              error.error == reason),
+              error.cause == reason),
         );
       }
 

--- a/dio/test/download_test.dart
+++ b/dio/test/download_test.dart
@@ -99,7 +99,7 @@ void main() {
             deleteOnError: true,
             onReceiveProgress: (count, total) => throw AssertionError(),
           )
-          .catchError((e) => throw (e as DioException).error!),
+          .catchError((e) => throw (e as DioException).cause!),
       throwsA(isA<AssertionError>()),
     );
     expect(f.existsSync(), isFalse);

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -43,10 +43,10 @@ void main() {
       error = e;
     }
     expect(error, isNotNull);
-    expect(error.error, isA<HandshakeException>());
-    expect((error.error as HandshakeException).osError, isNotNull);
+    expect(error.cause, isA<HandshakeException>());
+    expect((error.cause as HandshakeException).osError, isNotNull);
     expect(
-      ((error.error as HandshakeException).osError as OSError).message,
+      ((error.cause as HandshakeException).osError as OSError).message,
       contains('Hostname mismatch'),
     );
   });

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -56,23 +56,23 @@ void main() {
                   break;
                 case '/reject':
                   handler
-                      .reject(DioException(requestOptions: reqOpt, error: 3));
+                      .reject(DioException(requestOptions: reqOpt, cause: 3));
                   break;
                 case '/reject-next':
                   handler.reject(
-                    DioException(requestOptions: reqOpt, error: 4),
+                    DioException(requestOptions: reqOpt, cause: 4),
                     true,
                   );
                   break;
                 case '/reject-next/reject':
                   handler.reject(
-                    DioException(requestOptions: reqOpt, error: 5),
+                    DioException(requestOptions: reqOpt, cause: 5),
                     true,
                   );
                   break;
                 case '/reject-next-response':
                   handler.reject(
-                    DioException(requestOptions: reqOpt, error: 5),
+                    DioException(requestOptions: reqOpt, cause: 5),
                     true,
                   );
                   break;
@@ -97,13 +97,13 @@ void main() {
                   handler.reject(
                     DioException(
                       requestOptions: options,
-                      error: '/resolve-next/reject',
+                      cause: '/resolve-next/reject',
                     ),
                   );
                   break;
                 case '/resolve-next/reject-next':
                   handler.reject(
-                    DioException(requestOptions: options, error: ''),
+                    DioException(requestOptions: options, cause: ''),
                     true,
                   );
                   break;
@@ -121,14 +121,14 @@ void main() {
                 );
               } else if (err.requestOptions.path ==
                   '/resolve-next/reject-next') {
-                handler.next(err.copyWith(error: 1));
+                handler.next(err.copyWith(cause: 1));
               } else {
                 if (err.requestOptions.path == '/reject-next/reject') {
                   handler.reject(err);
                 } else {
-                  int count = err.error as int;
+                  int count = err.cause as int;
                   count++;
-                  handler.next(err.copyWith(error: count));
+                  handler.next(err.copyWith(cause: count));
                 }
               }
             },
@@ -150,13 +150,13 @@ void main() {
             },
             onError: (err, handler) {
               if (err.requestOptions.path == '/resolve-next/reject-next') {
-                int count = err.error as int;
+                int count = err.cause as int;
                 count++;
-                handler.next(err.copyWith(error: count));
+                handler.next(err.copyWith(cause: count));
               } else {
-                int count = err.error as int;
+                int count = err.cause as int;
                 count++;
-                handler.next(err.copyWith(error: count));
+                handler.next(err.copyWith(cause: count));
               }
             },
           ),
@@ -177,31 +177,31 @@ void main() {
       expect(response.data, 100);
 
       expect(
-        dio.get('/reject').catchError((e) => throw e.error as num),
+        dio.get('/reject').catchError((e) => throw e.cause as num),
         throwsA(3),
       );
 
       expect(
-        dio.get('/reject-next').catchError((e) => throw e.error as num),
+        dio.get('/reject-next').catchError((e) => throw e.cause as num),
         throwsA(6),
       );
 
       expect(
-        dio.get('/reject-next/reject').catchError((e) => throw e.error as num),
+        dio.get('/reject-next/reject').catchError((e) => throw e.cause as num),
         throwsA(5),
       );
 
       expect(
         dio
             .get('/resolve-next/reject')
-            .catchError((e) => throw e.error as Object),
+            .catchError((e) => throw e.cause as Object),
         throwsA('/resolve-next/reject'),
       );
 
       expect(
         dio
             .get('/resolve-next/reject-next')
-            .catchError((e) => throw e.error as num),
+            .catchError((e) => throw e.cause as num),
         throwsA(2),
       );
     });
@@ -219,13 +219,13 @@ void main() {
             handler.next(reqOpt.copyWith(path: '/xxx'));
           },
           onError: (err, handler) {
-            handler.next(err.copyWith(error: 'unexpected error'));
+            handler.next(err.copyWith(cause: 'unexpected error'));
           },
         ),
       );
 
       expect(
-        dio.get('/error').catchError((e) => throw e.error as String),
+        dio.get('/error').catchError((e) => throw e.cause as String),
         throwsA('unexpected error'),
       );
 
@@ -264,7 +264,7 @@ void main() {
                 handler.reject(
                   DioException(
                     requestOptions: options,
-                    error: 'test error',
+                    cause: 'test error',
                   ),
                 );
                 break;
@@ -272,7 +272,7 @@ void main() {
                 handler.reject(
                   DioException(
                     requestOptions: options,
-                    error: 'test error',
+                    cause: 'test error',
                   ),
                 );
                 break;
@@ -443,7 +443,7 @@ void main() {
                 case urlNotFound3:
                   return handler.next(
                     e.copyWith(
-                      error: 'custom error info [${e.response!.statusCode}]',
+                      cause: 'custom error info [${e.response!.statusCode}]',
                     ),
                   );
               }

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -414,7 +414,7 @@ void main() {
     // Throws a type error during cast.
     expectLater(
       dio.get<Map<String, dynamic>>('/test-plain-text-content-type'),
-      throwsA((e) => e is DioException && e.error is TypeError),
+      throwsA((e) => e is DioException && e.cause is TypeError),
     );
   });
 
@@ -438,7 +438,7 @@ void main() {
     void testInvalidArgumentException(String method) async {
       await expectLater(
         dio.fetch(RequestOptions(path: 'http://127.0.0.1', method: method)),
-        throwsA((e) => e is DioException && e.error is ArgumentError),
+        throwsA((e) => e is DioException && e.cause is ArgumentError),
       );
     }
 

--- a/dio/test/stacktrace_test.dart
+++ b/dio/test/stacktrace_test.dart
@@ -11,23 +11,21 @@ import 'mock/http_mock.dart';
 import 'mock/http_mock.mocks.dart';
 
 void main() async {
-  group('$DioException.stackTrace', () {
+  group('DioException is thrown with correct stackTrace', () {
     test(DioExceptionType.badResponse, () async {
       final dio = Dio()
         ..httpClientAdapter = MockAdapter()
         ..options.baseUrl = MockAdapter.mockBase;
 
-      await expectLater(
-        dio.get('/foo'),
-        throwsA(
-          allOf([
-            isA<DioException>(),
-            (e) => e.type == DioExceptionType.badResponse,
-            (e) =>
-                e.stackTrace.toString().contains('test/stacktrace_test.dart'),
-          ]),
-        ),
-      );
+      try {
+        await dio.get('/foo');
+        fail('should throw');
+      } on DioException catch (e, s) {
+        expect(e.type, DioExceptionType.badResponse);
+        expect(s.toString(), contains('test/stacktrace_test.dart'));
+      } catch (_) {
+        fail('should throw DioException');
+      }
     });
 
     test(DioExceptionType.cancel, () async {
@@ -41,17 +39,15 @@ void main() async {
         dio.httpClientAdapter.close(force: true);
       });
 
-      await expectLater(
-        dio.get('/test-timeout', cancelToken: token),
-        throwsA(
-          allOf([
-            isA<DioException>(),
-            (e) => e.type == DioExceptionType.cancel,
-            (e) =>
-                e.stackTrace.toString().contains('test/stacktrace_test.dart'),
-          ]),
-        ),
-      );
+      try {
+        await dio.get('/test-timeout', cancelToken: token);
+        fail('should throw');
+      } on DioException catch (e, s) {
+        expect(e.type, DioExceptionType.cancel);
+        expect(s.toString(), contains('test/stacktrace_test.dart'));
+      } catch (_) {
+        fail('should throw DioException');
+      }
     });
 
     test(
@@ -73,18 +69,15 @@ void main() async {
             },
           );
 
-          await expectLater(
-            dio.get('/test'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (e) => e.type == DioExceptionType.connectionTimeout,
-                (e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+          try {
+            await dio.get('/test');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.connectionTimeout);
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         }, MockHttpOverrides());
       },
       testOn: '!browser',
@@ -113,18 +106,15 @@ void main() async {
             },
           );
 
-          await expectLater(
-            dio.get('/test'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (DioException e) => e.type == DioExceptionType.receiveTimeout,
-                (DioException e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+          try {
+            await dio.get('/test');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.receiveTimeout);
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         }, MockHttpOverrides());
       },
       testOn: '!browser',
@@ -152,18 +142,15 @@ void main() async {
             },
           );
 
-          await expectLater(
-            dio.get('/test', data: 'some data'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (DioException e) => e.type == DioExceptionType.sendTimeout,
-                (DioException e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+          try {
+            await dio.get('/test', data: 'some data');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.sendTimeout);
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         }, MockHttpOverrides());
       },
       testOn: '!browser',
@@ -189,72 +176,67 @@ void main() async {
             },
           );
 
-          await expectLater(
-            dio.get('/test'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (DioException e) => e.type == DioExceptionType.badCertificate,
-                (DioException e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+          try {
+            await dio.get('/test');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.badCertificate);
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         }, MockHttpOverrides());
       },
       testOn: '!browser',
     );
-    group('DioExceptionType.connectionError', () {
+
+    group(DioExceptionType.connectionError, () {
       test(
         'SocketException on request',
         () async {
           final dio = Dio()
             ..options.baseUrl = 'https://does.not.exist'
             ..httpClientAdapter = IOHttpClientAdapter();
-          await expectLater(
-            dio.get('/test', data: 'test'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (e) => e.type == DioExceptionType.connectionError,
-                (e) => e.error is SocketException,
-                (e) => (e.error as SocketException)
-                    .message
-                    .contains("Failed host lookup: 'does.not.exist'"),
-                (e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+
+          try {
+            await dio.get('/test', data: 'test');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.connectionError);
+            expect(e.cause, isA<SocketException>());
+            expect(
+              (e.cause as SocketException).message,
+              contains("Failed host lookup: 'does.not.exist'"),
+            );
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         },
         testOn: 'vm',
       );
     });
-    group('DioExceptionType.unknown', () {
+
+    group(DioExceptionType.unknown, () {
       test(
         JsonUnsupportedObjectError,
         () async {
           final dio = Dio()..options.baseUrl = 'https://does.not.exist';
 
-          await expectLater(
-            dio.get(
+          try {
+            await dio.get(
               '/test',
               options: Options(contentType: Headers.jsonContentType),
               data: Object(),
-            ),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (DioException e) => e.type == DioExceptionType.unknown,
-                (DioException e) => e.error is JsonUnsupportedObjectError,
-                (DioException e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+            );
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.unknown);
+            expect(e.cause, isA<JsonUnsupportedObjectError>());
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         },
         testOn: '!browser',
       );
@@ -280,19 +262,16 @@ void main() async {
               },
             );
 
-          await expectLater(
-            dio.get('/test', data: 'test'),
-            throwsA(
-              allOf([
-                isA<DioException>(),
-                (e) => e.type == DioExceptionType.unknown,
-                (e) => e.error is SocketException,
-                (e) => e.stackTrace
-                    .toString()
-                    .contains('test/stacktrace_test.dart'),
-              ]),
-            ),
-          );
+          try {
+            await dio.get('/test', data: 'test');
+            fail('should throw');
+          } on DioException catch (e, s) {
+            expect(e.type, DioExceptionType.unknown);
+            expect(e.cause, isA<SocketException>());
+            expect(s.toString(), contains('test/stacktrace_test.dart'));
+          } catch (_) {
+            fail('should throw DioException');
+          }
         },
         testOn: 'vm',
       );
@@ -303,34 +282,33 @@ void main() async {
         ..options.baseUrl = EchoAdapter.mockBase
         ..httpClientAdapter = EchoAdapter();
 
-      StackTrace? caughtStackTrace;
+      // StackTrace? caughtStackTrace;
       dio.interceptors.addAll([
         InterceptorsWrapper(
           onError: (err, handler) {
-            caughtStackTrace = err.stackTrace;
+            // caughtStackTrace = err.bestStackTrace;
             handler.next(err);
           },
         ),
         InterceptorsWrapper(
           onRequest: (options, handler) {
-            final error = DioException(error: Error(), requestOptions: options);
+            final error = DioException(cause: Error(), requestOptions: options);
             handler.reject(error, true);
           },
         ),
       ]);
 
-      await expectLater(
-        dio.get('/error'),
-        throwsA(
-          allOf([
-            isA<DioException>(),
-            (e) => e.stackTrace == caughtStackTrace,
-            (e) =>
-                e.stackTrace.toString().contains('test/stacktrace_test.dart'),
-          ]),
-        ),
-        reason: 'Stacktrace should be available in onError',
-      );
+      try {
+        await dio.get('/error');
+        fail('should throw');
+      } on DioException catch (e, s) {
+        expect(e.type, DioExceptionType.unknown);
+        expect(e.cause, isA<Error>());
+        expect(s.toString(), contains('test/stacktrace_test.dart'));
+        // expect(s, caughtStackTrace);
+      } catch (_) {
+        fail('should throw DioException');
+      }
     });
 
     test('QueuedInterceptor gets stacktrace in onError', () async {
@@ -338,18 +316,19 @@ void main() async {
         ..options.baseUrl = EchoAdapter.mockBase
         ..httpClientAdapter = EchoAdapter();
 
-      StackTrace? caughtStackTrace;
+      // StackTrace? caughtStackTrace;
       dio.interceptors.addAll([
         QueuedInterceptorsWrapper(
           onError: (err, handler) {
-            caughtStackTrace = err.stackTrace;
+            // TODO should we get better access to the stacktrace here?
+            // caughtStackTrace = err.bestStackTrace;
             handler.next(err);
           },
         ),
         QueuedInterceptorsWrapper(
           onRequest: (options, handler) {
             final error = DioException(
-              error: Error(),
+              cause: Error(),
               requestOptions: options,
             );
             handler.reject(error, true);
@@ -357,18 +336,17 @@ void main() async {
         ),
       ]);
 
-      await expectLater(
-        dio.get('/error'),
-        throwsA(
-          allOf([
-            isA<DioException>(),
-            (e) => e.stackTrace == caughtStackTrace,
-            (e) =>
-                e.stackTrace.toString().contains('test/stacktrace_test.dart'),
-          ]),
-        ),
-        reason: 'Stacktrace should be available in onError',
-      );
+      try {
+        await dio.get('/error');
+        fail('should throw');
+      } on DioException catch (e, s) {
+        expect(e.type, DioExceptionType.unknown);
+        expect(e.cause, isA<Error>());
+        expect(s.toString(), contains('test/stacktrace_test.dart'));
+        // expect(s, caughtStackTrace);
+      } catch (_) {
+        fail('should throw DioException');
+      }
     });
   });
 }

--- a/example/lib/request_interceptors.dart
+++ b/example/lib/request_interceptors.dart
@@ -25,7 +25,7 @@ void main() async {
             return handler.reject(
               DioException(
                 requestOptions: options,
-                error: 'test error',
+                cause: 'test error',
               ),
             );
           default:

--- a/example/lib/response_interceptor.dart
+++ b/example/lib/response_interceptor.dart
@@ -39,7 +39,7 @@ void main() async {
             case urlNotFound3:
               handler.next(
                 e.copyWith(
-                  error: 'custom error info [${e.response!.statusCode}]',
+                  cause: 'custom error info [${e.response!.statusCode}]',
                 ),
               );
               break;

--- a/example/lib/transformer.dart
+++ b/example/lib/transformer.dart
@@ -12,7 +12,7 @@ class MyTransformer extends BackgroundTransformer {
   Future<String> transformRequest(RequestOptions options) async {
     if (options.data is List<String>) {
       throw DioException(
-        error: "Can't send List to sever directly",
+        cause: "Can't send List to sever directly",
         requestOptions: options,
       );
     } else {

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -63,7 +63,7 @@ class CookieManager extends Interceptor {
     }).catchError((dynamic e, StackTrace s) {
       final err = DioException(
         requestOptions: options,
-        error: e,
+        cause: e,
         stackTrace: s,
       );
       handler.reject(err, true);
@@ -76,7 +76,7 @@ class CookieManager extends Interceptor {
       (dynamic e, StackTrace s) {
         final err = DioException(
           requestOptions: response.requestOptions,
-          error: e,
+          cause: e,
           stackTrace: s,
         );
         handler.reject(err, true);
@@ -91,7 +91,7 @@ class CookieManager extends Interceptor {
         (dynamic e, StackTrace s) {
           final error = DioException(
             requestOptions: err.response!.requestOptions,
-            error: e,
+            cause: e,
             stackTrace: s,
           );
           handler.next(error);

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -103,7 +103,7 @@ class _ConnectionManager implements ConnectionManager {
         throw DioException(
           requestOptions: options,
           type: DioExceptionType.badCertificate,
-          error: socket.peerCertificate,
+          cause: socket.peerCertificate,
           message: 'The certificate of the response is not approved.',
         );
       }
@@ -177,7 +177,7 @@ class _ConnectionManager implements ConnectionManager {
     Never onProxyError(Object? error, StackTrace stackTrace) {
       throw DioException(
         requestOptions: options,
-        error: error,
+        cause: error,
         type: DioExceptionType.connectionError,
         stackTrace: stackTrace,
       );


### PR DESCRIPTION
An evaluation of how `DioException` can work with better stack traces that can be `catch`ed while still being aware of the cause and the stack trace of the cause.
Related to https://github.com/cfug/dio/discussions/1914

* rename `DioException.error` to `DioException.cause`
* add `DioException.causeStackTrace`
* get rid of `RequestOptions.sourceStackTrace` property
* use `Error.throwWithStackTrace` to throw all errors with the manually captured stack trace at a single point in `DioMixin`
* extract some inner functions inside `DioMixin.fetch` to prevent them capturing the state of `requestOptions` and `cancelToken` variables, instead pass them as arguments

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
