### PR TITLE
🐛 Avoid `Interceptors.clear` removes `ImplyContentTypeInterceptor`

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -12,6 +12,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Reduce cases in which browsers would trigger a CORS preflight request.
 - Add warnings in debug mode when using `sendTimeout` and `onSendProgress` with an empty request body.
 - Fix `receiveTimeout` not working correctly on web.
+- Fix `ImplyContentTypeInterceptor` can be removed by `Interceptors.clear()` by default.
 
 ## 5.3.2
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -320,13 +320,13 @@ class Interceptors extends ListMixin<Interceptor> {
   }
 
   /// The default [ImplyContentTypeInterceptor] will be removed only if
-  /// [withImplyContentTypeInterceptor] is true.
+  /// [keepImplyContentTypeInterceptor] is false.
   @override
-  void clear({bool withImplyContentTypeInterceptor = false}) {
-    if (withImplyContentTypeInterceptor) {
-      super.clear();
-    } else {
+  void clear({bool keepImplyContentTypeInterceptor = true}) {
+    if (keepImplyContentTypeInterceptor) {
       _list.removeWhere((e) => e is! ImplyContentTypeInterceptor);
+    } else {
+      super.clear();
     }
   }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -319,6 +319,15 @@ class Interceptors extends ListMixin<Interceptor> {
     }
   }
 
+  @override
+  void clear({bool withImplyContentTypeInterceptor = false}) {
+    if (withImplyContentTypeInterceptor) {
+      super.clear();
+    } else {
+      _list.removeWhere((e) => e is! ImplyContentTypeInterceptor);
+    }
+  }
+
   /// Remove the default imply content type interceptor.
   void removeImplyContentTypeInterceptor() {
     _list.removeWhere((e) => e is ImplyContentTypeInterceptor);

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -319,6 +319,8 @@ class Interceptors extends ListMixin<Interceptor> {
     }
   }
 
+  /// The default [ImplyContentTypeInterceptor] will be removed only if
+  /// [withImplyContentTypeInterceptor] is true.
   @override
   void clear({bool withImplyContentTypeInterceptor = false}) {
     if (withImplyContentTypeInterceptor) {

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -583,6 +583,7 @@ void main() {
       expect(tokenRequestCounts, 1);
       expect(result, 3);
       expect(myInter.requestCount, predicate((int e) => e > 0));
+      // The `ImplyContentTypeInterceptor` will be replaced.
       dio.interceptors[0] = myInter;
       dio.interceptors.clear();
       expect(dio.interceptors.isEmpty, true);
@@ -659,6 +660,9 @@ void main() {
     expect(interceptors.length, equals(2));
     expect(interceptors, isNotEmpty);
     interceptors.clear();
+    expect(interceptors.length, equals(1));
+    expect(interceptors.single, isA<ImplyContentTypeInterceptor>());
+    interceptors.clear(withImplyContentTypeInterceptor: true);
     expect(interceptors.length, equals(0));
     expect(interceptors, isEmpty);
   });

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -662,7 +662,7 @@ void main() {
     interceptors.clear();
     expect(interceptors.length, equals(1));
     expect(interceptors.single, isA<ImplyContentTypeInterceptor>());
-    interceptors.clear(withImplyContentTypeInterceptor: true);
+    interceptors.clear(keepImplyContentTypeInterceptor: false);
     expect(interceptors.length, equals(0));
     expect(interceptors, isEmpty);
   });


### PR DESCRIPTION
Resolves #1973

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

The PR only addresses `clear`. However, lists can be modified in various ways which might also remove/replace the interceptor. We might need to rethink an extra internal interceptors list.