### PR TITLE
feat(http2_adapter): gzip

### DIFF
--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -126,4 +126,16 @@ void main() {
     final res = await dio.get('absolute-redirect/2');
     expect(res.statusCode, 200);
   });
+
+  test('decodes gzip', () async {
+    final dio = Dio()
+      ..options.baseUrl = 'https://httpbin.org/'
+      ..options.responseType = ResponseType.json
+      ..options.headers['accept-encoding'] = 'gzip'
+      ..httpClientAdapter = Http2Adapter(ConnectionManager());
+
+    final res = await dio.get<Map<String, Object?>>('gzip');
+    expect(res.headers.value(Headers.contentEncodingHeader), 'gzip');
+    expect(res.data!['gzipped'] as bool, true);
+  });
 }


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

Adds gzip encoding/decoding to the http2 adapter because it doesn't seem like Dart will add gzip to it themselves. I welcome comment as I'm not sure this is the _best_ way to do this _and_ because I don't have a test for encoding gzip and I'd like some help making an adequate test. Do let me know if this is the direction you want to go in, that is, adding gzip to the adapter.
