### PR TITLE
💬 Remove dot from `DioException.connectionError(reason)`

### DIFF
--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -163,7 +163,7 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.connectionError,
-        message: 'The connection errored: $reason. '
+        message: 'The connection errored: $reason '
             'This indicates an error which most likely cannot be solved by the library.',
         requestOptions: requestOptions,
         response: null,


### PR DESCRIPTION
We mainly construct the exception with a complete sentence, which will produce a double `.` in the message.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

@ueman 
