### PR TITLE
⚡ Ignore zero duration timeout

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,8 +6,9 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Raise warning for `Map`s other than `Map<String, dynamic>` when encoding request data.
-- Improve exception messages
-- Allow `ResponseDecoder` and `RequestEncoder` to be async
+- Improve exception messages.
+- Allow `ResponseDecoder` and `RequestEncoder` to be async.
+- Ignores `Duration.zero` timeouts.
 
 ## 5.3.3
 

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -62,9 +62,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     final connectTimeout = options.connectTimeout ?? Duration.zero;
     final receiveTimeout = options.receiveTimeout ?? Duration.zero;
     final xhrTimeout = (connectTimeout + receiveTimeout).inMilliseconds;
-    if (xhrTimeout > 0) {
-      xhr.timeout = xhrTimeout;
-    }
+    xhr.timeout = xhrTimeout;
 
     final completer = Completer<ResponseBody>();
 

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -107,7 +107,7 @@ mixin OptionsMixin {
   /// [Dio] will throw the [DioException] with
   /// [DioExceptionType.connectionTimeout] type when time out.
   ///
-  /// `null` meanings no timeout limit.
+  /// `null` or `Duration.zero` meanings no timeout limit.
   Duration? get connectTimeout => _connectTimeout;
   Duration? _connectTimeout;
 
@@ -363,7 +363,7 @@ class Options {
   /// [Dio] will throw the [DioException] with
   /// [DioExceptionType.sendTimeout] type when timed out.
   ///
-  /// `null` meanings no timeout limit.
+  /// `null` or `Duration.zero` meanings no timeout limit.
   Duration? get sendTimeout => _sendTimeout;
   Duration? _sendTimeout;
 
@@ -382,7 +382,7 @@ class Options {
   /// [Dio] will throw the [DioException] with
   /// [DioExceptionType.receiveTimeout] type when time out.
   ///
-  /// `null` meanings no timeout limit.
+  /// `null` or `Duration.zero` meanings no timeout limit.
   Duration? get receiveTimeout => _receiveTimeout;
   Duration? _receiveTimeout;
 

--- a/dio/test/timeout_test.dart
+++ b/dio/test/timeout_test.dart
@@ -70,4 +70,31 @@ void main() {
     } on DioException catch (_) {}
     expect(http.connectionTimeout?.inSeconds == 1, isTrue);
   }, testOn: 'vm');
+
+  test('ignores zero duration timeouts', () async {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://httpbun.com/',
+        connectTimeout: Duration.zero,
+        sendTimeout: Duration.zero,
+        receiveTimeout: Duration.zero,
+      ),
+    );
+    // Ignores zero duration timeouts from the base options.
+    await dio.get('/drip-lines?delay=1');
+    // Reset the base options.
+    dio.options
+      ..connectTimeout = Duration(seconds: 10)
+      ..sendTimeout = Duration(seconds: 10)
+      ..receiveTimeout = Duration(seconds: 10);
+    // Override with request options.
+    await dio.get(
+      '/drip-lines?delay=1',
+      options: Options(
+        sendTimeout: Duration.zero,
+        receiveTimeout: Duration.zero,
+      ),
+    );
+    await dio.get('/drip-lines?delay=1');
+  });
 }

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Implement `sendTimeout` and `receiveTimeout` for the adapter.
 - Fix redirect not working when requestStream is null.
+- Ignores `Duration.zero` timeouts.
 
 ## 2.3.1+1
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -92,8 +92,8 @@ class Http2Adapter implements HttpClientAdapter {
       final requestStreamFuture = requestStream!.listen((data) {
         stream.outgoingMessages.add(DataStreamMessage(data));
       }).asFuture();
-      final sendTimeout = options.sendTimeout;
-      if (sendTimeout != null) {
+      final sendTimeout = options.sendTimeout ?? Duration.zero;
+      if (sendTimeout > Duration.zero) {
         await requestStreamFuture.timeout(
           sendTimeout,
           onTimeout: () {
@@ -158,8 +158,8 @@ class Http2Adapter implements HttpClientAdapter {
       cancelOnError: true,
     );
 
-    final receiveTimeout = options.receiveTimeout;
-    if (receiveTimeout != null) {
+    final receiveTimeout = options.receiveTimeout ?? Duration.zero;
+    if (receiveTimeout > Duration.zero) {
       await completer.future.timeout(
         receiveTimeout,
         onTimeout: () {


### PR DESCRIPTION
Resolves #2022.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

I've found that the `IOHttpClientAdapter` uses `Stopwatch` to integrate with `receiveTimeout`, which might cause infinity awaits if the stream has no response forever. This might be the root cause of #1739.
https://github.com/cfug/dio/blob/78f3813a8d8948887198ef628e5a2e2039489b03/dio/lib/src/adapters/io_adapter.dart#L194-L200