### PR TITLE
💚 Run `update` before `install` for `apt-get`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           chmod +x ./scripts/prepare_pinning_certs.sh
           ./scripts/prepare_pinning_certs.sh
       - name: Install proxy for tests
-        run: sudo apt-get install -y squid
+        run: sudo apt-get update && sudo apt-get install -y squid
       - run: dart pub get
       - uses: bluefireteam/melos-action@v2
         with:


### PR DESCRIPTION
Fix random failures during tests. Suggested by https://github.com/actions/runner-images/issues/6039#issuecomment-1209531257.