### PR TITLE
[native_dio_adapter] ✨ Adds `createCronetEngine` and `createCupertinoConfiguration`

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-*None.*
+- Adds `createCronetEngine` and `createCupertinoConfiguration`
+  to deprecate `cronetEngine` and `cupertinoConfiguration`
+  for the `NativeAdapter`, to avoid platform exceptions.
 
 ## 1.1.1
 

--- a/plugins/native_dio_adapter/README.md
+++ b/plugins/native_dio_adapter/README.md
@@ -39,9 +39,7 @@ Add the `native_dio_adapter` package to your
 
 ```dart
 final dioClient = Dio();
-if (Platform.isIOS || Platform.isMacOS || Platform.isAndroid) {
-  dioClient.httpClientAdapter = NativeAdapter();
-}
+dioClient.httpClientAdapter = NativeAdapter();
 ```
 
 ## 📣 About the author

--- a/plugins/native_dio_adapter/example/lib/main.dart
+++ b/plugins/native_dio_adapter/example/lib/main.dart
@@ -70,7 +70,7 @@ class _MyHomePageState extends State<MyHomePage> {
     final dio = Dio();
 
     dio.httpClientAdapter = NativeAdapter(
-      cupertinoConfiguration:
+      createCupertinoConfiguration: () =>
           URLSessionConfiguration.ephemeralSessionConfiguration()
             ..allowsCellularAccess = false
             ..allowsConstrainedNetworkAccess = false
@@ -101,7 +101,7 @@ class _MyHomePageState extends State<MyHomePage> {
     final dio = Dio();
 
     dio.httpClientAdapter = NativeAdapter(
-      cupertinoConfiguration:
+      createCupertinoConfiguration: () =>
           URLSessionConfiguration.ephemeralSessionConfiguration()
             ..allowsCellularAccess = false
             ..allowsConstrainedNetworkAccess = false

--- a/plugins/native_dio_adapter/lib/src/native_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/native_adapter.dart
@@ -17,14 +17,27 @@ import 'cupertino_adapter.dart';
 /// make HTTP requests.
 class NativeAdapter implements HttpClientAdapter {
   NativeAdapter({
+    CronetEngine Function()? createCronetEngine,
+    URLSessionConfiguration Function()? createCupertinoConfiguration,
+    @Deprecated(
+      'Use createCronetEngine instead. '
+      'This will cause platform exception on iOS/macOS platforms',
+    )
     CronetEngine? androidCronetEngine,
+    @Deprecated(
+      'Use createCupertinoConfiguration instead. '
+      'This will cause platform exception on the Android platform',
+    )
     URLSessionConfiguration? cupertinoConfiguration,
   }) {
     if (Platform.isAndroid) {
-      _adapter = CronetAdapter(androidCronetEngine);
+      _adapter = CronetAdapter(
+        createCronetEngine?.call() ?? androidCronetEngine,
+      );
     } else if (Platform.isIOS || Platform.isMacOS) {
       _adapter = CupertinoAdapter(
-        cupertinoConfiguration ??
+        createCupertinoConfiguration?.call() ??
+            cupertinoConfiguration ??
             URLSessionConfiguration.defaultSessionConfiguration(),
       );
     } else {

--- a/plugins/native_dio_adapter/lib/src/native_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/native_adapter.dart
@@ -21,12 +21,14 @@ class NativeAdapter implements HttpClientAdapter {
     URLSessionConfiguration Function()? createCupertinoConfiguration,
     @Deprecated(
       'Use createCronetEngine instead. '
-      'This will cause platform exception on iOS/macOS platforms',
+      'This will cause platform exception on iOS/macOS platforms. '
+      'This will be removed in v2.0.0',
     )
     CronetEngine? androidCronetEngine,
     @Deprecated(
       'Use createCupertinoConfiguration instead. '
-      'This will cause platform exception on the Android platform',
+      'This will cause platform exception on the Android platform. '
+      'This will be removed in v2.0.0',
     )
     URLSessionConfiguration? cupertinoConfiguration,
   }) {


### PR DESCRIPTION
...to deprecate `cronetEngine` and `cupertinoConfiguration` for the `NativeAdapter`, to avoid platform exceptions.

Fixes #2039.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
