### PR TITLE
⚡️ Check `Uint8List` before doing byte conversions

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,7 +9,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Allow case-sensitive header keys with the `preserveHeaderCase` flag through options.
 - Fix `receiveTimeout` for the `IOHttpClientAdapter`.
 - Fix `receiveTimeout` for the `download` method of `DioForNative`.
-- Improve the request stream byte conversion on Web.
+- Improve the stream byte conversion.
 
 ## 5.3.4
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,6 +9,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Allow case-sensitive header keys with the `preserveHeaderCase` flag through options.
 - Fix `receiveTimeout` for the `IOHttpClientAdapter`.
 - Fix `receiveTimeout` for the `download` method of `DioForNative`.
+- Improve the request stream byte conversion on Web.
 
 ## 5.3.4
 

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -75,7 +75,9 @@ class ResponseBody {
     this.statusMessage,
     this.isRedirect = false,
     Map<String, List<String>>? headers,
-  })  : stream = Stream.value(Uint8List.fromList(bytes)),
+  })  : stream = Stream.value(
+          bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
+        ),
         headers = headers ?? {};
 
   /// Whether this response is a redirect.

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -278,7 +278,9 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       }
       final completer = Completer<Uint8List>();
       final sink = ByteConversionSink.withCallback(
-        (bytes) => completer.complete(Uint8List.fromList(bytes)),
+        (bytes) => completer.complete(
+          bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
+        ),
       );
       requestStream.listen(
         sink.add,

--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Adds `createCronetEngine` and `createCupertinoConfiguration`
   to deprecate `cronetEngine` and `cupertinoConfiguration`
   for the `NativeAdapter`, to avoid platform exceptions.
+- Improve the request stream byte conversion.
 
 ## 1.1.1
 

--- a/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
@@ -56,7 +56,9 @@ class ConversionLayerAdapter implements HttpClientAdapter {
     if (requestStream != null) {
       final completer = Completer<Uint8List>();
       final sink = ByteConversionSink.withCallback(
-        (bytes) => completer.complete(Uint8List.fromList(bytes)),
+        (bytes) => completer.complete(
+          bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
+        ),
       );
       requestStream.listen(
         sink.add,


### PR DESCRIPTION
Prevent `Uint8List.fromList` if it already is `Uint8List`.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package