### PR TITLE
🐛 Fix `receiveTimeout` for streamed responses

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Fix `receiveTimeout` for streamed responses.
 
 ## 5.4.0
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -238,12 +238,12 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       });
     }
 
-    responseSubscription = responseStream.listen(
+    responseSubscription = responseStream.cast<Uint8List>().listen(
       (data) {
         watchReceiveTimeout();
         // Always true if the receive timeout was not set.
         if (receiveStopwatch.elapsed <= receiveTimeout) {
-          responseSink.add(data is Uint8List ? data : Uint8List.fromList(data));
+          responseSink.add(data);
         }
       },
       onError: (error, stackTrace) {

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -203,7 +203,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
     }
 
     // Use a StreamController to explicitly handle receive timeouts.
-    final responseSink = StreamController<Uint8List>.broadcast();
+    final responseSink = StreamController<Uint8List>();
     late StreamSubscription<List<int>> responseSubscription;
 
     final receiveStopwatch = Stopwatch();

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -247,6 +247,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
         }
       },
       onError: (error, stackTrace) {
+        stopWatchReceiveTimeout();
         responseSink.addError(error, stackTrace);
         responseSink.close();
       },

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -202,6 +202,10 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       }
     }
 
+    // Use a StreamController to explicitly handle receive timeouts.
+    final responseSink = StreamController<Uint8List>.broadcast();
+    late StreamSubscription<List<int>> responseSubscription;
+
     final receiveStopwatch = Stopwatch();
     Timer? receiveTimer;
 
@@ -211,7 +215,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       receiveStopwatch.stop();
     }
 
-    void watchReceiveTimeout(EventSink<Uint8List> sink) {
+    void watchReceiveTimeout() {
       if (receiveTimeout <= Duration.zero) {
         return;
       }
@@ -221,32 +225,37 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       }
       receiveTimer?.cancel();
       receiveTimer = Timer(receiveTimeout, () {
-        sink.addError(
+        responseSink.addError(
           DioException.receiveTimeout(
             timeout: receiveTimeout,
             requestOptions: options,
           ),
         );
-        sink.close();
+        responseSink.close();
+        responseSubscription.cancel();
         responseStream.detachSocket().then((socket) => socket.destroy());
         stopWatchReceiveTimeout();
       });
     }
 
-    final stream = responseStream.transform<Uint8List>(
-      StreamTransformer.fromHandlers(
-        handleData: (data, sink) {
-          watchReceiveTimeout(sink);
-          // Always true if the receive timeout was not set.
-          if (receiveStopwatch.elapsed <= receiveTimeout) {
-            sink.add(data is Uint8List ? data : Uint8List.fromList(data));
-          }
-        },
-        handleDone: (sink) {
-          stopWatchReceiveTimeout();
-          sink.close();
-        },
-      ),
+    responseSubscription = responseStream.listen(
+      (data) {
+        watchReceiveTimeout();
+        // Always true if the receive timeout was not set.
+        if (receiveStopwatch.elapsed <= receiveTimeout) {
+          responseSink.add(data is Uint8List ? data : Uint8List.fromList(data));
+        }
+      },
+      onError: (error, stackTrace) {
+        responseSink.addError(error, stackTrace);
+        responseSink.close();
+      },
+      onDone: () {
+        stopWatchReceiveTimeout();
+        responseSubscription.cancel();
+        responseSink.close();
+      },
+      cancelOnError: true,
     );
 
     final headers = <String, List<String>>{};
@@ -254,7 +263,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       headers[key] = values;
     });
     return ResponseBody(
-      stream,
+      responseSink.stream,
       responseStream.statusCode,
       headers: headers,
       isRedirect:

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -561,8 +561,7 @@ void main() {
       when(response.reasonPhrase).thenReturn('OK');
       when(response.isRedirect).thenReturn(false);
       when(response.redirects).thenReturn([]);
-      when(response.transform(any))
-          .thenAnswer((_) => Stream<Uint8List>.empty());
+      when(response.cast()).thenAnswer((_) => Stream<Uint8List>.empty());
       return Future.value(request);
     });
 

--- a/dio/test/timeout_test.dart
+++ b/dio/test/timeout_test.dart
@@ -13,8 +13,6 @@ void main() {
 
   group('Timeout exception of', () {
     group('connectTimeout', () {
-      final dio = Dio()..options.baseUrl = 'http://127.1.2.3:1234';
-
       test('with response', () async {
         dio.options.connectTimeout = Duration(milliseconds: 3);
         await expectLater(

--- a/dio/test/timeout_test.dart
+++ b/dio/test/timeout_test.dart
@@ -38,7 +38,9 @@ void main() {
         ),
       ),
       throwsA(
-        predicate<DioException>((e) => e.message!.contains('0:00:01.000000')),
+        predicate<DioException>(
+          (e) => e.message!.contains(dio.options.receiveTimeout.toString()),
+        ),
       ),
     ]);
     await expectLater(

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -116,6 +116,7 @@ class Http2Adapter implements HttpClientAdapter {
     final sc = StreamController<Uint8List>();
     final responseHeaders = Headers();
     final responseCompleter = Completer<void>();
+    late StreamSubscription subscription;
     bool needRedirect = false;
     bool needResponse = false;
 
@@ -152,7 +153,6 @@ class Http2Adapter implements HttpClientAdapter {
     }
 
     late int statusCode;
-    late StreamSubscription subscription;
     subscription = stream.incomingMessages.listen(
       (StreamMessage message) async {
         if (message is HeadersStreamMessage) {
@@ -191,6 +191,7 @@ class Http2Adapter implements HttpClientAdapter {
       },
       onDone: () {
         stopWatchReceiveTimeout();
+        subscription.cancel();
         sc.close();
       },
       onError: (Object error, StackTrace stackTrace) {
@@ -204,6 +205,8 @@ class Http2Adapter implements HttpClientAdapter {
           sc.addError(error, stackTrace);
         }
         stopWatchReceiveTimeout();
+        subscription.cancel();
+        sc.close();
       },
       cancelOnError: true,
     );

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -59,7 +59,7 @@ void main() {
       options: Options(responseType: ResponseType.stream),
     );
     (streamedResponse.data as ResponseBody).stream.listen(
-          (event) {},
+      (event) {},
       onError: (error) {
         if (!completer.isCompleted) {
           completer.completeError(error);

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -41,7 +41,9 @@ void main() {
         ),
       ),
       throwsA(
-        predicate<DioException>((e) => e.message!.contains('0:00:01.000000')),
+        predicate<DioException>(
+          (e) => e.message!.contains(dio.options.receiveTimeout.toString()),
+        ),
       ),
     ]);
     await expectLater(

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -18,33 +18,8 @@ void main() {
 
   group('Timeout exception of', () {
     group('connectTimeout', () {
-      final dio = Dio()..options.baseUrl = 'http://127.1.2.3:1234';
-
       test('with response', () async {
         dio.options.connectTimeout = Duration(milliseconds: 3);
-        await expectLater(
-          dio.get('/'),
-          allOf(
-            throwsA(isA<DioException>()),
-            throwsA(predicate((DioException e) =>
-                e.type == DioExceptionType.connectionTimeout &&
-                e.message!.contains('${dio.options.connectTimeout}'))),
-          ),
-        );
-      });
-
-      test('update between calls', () async {
-        dio.options.connectTimeout = Duration(milliseconds: 5);
-        await expectLater(
-          dio.get('/'),
-          allOf(
-            throwsA(isA<DioException>()),
-            throwsA(predicate((DioException e) =>
-                e.type == DioExceptionType.connectionTimeout &&
-                e.message!.contains('${dio.options.connectTimeout}'))),
-          ),
-        );
-        dio.options.connectTimeout = Duration(milliseconds: 10);
         await expectLater(
           dio.get('/'),
           allOf(

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -1,4 +1,6 @@
 @TestOn('vm')
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:test/test.dart';
@@ -49,10 +51,31 @@ void main() {
       ),
       matcher,
     );
+
+    final completer = Completer<void>();
+    final streamedResponse = await dio.get(
+      '/drip',
+      queryParameters: {'delay': 0, 'duration': 20},
+      options: Options(responseType: ResponseType.stream),
+    );
+    (streamedResponse.data as ResponseBody).stream.listen(
+          (event) {},
+      onError: (error) {
+        if (!completer.isCompleted) {
+          completer.completeError(error);
+        }
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      },
+    );
+    await expectLater(completer.future, matcher);
     await expectLater(
       dio.get(
         '/drip',
-        queryParameters: {'delay': 0, 'duration:': 1},
+        queryParameters: {'delay': 0, 'duration': 2},
         options: Options(responseType: ResponseType.stream),
       ),
       matcher,

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -72,13 +72,5 @@ void main() {
       },
     );
     await expectLater(completer.future, matcher);
-    await expectLater(
-      dio.get(
-        '/drip',
-        queryParameters: {'delay': 0, 'duration': 2},
-        options: Options(responseType: ResponseType.stream),
-      ),
-      matcher,
-    );
   });
 }


### PR DESCRIPTION
Due to httpbun issues, I found a fake test with timeouts which tested with inappropriate queries (wrote `duration:` instead of `duration`), and also found an incorrect implementation of the response stream.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

- Once `EventSink` is called with `add` or `addError`, it cannot be used again to make these calls, but it won't throw exceptions.
- `HttpClient` seems reused even if you created a new one.