### PR TITLE
⚡️ Mark `DioMixin`'s todo and add tests

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -23,7 +23,8 @@ import 'progress_stream/io_progress_stream.dart'
 
 part 'interceptor.dart';
 
-mixin DioMixin implements Dio {
+// TODO(EVERYONE): Use `mixin class` when the lower bound of SDK is raised to 3.0.0.
+abstract class DioMixin implements Dio {
   /// The base request config for the instance.
   @override
   late BaseOptions options;

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -23,7 +23,7 @@ import 'progress_stream/io_progress_stream.dart'
 
 part 'interceptor.dart';
 
-abstract class DioMixin implements Dio {
+mixin DioMixin implements Dio {
   /// The base request config for the instance.
   @override
   late BaseOptions options;

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -2,6 +2,11 @@ import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('not thrown for implements', () {
+    expect(_TestDioMixin().interceptors, isA<Interceptors>());
+    expect(_TestDioMixinExtends().interceptors, isA<Interceptors>());
+  });
+
   test('assureResponse', () {
     final requestOptions = RequestOptions(path: '');
     final untypedResponse = Response<dynamic>(
@@ -26,3 +31,5 @@ void main() {
 }
 
 class _TestDioMixin with DioMixin implements Dio {}
+
+class _TestDioMixinExtends extends DioMixin implements Dio {}


### PR DESCRIPTION
`DioMixin` was never a real mixin before. Marking it to use `mixin class` once we use `>=3.0.0` as the SDK constraint.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

The following exception will be raised if we roll the lower bound of the package to ^3.0.0:
`The class 'DioMixin' can't be used as a mixin because it's neither a mixin class nor a mixin.`