### PR TITLE
Fix streamed response cancellation and progress

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,7 +7,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 - Provide fix suggestions for `dart fix`.
 - Fix `receiveTimeout` for streamed responses.
-- Fix cancellation and missing progress handling for streamed responses when using `IOHttpClientAdapter`.
+- Fix cancellation for streamed responses and downloads when using `IOHttpClientAdapter`.
+- Fix receive progress for streamed responses and downloads when using `IOHttpClientAdapter`.
 
 ## 5.4.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,6 +7,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 - Provide fix suggestions for `dart fix`.
 - Fix `receiveTimeout` for streamed responses.
+- Fix cancellation and missing progress handling for streamed responses and downloads when using `IOHttpClientAdapter`.
 
 ## 5.4.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 - Provide fix suggestions for `dart fix`.
 - Fix `receiveTimeout` for streamed responses.
-- Fix cancellation and missing progress handling for streamed responses and downloads when using `IOHttpClientAdapter`.
+- Fix cancellation and missing progress handling for streamed responses when using `IOHttpClientAdapter`.
 
 ## 5.4.0
 

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
+
 import 'headers.dart';
 import 'options.dart';
 import 'redirect_record.dart';
@@ -58,28 +60,34 @@ class ResponseBody {
     this.statusMessage,
     this.isRedirect = false,
     this.redirects,
+    void Function()? onClose,
     Map<String, List<String>>? headers,
-  }) : headers = headers ?? {};
+  })  : headers = headers ?? {},
+        _onClose = onClose;
 
   ResponseBody.fromString(
     String text,
     this.statusCode, {
     this.statusMessage,
     this.isRedirect = false,
+    void Function()? onClose,
     Map<String, List<String>>? headers,
   })  : stream = Stream.value(Uint8List.fromList(utf8.encode(text))),
-        headers = headers ?? {};
+        headers = headers ?? {},
+        _onClose = onClose;
 
   ResponseBody.fromBytes(
     List<int> bytes,
     this.statusCode, {
     this.statusMessage,
     this.isRedirect = false,
+    void Function()? onClose,
     Map<String, List<String>>? headers,
   })  : stream = Stream.value(
           bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
         ),
-        headers = headers ?? {};
+        headers = headers ?? {},
+        _onClose = onClose;
 
   /// Whether this response is a redirect.
   final bool isRedirect;
@@ -107,4 +115,10 @@ class ResponseBody {
 
   /// The extra field which will pass-through to the [Response.extra].
   Map<String, dynamic> extra = {};
+
+  final void Function()? _onClose;
+
+  /// Closes the request & frees the underlying resources.
+  @internal
+  void close() => _onClose?.call();
 }

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'headers.dart';
 import 'options.dart';
 import 'redirect_record.dart';
 
@@ -88,6 +89,10 @@ class ResponseBody {
 
   /// HTTP status code.
   int statusCode;
+
+  /// Content length of the response or -1 if not specified
+  int get contentLength =>
+      int.parse(headers[Headers.contentLengthHeader]?.first ?? '-1');
 
   /// Returns the reason phrase corresponds to the status code.
   /// The message can be [HttpRequest.statusText]

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -255,17 +255,6 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       cancelOnError: true,
     );
 
-    cancelFuture?.whenComplete(() {
-      /// Close the stream upon a cancellation.
-      responseSubscription.cancel();
-      if (!responseSink.isClosed) {
-        /// If the request was aborted via [Request.abort], then the
-        /// [responseSubscription] may have emitted a done event already.
-        responseSink.addError(options.cancelToken!.cancelError!);
-        responseSink.close();
-      }
-    });
-
     final headers = <String, List<String>>{};
     responseStream.headers.forEach((key, values) {
       headers[key] = values;

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -269,6 +269,12 @@ class IOHttpClientAdapter implements HttpClientAdapter {
           .map((e) => RedirectRecord(e.statusCode, e.method, e.location))
           .toList(),
       statusMessage: responseStream.reasonPhrase,
+      onClose: () {
+        responseSink.close();
+        responseSubscription.cancel();
+        responseStream.detachSocket().then((socket) => socket.destroy());
+        stopWatchReceiveTimeout();
+      },
     );
   }
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -198,69 +198,12 @@ class IOHttpClientAdapter implements HttpClientAdapter {
       }
     }
 
-    // Use a StreamController to explicitly handle receive timeouts.
-    final responseSink = StreamController<Uint8List>();
-    late StreamSubscription<List<int>> responseSubscription;
-
-    final receiveStopwatch = Stopwatch();
-    Timer? receiveTimer;
-
-    void stopWatchReceiveTimeout() {
-      receiveTimer?.cancel();
-      receiveTimer = null;
-      receiveStopwatch.stop();
-    }
-
-    void watchReceiveTimeout() {
-      if (receiveTimeout <= Duration.zero) {
-        return;
-      }
-      receiveStopwatch.reset();
-      if (!receiveStopwatch.isRunning) {
-        receiveStopwatch.start();
-      }
-      receiveTimer?.cancel();
-      receiveTimer = Timer(receiveTimeout, () {
-        responseSink.addError(
-          DioException.receiveTimeout(
-            timeout: receiveTimeout,
-            requestOptions: options,
-          ),
-        );
-        responseSink.close();
-        responseSubscription.cancel();
-        responseStream.detachSocket().then((socket) => socket.destroy());
-        stopWatchReceiveTimeout();
-      });
-    }
-
-    responseSubscription = responseStream.cast<Uint8List>().listen(
-      (data) {
-        watchReceiveTimeout();
-        // Always true if the receive timeout was not set.
-        if (receiveStopwatch.elapsed <= receiveTimeout) {
-          responseSink.add(data);
-        }
-      },
-      onError: (error, stackTrace) {
-        stopWatchReceiveTimeout();
-        responseSink.addError(error, stackTrace);
-        responseSink.close();
-      },
-      onDone: () {
-        stopWatchReceiveTimeout();
-        responseSubscription.cancel();
-        responseSink.close();
-      },
-      cancelOnError: true,
-    );
-
     final headers = <String, List<String>>{};
     responseStream.headers.forEach((key, values) {
       headers[key] = values;
     });
     return ResponseBody(
-      responseSink.stream,
+      responseStream.cast(),
       responseStream.statusCode,
       headers: headers,
       isRedirect:
@@ -270,10 +213,7 @@ class IOHttpClientAdapter implements HttpClientAdapter {
           .toList(),
       statusMessage: responseStream.reasonPhrase,
       onClose: () {
-        responseSink.close();
-        responseSubscription.cancel();
         responseStream.detachSocket().then((socket) => socket.destroy());
-        stopWatchReceiveTimeout();
       },
     );
   }

--- a/dio/lib/src/dio/dio_for_native.dart
+++ b/dio/lib/src/dio/dio_for_native.dart
@@ -48,7 +48,7 @@ class DioForNative with DioMixin implements Dio {
         data: data,
         options: options,
         queryParameters: queryParameters,
-        cancelToken: cancelToken ?? CancelToken(),
+        cancelToken: cancelToken,
       );
     } on DioException catch (e) {
       if (e.type == DioExceptionType.badResponse) {

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -15,6 +15,7 @@ import 'headers.dart';
 import 'interceptors/imply_content_type.dart';
 import 'options.dart';
 import 'response.dart';
+import 'response/response_stream_handler.dart';
 import 'transformer.dart';
 import 'transformers/background_transformer.dart';
 
@@ -546,6 +547,9 @@ abstract class DioMixin implements Dio {
             T != String &&
             reqOpt.responseType == ResponseType.json) {
           data = null;
+        } else if (reqOpt.responseType == ResponseType.stream &&
+            data is ResponseBody) {
+          data.stream = handleResponseStream(reqOpt, data);
         }
         ret.data = data;
       } else {

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -536,6 +536,8 @@ abstract class DioMixin implements Dio {
       );
       final statusOk = reqOpt.validateStatus(responseBody.statusCode);
       if (statusOk || reqOpt.receiveDataWhenStatusError == true) {
+        responseBody.stream = handleResponseStream(reqOpt, responseBody);
+
         Object? data = await transformer.transformResponse(
           reqOpt,
           responseBody,
@@ -547,13 +549,10 @@ abstract class DioMixin implements Dio {
             T != String &&
             reqOpt.responseType == ResponseType.json) {
           data = null;
-        } else if (reqOpt.responseType == ResponseType.stream &&
-            data is ResponseBody) {
-          data.stream = handleResponseStream(reqOpt, data);
         }
         ret.data = data;
       } else {
-        await responseBody.stream.listen(null).cancel();
+        responseBody.close();
       }
       checkCancelled(cancelToken);
       if (statusOk) {

--- a/dio/lib/src/response/response_stream_handler.dart
+++ b/dio/lib/src/response/response_stream_handler.dart
@@ -3,37 +3,80 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
-/// An internal helper function to handle things around
-/// streamed responses.
+/// An internal helper which handles functionality
+/// common to all adapters. This function ensures that
+/// all resources are closed when the request is finished
+/// or cancelled.
+///
+/// - [options.receiveTimeout] between received chunks
+/// - [options.onReceiveProgress] progress for received chunks
+/// - [options.cancelToken] for cancellation while receiving
 Stream<Uint8List> handleResponseStream(
   RequestOptions options,
   ResponseBody response,
 ) {
   final source = response.stream;
-
-  // Use a StreamController to explicitly handle receive timeouts.
   final responseSink = StreamController<Uint8List>();
   late StreamSubscription<List<int>> responseSubscription;
 
   late int totalLength;
+  int receivedLength = 0;
   if (options.onReceiveProgress != null) {
     totalLength = response.contentLength;
   }
 
-  int dataLength = 0;
+  final receiveTimeout = options.receiveTimeout ?? Duration.zero;
+  final receiveStopwatch = Stopwatch();
+  Timer? receiveTimer;
+
+  void stopWatchReceiveTimeout() {
+    receiveTimer?.cancel();
+    receiveTimer = null;
+    receiveStopwatch.stop();
+  }
+
+  void watchReceiveTimeout() {
+    if (receiveTimeout <= Duration.zero) {
+      return;
+    }
+    receiveStopwatch.reset();
+    if (!receiveStopwatch.isRunning) {
+      receiveStopwatch.start();
+    }
+    receiveTimer?.cancel();
+    receiveTimer = Timer(receiveTimeout, () {
+      responseSink.addError(
+        DioException.receiveTimeout(
+          timeout: receiveTimeout,
+          requestOptions: options,
+        ),
+      );
+      response.close();
+      responseSink.close();
+      responseSubscription.cancel();
+      stopWatchReceiveTimeout();
+    });
+  }
+
   responseSubscription = source.listen(
     (data) {
-      responseSink.add(data);
-      options.onReceiveProgress?.call(
-        dataLength += data.length,
-        totalLength,
-      );
+      watchReceiveTimeout();
+      // Always true if the receive timeout was not set.
+      if (receiveStopwatch.elapsed <= receiveTimeout) {
+        responseSink.add(data);
+        options.onReceiveProgress?.call(
+          receivedLength += data.length,
+          totalLength,
+        );
+      }
     },
     onError: (error, stackTrace) {
+      stopWatchReceiveTimeout();
       responseSink.addError(error, stackTrace);
       responseSink.close();
     },
     onDone: () {
+      stopWatchReceiveTimeout();
       responseSubscription.cancel();
       responseSink.close();
     },

--- a/dio/lib/src/response/response_stream_handler.dart
+++ b/dio/lib/src/response/response_stream_handler.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+/// An internal helper function to handle things around
+/// streamed responses.
+Stream<Uint8List> handleResponseStream(
+  RequestOptions options,
+  ResponseBody response,
+) {
+  final source = response.stream;
+
+  // Use a StreamController to explicitly handle receive timeouts.
+  final responseSink = StreamController<Uint8List>();
+  late StreamSubscription<List<int>> responseSubscription;
+
+  late int totalLength;
+  if (options.onReceiveProgress != null) {
+    totalLength = response.contentLength;
+  }
+
+  int dataLength = 0;
+  responseSubscription = source.listen(
+    (data) {
+      responseSink.add(data);
+      options.onReceiveProgress?.call(
+        dataLength += data.length,
+        totalLength,
+      );
+    },
+    onError: (error, stackTrace) {
+      responseSink.addError(error, stackTrace);
+      responseSink.close();
+    },
+    onDone: () {
+      responseSubscription.cancel();
+      responseSink.close();
+    },
+    cancelOnError: true,
+  );
+
+  options.cancelToken?.whenCancel.whenComplete(() {
+    /// Close the response stream upon a cancellation.
+    responseSubscription.cancel();
+    if (!responseSink.isClosed) {
+      responseSink.addError(options.cancelToken!.cancelError!);
+      responseSink.close();
+    }
+  });
+  return responseSink.stream;
+}

--- a/dio/lib/src/response/response_stream_handler.dart
+++ b/dio/lib/src/response/response_stream_handler.dart
@@ -43,6 +43,7 @@ Stream<Uint8List> handleResponseStream(
   options.cancelToken?.whenCancel.whenComplete(() {
     /// Close the response stream upon a cancellation.
     responseSubscription.cancel();
+    response.close();
     if (!responseSink.isClosed) {
       responseSink.addError(options.cancelToken!.cancelError!);
       responseSink.close();

--- a/dio/lib/src/transformers/sync_transformer.dart
+++ b/dio/lib/src/transformers/sync_transformer.dart
@@ -64,9 +64,7 @@ class SyncTransformer extends Transformer {
 
     final int totalLength;
     if (options.onReceiveProgress != null) {
-      totalLength = int.parse(
-        responseBody.headers[Headers.contentLengthHeader]?.first ?? '-1',
-      );
+      totalLength = responseBody.contentLength;
     } else {
       totalLength = 0;
     }

--- a/dio/test/cancel_token_test.dart
+++ b/dio/test/cancel_token_test.dart
@@ -36,25 +36,23 @@ void main() {
         final dio = Dio()..options.baseUrl = 'https://httpbun.com/';
 
         final cancelToken = CancelToken();
+
         final response = await dio.get(
-          'bytes/${1024 * 1024 * 10}',
+          'bytes/${1024 * 1024 * 100}',
           options: Options(responseType: ResponseType.stream),
           cancelToken: cancelToken,
+          onReceiveProgress: (c, t) {
+            if (c > 5000) {
+              cancelToken.cancel();
+            }
+          },
         );
-
-        expect(response.statusCode, 200);
-
-        Future.delayed(const Duration(milliseconds: 750), () {
-          cancelToken.cancel();
-        });
 
         await expectLater(
           (response.data as ResponseBody).stream.last,
           throwsDioException(
             DioExceptionType.cancel,
             stackTraceContains: 'test/cancel_token_test.dart',
-            matcher: (DioException e) => e.message!
-                .contains('The request was manually cancelled by the user'),
           ),
         );
       },

--- a/dio/test/download_test.dart
+++ b/dio/test/download_test.dart
@@ -46,10 +46,10 @@ void main() {
       },
     );
 
-    expect(count, total);
-
     final f = File(savePath);
     expect(f.readAsStringSync(), equals('I am a text file'));
+    expect(count, f.readAsBytesSync().length);
+    expect(count, total);
   });
 
   test('download2', () async {

--- a/dio/test/download_test.dart
+++ b/dio/test/download_test.dart
@@ -35,6 +35,19 @@ void main() {
     final dio = Dio()..options.baseUrl = serverUrl.toString();
     await dio.download('/download', savePath);
 
+    int? total;
+    int? count;
+    await dio.download(
+      '/download',
+      savePath,
+      onReceiveProgress: (c, t) {
+        total = t;
+        count = c;
+      },
+    );
+
+    expect(count, total);
+
     final f = File(savePath);
     expect(f.readAsStringSync(), equals('I am a text file'));
   });
@@ -142,17 +155,48 @@ void main() {
     final cancelToken = CancelToken();
     final dio = Dio()..options.baseUrl = serverUrl.toString();
     await expectLater(
-      dio
-          .download(
-            '/download',
-            savePath,
-            deleteOnError: true,
-            cancelToken: cancelToken,
-            onReceiveProgress: (count, total) => cancelToken.cancel(),
-          )
-          .catchError((e) => throw (e as DioException).type),
-      throwsA(DioExceptionType.cancel),
+      dio.download(
+        '/download',
+        savePath,
+        deleteOnError: true,
+        cancelToken: cancelToken,
+        onReceiveProgress: (count, total) => cancelToken.cancel(),
+      ),
+      throwsDioException(
+        DioExceptionType.cancel,
+        stackTraceContains: 'test/download_test.dart',
+      ),
     );
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(f.existsSync(), isFalse);
+  });
+
+  test('cancel download mid stream', () async {
+    const savePath = 'test/download/_test.md';
+    final f = File(savePath)..createSync(recursive: true);
+    expect(f.existsSync(), isTrue);
+
+    final cancelToken = CancelToken();
+    final dio = Dio()..options.baseUrl = 'https://httpbun.com';
+
+    await expectLater(
+      dio.download(
+        '/bytes/10000',
+        savePath,
+        cancelToken: cancelToken,
+        deleteOnError: true,
+        onReceiveProgress: (c, t) {
+          if (c > 5000) {
+            cancelToken.cancel();
+          }
+        },
+      ),
+      throwsDioException(
+        DioExceptionType.cancel,
+        stackTraceContains: 'test/download_test.dart',
+      ),
+    );
+
     await Future.delayed(const Duration(milliseconds: 100));
     expect(f.existsSync(), isFalse);
   });

--- a/dio/test/request_integration_test.dart
+++ b/dio/test/request_integration_test.dart
@@ -34,7 +34,6 @@ void main() {
         expect(response.data['args'], {'id': '12', 'name': 'wendu'});
       });
 
-      // TODO This is not supported on web, should we warn?
       test('GET with content', () async {
         final response = await dio.get(
           '/anything',

--- a/dio/test/utils.dart
+++ b/dio/test/utils.dart
@@ -178,19 +178,31 @@ final Matcher throwsDioExceptionConnectionError = throwsA(
 /// A matcher for functions that throw [DioException] of a specified type,
 /// with an optional matcher for the stackTrace containing the specified text.
 Matcher throwsDioException(
-    DioExceptionType type, {
-      String? stackTraceContains,
-      Object? matcher,
-    }) =>
+  DioExceptionType type, {
+  String? stackTraceContains,
+  Object? matcher,
+}) =>
     throwsA(
-      allOf([
-        isA<DioException>(),
-            (DioException e) => e.type == type,
-        if (stackTraceContains != null)
-              (DioException e) => e.stackTrace.toString().contains(stackTraceContains),
-        if (matcher != null) matcher,
-      ]),
+      matchesDioException(
+        type,
+        stackTraceContains: stackTraceContains,
+        matcher: matcher,
+      ),
     );
+
+Matcher matchesDioException(
+  DioExceptionType type, {
+  String? stackTraceContains,
+  Object? matcher,
+}) =>
+    allOf([
+      isA<DioException>(),
+      (DioException e) => e.type == type,
+      if (stackTraceContains != null)
+        (DioException e) =>
+            e.stackTrace.toString().contains(stackTraceContains),
+      if (matcher != null) matcher,
+    ]);
 
 /// A stream of chunks of bytes representing a single piece of data.
 class ByteStream extends StreamView<List<int>> {

--- a/dio/test/utils.dart
+++ b/dio/test/utils.dart
@@ -175,6 +175,23 @@ final Matcher throwsDioExceptionConnectionError = throwsA(
   ]),
 );
 
+/// A matcher for functions that throw [DioException] of a specified type,
+/// with an optional matcher for the stackTrace containing the specified text.
+Matcher throwsDioException(
+    DioExceptionType type, {
+      String? stackTraceContains,
+      Object? matcher,
+    }) =>
+    throwsA(
+      allOf([
+        isA<DioException>(),
+            (DioException e) => e.type == type,
+        if (stackTraceContains != null)
+              (DioException e) => e.stackTrace.toString().contains(stackTraceContains),
+        if (matcher != null) matcher,
+      ]),
+    );
+
 /// A stream of chunks of bytes representing a single piece of data.
 class ByteStream extends StreamView<List<int>> {
   ByteStream(Stream<List<int>> stream) : super(stream);

--- a/example/lib/extend_dio.dart
+++ b/example/lib/extend_dio.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 
 class HttpService extends DioForNative {
-  HttpService([BaseOptions? baseOptions]) : super(baseOptions) {
+  HttpService([super.baseOptions]) {
     options
       ..baseUrl = 'https://httpbin.org/'
       ..contentType = Headers.jsonContentType;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cookie_jar:

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Fix cancellation for streamed responses and downloads.
 
 ## 2.4.0
 

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fix cancellation for streamed responses and downloads.
+- Fix progress for streamed responses and downloads.
+- Bump minimum Dart SDK to 3.0.0 as required by the `http2` package.
 
 ## 2.4.0
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -121,37 +121,6 @@ class Http2Adapter implements HttpClientAdapter {
     bool needResponse = false;
 
     final receiveTimeout = options.receiveTimeout ?? Duration.zero;
-    final receiveStopwatch = Stopwatch();
-    Timer? receiveTimer;
-
-    void stopWatchReceiveTimeout() {
-      receiveTimer?.cancel();
-      receiveTimer = null;
-      receiveStopwatch.stop();
-    }
-
-    void watchReceiveTimeout() {
-      if (receiveTimeout <= Duration.zero) {
-        return;
-      }
-      receiveStopwatch.reset();
-      if (!receiveStopwatch.isRunning) {
-        receiveStopwatch.start();
-      }
-      receiveTimer?.cancel();
-      receiveTimer = Timer(receiveTimeout, () {
-        responseSink.addError(
-          DioException.receiveTimeout(
-            timeout: receiveTimeout,
-            requestOptions: options,
-          ),
-        );
-        responseSink.close();
-        responseSubscription.cancel();
-        stream.terminate();
-        stopWatchReceiveTimeout();
-      });
-    }
 
     late int statusCode;
     responseSubscription = stream.incomingMessages.listen(
@@ -175,14 +144,12 @@ class Http2Adapter implements HttpClientAdapter {
           }
         } else if (message is DataStreamMessage) {
           if (needResponse) {
-            watchReceiveTimeout();
             responseSink.add(
               message.bytes is Uint8List
                   ? message.bytes as Uint8List
                   : Uint8List.fromList(message.bytes),
             );
           } else {
-            stopWatchReceiveTimeout();
             responseSubscription.cancel().whenComplete(() {
               stream.terminate();
               responseSink.close();
@@ -200,12 +167,10 @@ class Http2Adapter implements HttpClientAdapter {
         } else {
           responseSink.addError(error, stackTrace);
         }
-        stopWatchReceiveTimeout();
         responseSubscription.cancel();
         responseSink.close();
       },
       onDone: () {
-        stopWatchReceiveTimeout();
         responseSubscription.cancel();
         responseSink.close();
       },

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -212,20 +212,6 @@ class Http2Adapter implements HttpClientAdapter {
       cancelOnError: true,
     );
 
-
-    /// Cancel any up/download streams and connections
-    /// if the [CancelToken] is cancelled
-    /// and propagate the [DioException] to the response stream.
-    cancelFuture?.whenComplete(() {
-      stream.terminate();
-      transport.terminate();
-
-      responseSink.addError(options.cancelToken!.cancelError!);
-
-      responseSubscription.cancel();
-      responseSink.close();
-    });
-
     Future<void> responseFuture = responseCompleter.future;
     if (receiveTimeout > Duration.zero) {
       responseFuture = responseFuture.timeout(

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -212,6 +212,20 @@ class Http2Adapter implements HttpClientAdapter {
       cancelOnError: true,
     );
 
+
+    /// Cancel any up/download streams and connections
+    /// if the [CancelToken] is cancelled
+    /// and propagate the [DioException] to the response stream.
+    cancelFuture?.whenComplete(() {
+      stream.terminate();
+      transport.terminate();
+
+      responseSink.addError(options.cancelToken!.cancelError!);
+
+      responseSubscription.cancel();
+      responseSink.close();
+    });
+
     Future<void> responseFuture = responseCompleter.future;
     if (receiveTimeout > Duration.zero) {
       responseFuture = responseFuture.timeout(

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -248,6 +248,11 @@ class Http2Adapter implements HttpClientAdapter {
       headers: responseHeaders.map,
       redirects: redirects,
       isRedirect: redirects.isNotEmpty,
+      onClose: () {
+        responseSubscription.cancel();
+        responseSink.close();
+        stream.terminate();
+      },
     );
   }
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: void_checks
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -12,10 +12,10 @@ repository: https://github.com/cfug/dio/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  http2: ^2.0.0
+  http2: ^2.1.0
   dio: ^5.2.0
 
 dev_dependencies:

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -22,3 +22,4 @@ dev_dependencies:
   crypto: ^3.0.2
   lints: any
   test: ^1.16.4
+  path: ^1.8.0

--- a/plugins/http2_adapter/test/request_test.dart
+++ b/plugins/http2_adapter/test/request_test.dart
@@ -29,11 +29,13 @@ void main() {
       final size = 10000;
       int progressEventCount = 0;
       int count = 0;
+      int total = 0;
       await dio.download(
         '/bytes/$size',
         path,
         onReceiveProgress: (c, t) {
           count = c;
+          total = t;
           progressEventCount++;
         },
       );
@@ -41,6 +43,7 @@ void main() {
       final f = File(path);
       expect(count, f.readAsBytesSync().length);
       expect(progressEventCount, greaterThan(1));
+      expect(count, total);
     });
 
     test('cancels request', () async {
@@ -63,19 +66,42 @@ void main() {
       );
     });
 
-    test('cancels streamed responses', () async {
+    test('cancels download', () async {
       final cancelToken = CancelToken();
-      final response = await dio.get(
-        'bytes/${1024 * 1024 * 10}',
-        options: Options(responseType: ResponseType.stream),
-        cancelToken: cancelToken,
-      );
+      final path = p.join(tmp.path, 'download.txt');
 
-      Future.delayed(const Duration(milliseconds: 750), () {
+      Future.delayed(const Duration(milliseconds: 50), () {
         cancelToken.cancel();
       });
 
-      expect(response.statusCode, 200);
+      await expectLater(
+        dio.download(
+          '/bytes/5000',
+          path,
+          cancelToken: cancelToken,
+        ),
+        throwsDioException(
+          DioExceptionType.cancel,
+          stackTraceContains: 'test/request_test.dart',
+        ),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 250), () {});
+      expect(File(path).existsSync(), false);
+    });
+
+    test('cancels streamed response mid request', () async {
+      final cancelToken = CancelToken();
+      final response = await dio.get(
+        'bytes/${1024 * 1024 * 100}',
+        options: Options(responseType: ResponseType.stream),
+        cancelToken: cancelToken,
+        onReceiveProgress: (c, t) {
+          if (c > 5000) {
+            cancelToken.cancel();
+          }
+        },
+      );
 
       await expectLater(
         (response.data as ResponseBody).stream.last,
@@ -84,6 +110,31 @@ void main() {
           stackTraceContains: 'test/request_test.dart',
         ),
       );
+    });
+
+    test('cancels download mid request', () async {
+      final cancelToken = CancelToken();
+      final path = p.join(tmp.path, 'download_2.txt');
+
+      await expectLater(
+        dio.download(
+          'bytes/${1024 * 1024 * 10}',
+          path,
+          cancelToken: cancelToken,
+          onReceiveProgress: (c, t) {
+            if (c > 5000) {
+              cancelToken.cancel();
+            }
+          },
+        ),
+        throwsDioException(
+          DioExceptionType.cancel,
+          stackTraceContains: 'test/request_test.dart',
+        ),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 250), () {});
+      expect(File(path).existsSync(), false);
     });
   });
 }

--- a/plugins/http2_adapter/test/request_test.dart
+++ b/plugins/http2_adapter/test/request_test.dart
@@ -1,0 +1,89 @@
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio_http2_adapter/dio_http2_adapter.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+void main() {
+  late Directory tmp;
+
+  final dio = Dio()
+    ..httpClientAdapter = Http2Adapter(null)
+    ..options.baseUrl = 'https://httpbun.com/';
+
+  setUpAll(() {
+    tmp = Directory.systemTemp.createTempSync('dio_test_');
+    addTearDown(() {
+      tmp.deleteSync(recursive: true);
+    });
+  });
+
+  group('requests >', () {
+    test('download bytes', () async {
+      final path = p.join(tmp.path, 'bytes.txt');
+
+      final size = 10000;
+      int progressEventCount = 0;
+      int count = 0;
+      await dio.download(
+        '/bytes/$size',
+        path,
+        onReceiveProgress: (c, t) {
+          count = c;
+          progressEventCount++;
+        },
+      );
+
+      final f = File(path);
+      expect(count, f.readAsBytesSync().length);
+      expect(progressEventCount, greaterThan(1));
+    });
+
+    test('cancels request', () async {
+      final cancelToken = CancelToken();
+
+      Future.delayed(const Duration(milliseconds: 50), () {
+        cancelToken.cancel();
+      });
+
+      await expectLater(
+        dio.get(
+          '/bytes/5000',
+          options: Options(responseType: ResponseType.stream),
+          cancelToken: cancelToken,
+        ),
+        throwsDioException(
+          DioExceptionType.cancel,
+          stackTraceContains: 'test/request_test.dart',
+        ),
+      );
+    });
+
+    test('cancels streamed responses', () async {
+      final cancelToken = CancelToken();
+      final response = await dio.get(
+        'bytes/${1024 * 1024 * 10}',
+        options: Options(responseType: ResponseType.stream),
+        cancelToken: cancelToken,
+      );
+
+      Future.delayed(const Duration(milliseconds: 750), () {
+        cancelToken.cancel();
+      });
+
+      expect(response.statusCode, 200);
+
+      await expectLater(
+        (response.data as ResponseBody).stream.last,
+        throwsDioException(
+          DioExceptionType.cancel,
+          stackTraceContains: 'test/request_test.dart',
+        ),
+      );
+    });
+  });
+}

--- a/plugins/http2_adapter/test/utils.dart
+++ b/plugins/http2_adapter/test/utils.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+/// A matcher for functions that throw [DioException] of a specified type,
+/// with an optional matcher for the stackTrace containing the specified text.
+Matcher throwsDioException(
+  DioExceptionType type, {
+  String? stackTraceContains,
+  Object? matcher,
+}) =>
+    throwsA(
+      allOf([
+        isA<DioException>(),
+        (DioException e) => e.type == type,
+        if (stackTraceContains != null)
+          (DioException e) =>
+              e.stackTrace.toString().contains(stackTraceContains),
+        if (matcher != null) matcher,
+      ]),
+    );


### PR DESCRIPTION
* fixes #2025

This is a new approach that handles both IO & HTTP/2 adapters.
I also moved the `receiveTimeout` handling for IO & HTTP2 to the new helper.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
