### PR TITLE
Bump min Dart SDK to 3.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: subosito/flutter-action@v2.8.0
         with:
           cache: true
-          flutter-version: ${{ matrix.sdk == 'min' && '2.8.0' || '' }}
+          flutter-version: ${{ matrix.sdk == 'min' && '3.10.0' || '' }}
           channel: ${{ matrix.sdk == 'min' && '' || matrix.channel }}
       - run: |
           chmod +x ./scripts/prepare_pinning_certs.sh

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased 6.0.0
 
-- The minimum supported Dart version has been bumped from `2.15.0` to `2.19.0`.
+- The minimum supported Dart version has been bumped from `2.15.0` to `3.0.0`.
 - Remove `DefaultHttpClientAdapter` which was deprecated in `5.0.0`.
 - Remove `IOHttpClientAdapter.onHttpClientCreate` which was deprecated in `5.2.0`
 - Remove `DioError` and `DioErrorType` which was deprecated in `5.2.0`.

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -23,8 +23,7 @@ import 'progress_stream/io_progress_stream.dart'
 
 part 'interceptor.dart';
 
-// TODO(EVERYONE): Use `mixin class` when the lower bound of SDK is raised to 3.0.0.
-abstract class DioMixin implements Dio {
+mixin class DioMixin implements Dio {
   /// The base request config for the instance.
   @override
   late BaseOptions options;

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -17,7 +17,7 @@ repository: https://github.com/cfug/dio/blob/main/dio
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   async: ^2.8.2

--- a/example/lib/extend_dio.dart
+++ b/example/lib/extend_dio.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 
 class HttpService extends DioForNative {
-  HttpService([BaseOptions? baseOptions]) : super(baseOptions) {
+  HttpService([super.baseOptions]) {
     options
       ..baseUrl = 'https://httpbin.org/'
       ..contentType = Headers.jsonContentType;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cookie_jar:

--- a/example_flutter_app/pubspec.yaml
+++ b/example_flutter_app/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -13,11 +13,11 @@ repository: https://github.com/cfug/dio/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cookie_jar: ^4.0.0
-  dio: ^5.2.0
+  dio: ^6.0.0
 
 dev_dependencies:
   lints: any

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -12,11 +12,11 @@ repository: https://github.com/cfug/dio/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   http2: ^2.0.0
-  dio: ^5.2.0
+  dio: ^6.0.0
 
 dev_dependencies:
   crypto: ^3.0.2

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dio: ^5.4.0
+  dio: ^6.0.0
   cupertino_http: ^1.0.0
   cronet_http: ^0.4.0
   http: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 repository: https://github.com/cfug/dio
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
   lints: any


### PR DESCRIPTION
We decided for 2.19.0 half a year ago, so I think we can now safely go to Dart 3 for a 6.0.0 release.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
