### PR TITLE
[http2] Fix Http2Adapter not redirecting for relative URLs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,8 @@ jobs:
       - name: '[Verify step] Test Dart packages [VM]'
         run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --no-flutter -- "MELOS_ROOT_PATH/scripts/dart_test.sh --platform=vm"
       - name: '[Verify step] Test Dart packages [Chrome]'
-        run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --no-flutter -- "MELOS_ROOT_PATH/scripts/dart_test.sh --platform=chrome"
+        run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --ignore="*http2*" --no-flutter -- "MELOS_ROOT_PATH/scripts/dart_test.sh --platform=chrome"
       - name: '[Verify step] Test Dart packages [Firefox]'
-        run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --no-flutter -- "MELOS_ROOT_PATH/scripts/dart_test.sh --platform=firefox"
+        run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --ignore="*http2*" --no-flutter -- "MELOS_ROOT_PATH/scripts/dart_test.sh --platform=firefox"
       - name: '[Verify step] Test Flutter packages'
         run: melos exec $(eval echo $IGNORED_PACKAGES) --ignore="*example*" --flutter -- "flutter test"

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -16,6 +16,7 @@ environment:
 
 dependencies:
   http2: ^2.1.0
+  meta: ^1.9.1
   dio: ^5.2.0
 
 dev_dependencies:

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -128,13 +128,48 @@ void main() {
     await dio.get('/drip?delay=1&numbytes=1');
   });
 
-  test('request with redirect', () async {
+  group('redirects', () {
     final dio = Dio()
       ..options.baseUrl = 'https://httpbun.com/'
       ..httpClientAdapter = Http2Adapter(ConnectionManager());
 
-    final res = await dio.get('absolute-redirect/2');
-    expect(res.statusCode, 200);
+    test('single', () async {
+      final response = await dio.get(
+        '/redirect',
+        queryParameters: {'url': 'https://httpbun.com/get'},
+        onReceiveProgress: (received, total) {
+          // ignore progress
+        },
+      );
+      expect(response.isRedirect, isTrue);
+
+      // Redirects are not supported in web.
+      // Rhe browser will follow the redirects automatically.
+      expect(response.redirects.length, 1);
+      final ri = response.redirects.first;
+      expect(ri.statusCode, 302);
+      expect(ri.location.path, '/get');
+      expect(ri.method, 'GET');
+    });
+
+    test('multiple', () async {
+      final response = await dio.get(
+        '/redirect/3',
+      );
+      expect(response.isRedirect, isTrue);
+
+      // Redirects are not supported in web.
+      // The browser will follow the redirects automatically.
+      expect(response.redirects.length, 3);
+      final ri = response.redirects.first;
+      expect(ri.statusCode, 302);
+      expect(ri.method, 'GET');
+    });
+
+    test('request with redirect', () async {
+      final res = await dio.get('absolute-redirect/2');
+      expect(res.statusCode, 200);
+    });
   });
 
   test('header value types implicit support', () async {

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -182,30 +182,40 @@ void main() {
       final response = await dio.get(
         '/redirect',
         queryParameters: {'url': 'https://httpbun.com/get'},
-        onReceiveProgress: (received, total) {
-          // ignore progress
-        },
       );
       expect(response.isRedirect, isTrue);
-
-      // Redirects are not supported in web.
-      // Rhe browser will follow the redirects automatically.
       expect(response.redirects.length, 1);
+
       final ri = response.redirects.first;
       expect(ri.statusCode, 302);
       expect(ri.location.path, '/get');
       expect(ri.method, 'GET');
     });
 
+    test(
+      'empty location',
+      () async {
+        final response = await dio.get(
+          '/redirect',
+        );
+        expect(response.isRedirect, isTrue);
+        expect(response.redirects.length, 1);
+
+        final ri = response.redirects.first;
+        expect(ri.statusCode, 302);
+        expect(ri.location.path, '/get');
+        expect(ri.method, 'GET');
+      },
+      skip: 'Httpbun does not support empty location redirects',
+    );
+
     test('multiple', () async {
       final response = await dio.get(
         '/redirect/3',
       );
       expect(response.isRedirect, isTrue);
-
-      // Redirects are not supported in web.
-      // The browser will follow the redirects automatically.
       expect(response.redirects.length, 3);
+
       final ri = response.redirects.first;
       expect(ri.statusCode, 302);
       expect(ri.method, 'GET');

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'package:dio/dio.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:test/test.dart';

--- a/plugins/http2_adapter/test/pinning_test.dart
+++ b/plugins/http2_adapter/test/pinning_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';

--- a/plugins/http2_adapter/test/redirect_test.dart
+++ b/plugins/http2_adapter/test/redirect_test.dart
@@ -1,0 +1,45 @@
+import 'package:dio_http2_adapter/dio_http2_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(Http2Adapter.resolveRedirectUri, () {
+    test('empty location', () async {
+      final current = Uri.parse('https://example.com');
+      final result = Http2Adapter.resolveRedirectUri(
+        current,
+        Uri.parse(''),
+      );
+
+      expect(result, current.toString());
+    });
+
+    test('relative location 1', () async {
+      final result = Http2Adapter.resolveRedirectUri(
+        Uri.parse('https://example.com/foo'),
+        Uri.parse('/bar'),
+      );
+
+      expect(result, 'https://example.com/bar');
+    });
+
+    test('relative location 2', () async {
+      final result = Http2Adapter.resolveRedirectUri(
+        Uri.parse('https://example.com/foo'),
+        Uri.parse('../bar'),
+      );
+
+      expect(result, 'https://example.com/bar');
+    });
+
+    test('different location', () async {
+      final current = Uri.parse('https://example.com/foo');
+      final target = 'https://somewhere.com/bar';
+      final result = Http2Adapter.resolveRedirectUri(
+        current,
+        Uri.parse(target),
+      );
+
+      expect(result, target);
+    });
+  });
+}

--- a/plugins/http2_adapter/test/request_test.dart
+++ b/plugins/http2_adapter/test/request_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dio/dio.dart';

--- a/plugins/http2_adapter/test/timeout_test.dart
+++ b/plugins/http2_adapter/test/timeout_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:async';
 
 import 'package:dio/dio.dart';


### PR DESCRIPTION
Fixes a redirect bug discovered during https://github.com/cfug/dio/pull/2077 where the adapter would fail to properly redirect if the location header contains a relative URL.


<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
