### PR TITLE
Escape from uncaught exceptions for IDEs

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -10,7 +10,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Fix cancellation for streamed responses and downloads when using `IOHttpClientAdapter`.
 - Fix receive progress for streamed responses and downloads when using `IOHttpClientAdapter`.
 - Support relative `baseUrl` on the Web platform.
-- Fix `Excpetions` getting treated as `Uncaught` during debugging
+- Avoid fake uncaught exceptions during debugging with IDEs.
 
 ## 5.4.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -10,6 +10,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Fix cancellation for streamed responses and downloads when using `IOHttpClientAdapter`.
 - Fix receive progress for streamed responses and downloads when using `IOHttpClientAdapter`.
 - Support relative `baseUrl` on the Web platform.
+- Fix `Excpetions` getting treated as `Uncaught` during debugging
 
 ## 5.4.0
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -470,11 +470,12 @@ abstract class DioMixin implements Dio {
         RequestInterceptorHandler handler,
       ) async {
         requestOptions = reqOpt;
-        await _dispatchRequest<T>(reqOpt)
-            .then((value) => handler.resolve(value, true))
-            .catchError((e) {
-          handler.reject(e as DioException, true);
-        });
+        try {
+          final value = await _dispatchRequest<T>(reqOpt);
+          handler.resolve(value, true);
+        } on DioException catch (e) {
+          handler.reject(e, true);
+        }
       }),
     );
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -468,9 +468,9 @@ abstract class DioMixin implements Dio {
       requestInterceptorWrapper((
         RequestOptions reqOpt,
         RequestInterceptorHandler handler,
-      ) {
+      ) async {
         requestOptions = reqOpt;
-        _dispatchRequest<T>(reqOpt)
+        await _dispatchRequest<T>(reqOpt)
             .then((value) => handler.resolve(value, true))
             .catchError((e) {
           handler.reject(e as DioException, true);


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

I faced the same issue as #314 and #1869, and I also understand that it is not an error with the dio package but an error with the Flutter SDK / VScode, where VScode does not recognise the exceptions as handled when using Future.catchError(). 

Despite it not being a problem of this package, I believe "fixing" it such that it avoids the above mentioned problem is still the correct approach, the following modification avoids this problem, and allows the example Error Handling code on pub.dev works with VScode.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
