### PR TITLE
Test improvements

### DIFF
--- a/dio/dart_test.yaml
+++ b/dio/dart_test.yaml
@@ -18,3 +18,6 @@ override_platforms:
     settings:
       # headless argument has to be set explicitly for non-chrome browsers
       arguments: --headless
+      executable:
+        # https://github.com/dart-lang/test/pull/2195
+        mac_os: '/Applications/Firefox.app/Contents/MacOS/firefox'

--- a/dio/test/basic_test.dart
+++ b/dio/test/basic_test.dart
@@ -1,26 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:dio/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'mock/adapters.dart';
 
 void main() {
-  test('send with an invalid URL', () async {
-    await expectLater(
-      Dio().get('http://http.invalid'),
-      throwsA(
-        allOf([
-          isA<DioException>(),
-          (DioException e) => e.type == (DioExceptionType.connectionError),
-          if (!kIsWeb) (DioException e) => e.error is SocketException,
-        ]),
-      ),
-    );
-  });
-
   test('cancellation', () async {
     final dio = Dio()
       ..httpClientAdapter = MockAdapter()
@@ -35,38 +20,5 @@ void main() {
       dio.get('/test-timeout', cancelToken: token),
       throwsA((e) => e is DioException && CancelToken.isCancel(e)),
     );
-  });
-
-  test('status error', () async {
-    final dio = Dio()
-      ..options.baseUrl = EchoAdapter.mockBase
-      ..httpClientAdapter = EchoAdapter();
-    await expectLater(
-      dio.get('/401'),
-      throwsA(
-        (e) =>
-            e is DioException &&
-            e.type == DioExceptionType.badResponse &&
-            e.response!.statusCode == 401,
-      ),
-    );
-    final r = await dio.get(
-      '/401',
-      options: Options(validateStatus: (status) => true),
-    );
-    expect(r.statusCode, 401);
-  });
-
-  test('post map', () async {
-    final dio = Dio()
-      ..options.baseUrl = EchoAdapter.mockBase
-      ..httpClientAdapter = EchoAdapter();
-
-    final response = await dio.post(
-      '/post',
-      data: {'a': 1, 'b': 2, 'c': 3},
-    );
-    expect(response.data, '{"a":1,"b":2,"c":3}');
-    expect(response.statusCode, 200);
   });
 }

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -12,28 +12,6 @@ void main() {
     expect(error, isA<Exception>());
   });
 
-  test('catch DioException', () async {
-    DioException? error;
-    try {
-      await Dio().get('https://does.not.exist');
-      fail('did not throw');
-    } on DioException catch (e) {
-      error = e;
-    }
-    expect(error, isNotNull);
-  });
-
-  test('catch DioException as Exception', () async {
-    DioException? error;
-    try {
-      await Dio().get('https://does.not.exist');
-      fail('did not throw');
-    } on DioException catch (e) {
-      error = e;
-    }
-    expect(error, isNotNull);
-  });
-
   test(
     'catch DioException: hostname mismatch',
     () async {

--- a/dio_test/lib/src/test/cors_tests.dart
+++ b/dio_test/lib/src/test/cors_tests.dart
@@ -14,99 +14,103 @@ void corsTests(
     dio = create(httpbunBaseUrl);
   });
 
-  group('CORS preflight', () {
-    test('empty GET is not preflighted', () async {
-      // If there is no preflight (OPTIONS) request, the main request
-      // successfully completes with status 418.
-      final response = await dio.get(
-        '/status/418',
-        options: Options(
-          validateStatus: (status) => true,
-        ),
-      );
-      expect(response.statusCode, 418);
-    });
+  group(
+    'CORS preflight',
+    () {
+      test('empty GET is not preflighted', () async {
+        // If there is no preflight (OPTIONS) request, the main request
+        // successfully completes with status 418.
+        final response = await dio.get(
+          '/status/418',
+          options: Options(
+            validateStatus: (status) => true,
+          ),
+        );
+        expect(response.statusCode, 418);
+      });
 
-    test('GET with custom headers is preflighted', () async {
-      // If there is a preflight (OPTIONS) request, the server fails it
-      // by responding with status 418. This fails CORS, so the browser
-      // never sends the main request and this code throws.
-      expect(
-        () async {
-          final _ = await dio.get(
-            '/status/418',
-            options: Options(
-              headers: {
-                'x-request-header': 'value',
-              },
-            ),
-          );
-        },
-        throwsDioException(
-          DioExceptionType.connectionError,
-          stackTraceContains: 'test/test_suite_test.dart',
-        ),
-      );
-    });
+      test('GET with custom headers is preflighted', () async {
+        // If there is a preflight (OPTIONS) request, the server fails it
+        // by responding with status 418. This fails CORS, so the browser
+        // never sends the main request and this code throws.
+        expect(
+          () async {
+            final _ = await dio.get(
+              '/status/418',
+              options: Options(
+                headers: {
+                  'x-request-header': 'value',
+                },
+              ),
+            );
+          },
+          throwsDioException(
+            DioExceptionType.connectionError,
+            stackTraceContains: 'test/test_suite_test.dart',
+          ),
+        );
+      });
 
-    test('POST with text body is not preflighted', () async {
-      // If there is no preflight (OPTIONS) request, the main request
-      // successfully completes with status 418.
-      final response = await dio.post(
-        '/status/418',
-        data: 'body text',
-        options: Options(
-          validateStatus: (status) => true,
-          contentType: Headers.textPlainContentType,
-        ),
-      );
-      expect(response.statusCode, 418);
-    });
+      test('POST with text body is not preflighted', () async {
+        // If there is no preflight (OPTIONS) request, the main request
+        // successfully completes with status 418.
+        final response = await dio.post(
+          '/status/418',
+          data: 'body text',
+          options: Options(
+            validateStatus: (status) => true,
+            contentType: Headers.textPlainContentType,
+          ),
+        );
+        expect(response.statusCode, 418);
+      });
 
-    test('POST with sendTimeout is preflighted', () async {
-      // If there is a preflight (OPTIONS) request, the server fails it
-      // by responding with status 418. This fails CORS, so the browser
-      // never sends the main request and this code throws.
-      expect(
-        () async {
-          final _ = await dio.post(
-            '/status/418',
-            data: 'body text',
-            options: Options(
-              validateStatus: (status) => true,
-              contentType: Headers.textPlainContentType,
-              sendTimeout: Duration(seconds: 1),
-            ),
-          );
-        },
-        throwsDioException(
-          DioExceptionType.connectionError,
-          stackTraceContains: 'test/test_suite_test.dart',
-        ),
-      );
-    });
+      test('POST with sendTimeout is preflighted', () async {
+        // If there is a preflight (OPTIONS) request, the server fails it
+        // by responding with status 418. This fails CORS, so the browser
+        // never sends the main request and this code throws.
+        expect(
+          () async {
+            final _ = await dio.post(
+              '/status/418',
+              data: 'body text',
+              options: Options(
+                validateStatus: (status) => true,
+                contentType: Headers.textPlainContentType,
+                sendTimeout: Duration(seconds: 1),
+              ),
+            );
+          },
+          throwsDioException(
+            DioExceptionType.connectionError,
+            stackTraceContains: 'test/test_suite_test.dart',
+          ),
+        );
+      });
 
-    test('POST with onSendProgress is preflighted', () async {
-      // If there is a preflight (OPTIONS) request, the server fails it
-      // by responding with status 418. This fails CORS, so the browser
-      // never sends the main request and this code throws.
-      expect(
-        () async {
-          final _ = await dio.post(
-            '/status/418',
-            data: 'body text',
-            options: Options(
-              validateStatus: (status) => true,
-              contentType: Headers.textPlainContentType,
-            ),
-            onSendProgress: (_, __) {},
-          );
-        },
-        throwsDioException(
-          DioExceptionType.connectionError,
-          stackTraceContains: 'test/test_suite_test.dart',
-        ),
-      );
-    });
-  }, testOn: 'browser');
+      test('POST with onSendProgress is preflighted', () async {
+        // If there is a preflight (OPTIONS) request, the server fails it
+        // by responding with status 418. This fails CORS, so the browser
+        // never sends the main request and this code throws.
+        expect(
+          () async {
+            final _ = await dio.post(
+              '/status/418',
+              data: 'body text',
+              options: Options(
+                validateStatus: (status) => true,
+                contentType: Headers.textPlainContentType,
+              ),
+              onSendProgress: (_, __) {},
+            );
+          },
+          throwsDioException(
+            DioExceptionType.connectionError,
+            stackTraceContains: 'test/test_suite_test.dart',
+          ),
+        );
+      });
+    },
+    testOn: 'browser',
+  );
 }

--- a/dio_test/lib/src/test/download_stream_tests.dart
+++ b/dio_test/lib/src/test/download_stream_tests.dart
@@ -9,142 +9,146 @@ import 'package:test/test.dart';
 void downloadStreamTests(
   Dio Function(String baseUrl) create,
 ) {
-  group('download', () {
-    late Dio dio;
-    late Directory tmp;
+  group(
+    'download',
+    () {
+      late Dio dio;
+      late Directory tmp;
 
-    setUp(() {
-      dio = create(httpbunBaseUrl);
-    });
-
-    setUpAll(() {
-      tmp = Directory.systemTemp.createTempSync('dio_test_');
-      addTearDown(() {
-        tmp.deleteSync(recursive: true);
-      });
-    });
-
-    test('bytes', () async {
-      final path = p.join(tmp.path, 'bytes.txt');
-
-      final size = 50000;
-      int progressEventCount = 0;
-      int count = 0;
-      int total = 0;
-      await dio.download(
-        '/bytes/$size',
-        path,
-        onReceiveProgress: (c, t) {
-          count = c;
-          total = t;
-          progressEventCount++;
-        },
-      );
-
-      final f = File(path);
-      expect(count, f.readAsBytesSync().length);
-      expect(progressEventCount, greaterThanOrEqualTo(1));
-      expect(count, total);
-    });
-
-    test('cancels request', () async {
-      final cancelToken = CancelToken();
-
-      final res = await dio.get<ResponseBody>(
-        '/drip',
-        queryParameters: {'duration': '5', 'delay': '0'},
-        options: Options(responseType: ResponseType.stream),
-        cancelToken: cancelToken,
-      );
-
-      Future.delayed(const Duration(seconds: 2), () {
-        cancelToken.cancel();
+      setUp(() {
+        dio = create(httpbunBaseUrl);
       });
 
-      final completer = Completer();
-      res.data!.stream.listen((event) {}, onError: (e, s) {
-        completer.completeError(e, s);
+      setUpAll(() {
+        tmp = Directory.systemTemp.createTempSync('dio_test_');
+        addTearDown(() {
+          tmp.deleteSync(recursive: true);
+        });
       });
 
-      await expectLater(
-        completer.future,
-        throwsDioException(
-          DioExceptionType.cancel,
-          stackTraceContains: 'test/download_stream_tests.dart',
-        ),
-      );
-    });
+      test('bytes', () async {
+        final path = p.join(tmp.path, 'bytes.txt');
 
-    test('cancels download', () async {
-      final cancelToken = CancelToken();
-      final path = p.join(tmp.path, 'download.txt');
+        final size = 50000;
+        int progressEventCount = 0;
+        int count = 0;
+        int total = 0;
+        await dio.download(
+          '/bytes/$size',
+          path,
+          onReceiveProgress: (c, t) {
+            count = c;
+            total = t;
+            progressEventCount++;
+          },
+        );
 
-      Future.delayed(const Duration(milliseconds: 50), () {
-        cancelToken.cancel();
+        final f = File(path);
+        expect(count, f.readAsBytesSync().length);
+        expect(progressEventCount, greaterThanOrEqualTo(1));
+        expect(count, total);
       });
 
-      await expectLater(
-        dio.download(
+      test('cancels request', () async {
+        final cancelToken = CancelToken();
+
+        final res = await dio.get<ResponseBody>(
           '/drip',
-          path,
           queryParameters: {'duration': '5', 'delay': '0'},
+          options: Options(responseType: ResponseType.stream),
           cancelToken: cancelToken,
-        ),
-        throwsDioException(
-          DioExceptionType.cancel,
-          stackTraceContains: 'test/download_stream_tests.dart',
-        ),
-      );
+        );
 
-      await Future.delayed(const Duration(milliseconds: 250), () {});
-      expect(File(path).existsSync(), false);
-    });
+        Future.delayed(const Duration(seconds: 2), () {
+          cancelToken.cancel();
+        });
 
-    test('cancels streamed response mid request', () async {
-      final cancelToken = CancelToken();
-      final response = await dio.get(
-        '/bytes/${1024 * 1024 * 100}',
-        options: Options(responseType: ResponseType.stream),
-        cancelToken: cancelToken,
-        onReceiveProgress: (c, t) {
-          if (c > 5000) {
-            cancelToken.cancel();
-          }
-        },
-      );
+        final completer = Completer();
+        res.data!.stream.listen((event) {}, onError: (e, s) {
+          completer.completeError(e, s);
+        });
 
-      await expectLater(
-        (response.data as ResponseBody).stream.last,
-        throwsDioException(
-          DioExceptionType.cancel,
-          stackTraceContains: 'test/download_stream_tests.dart',
-        ),
-      );
-    });
+        await expectLater(
+          completer.future,
+          throwsDioException(
+            DioExceptionType.cancel,
+            stackTraceContains: 'test/download_stream_tests.dart',
+          ),
+        );
+      });
 
-    test('cancels download mid request', () async {
-      final cancelToken = CancelToken();
-      final path = p.join(tmp.path, 'download_2.txt');
+      test('cancels download', () async {
+        final cancelToken = CancelToken();
+        final path = p.join(tmp.path, 'download.txt');
 
-      await expectLater(
-        dio.download(
-          '/bytes/${1024 * 1024 * 10}',
-          path,
+        Future.delayed(const Duration(milliseconds: 50), () {
+          cancelToken.cancel();
+        });
+
+        await expectLater(
+          dio.download(
+            '/drip',
+            path,
+            queryParameters: {'duration': '5', 'delay': '0'},
+            cancelToken: cancelToken,
+          ),
+          throwsDioException(
+            DioExceptionType.cancel,
+            stackTraceContains: 'test/download_stream_tests.dart',
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 250), () {});
+        expect(File(path).existsSync(), false);
+      });
+
+      test('cancels streamed response mid request', () async {
+        final cancelToken = CancelToken();
+        final response = await dio.get(
+          '/bytes/${1024 * 1024 * 100}',
+          options: Options(responseType: ResponseType.stream),
           cancelToken: cancelToken,
           onReceiveProgress: (c, t) {
             if (c > 5000) {
               cancelToken.cancel();
             }
           },
-        ),
-        throwsDioException(
-          DioExceptionType.cancel,
-          stackTraceContains: 'test/download_stream_tests.dart',
-        ),
-      );
+        );
 
-      await Future.delayed(const Duration(milliseconds: 250), () {});
-      expect(File(path).existsSync(), false);
-    });
-  }, testOn: 'vm');
+        await expectLater(
+          (response.data as ResponseBody).stream.last,
+          throwsDioException(
+            DioExceptionType.cancel,
+            stackTraceContains: 'test/download_stream_tests.dart',
+          ),
+        );
+      });
+
+      test('cancels download mid request', () async {
+        final cancelToken = CancelToken();
+        final path = p.join(tmp.path, 'download_2.txt');
+
+        await expectLater(
+          dio.download(
+            '/bytes/${1024 * 1024 * 10}',
+            path,
+            cancelToken: cancelToken,
+            onReceiveProgress: (c, t) {
+              if (c > 5000) {
+                cancelToken.cancel();
+              }
+            },
+          ),
+          throwsDioException(
+            DioExceptionType.cancel,
+            stackTraceContains: 'test/download_stream_tests.dart',
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 250), () {});
+        expect(File(path).existsSync(), false);
+      });
+    },
+    testOn: 'vm',
+  );
 }

--- a/dio_test/lib/src/test/headers_tests.dart
+++ b/dio_test/lib/src/test/headers_tests.dart
@@ -28,5 +28,26 @@ void headerTests(
         equals('value1, value2'),
       );
     });
+
+    test('header value types implicit support', () async {
+      final res = await dio.post(
+        '/post',
+        data: 'TEST',
+        options: Options(
+          headers: {
+            'ListKey': ['1', '2'],
+            'StringKey': '1',
+            'NumKey': 2,
+            'BooleanKey': false,
+          },
+        ),
+      );
+      final content = res.data.toString();
+      expect(content, contains('TEST'));
+      expect(content, contains('Listkey: 1, 2'));
+      expect(content, contains('Stringkey: 1'));
+      expect(content, contains('Numkey: 2'));
+      expect(content, contains('Booleankey: false'));
+    });
   });
 }

--- a/dio_test/lib/src/test/http_method_tests.dart
+++ b/dio_test/lib/src/test/http_method_tests.dart
@@ -34,22 +34,26 @@ void httpMethodTests(
         expect(response.data['args'], {'id': '12', 'name': 'wendu'});
       });
 
-      test('GET with content', () async {
-        final response = await dio.get(
-          '/anything',
-          queryParameters: {'id': '12', 'name': 'wendu'},
-          data: data,
-        );
-        expect(response.statusCode, 200);
-        expect(response.isRedirect, isFalse);
-        expect(response.data['method'], 'GET');
-        expect(response.data['args'], {'id': '12', 'name': 'wendu'});
-        expect(response.data['json'], data);
-        expect(
-          response.data['headers']['Content-Type'],
-          Headers.jsonContentType,
-        );
-      }, testOn: '!browser');
+      test(
+        'GET with content',
+        () async {
+          final response = await dio.get(
+            '/anything',
+            queryParameters: {'id': '12', 'name': 'wendu'},
+            data: data,
+          );
+          expect(response.statusCode, 200);
+          expect(response.isRedirect, isFalse);
+          expect(response.data['method'], 'GET');
+          expect(response.data['args'], {'id': '12', 'name': 'wendu'});
+          expect(response.data['json'], data);
+          expect(
+            response.data['headers']['Content-Type'],
+            Headers.jsonContentType,
+          );
+        },
+        testOn: '!browser',
+      );
 
       test('POST', () async {
         final response = await dio.post(
@@ -141,23 +145,27 @@ void httpMethodTests(
       });
 
       // Not supported on web
-      test('GET with content', () async {
-        final response = await dio.getUri(
-          Uri(
-            path: '/anything',
-            queryParameters: {'id': '12', 'name': 'wendu'},
-          ),
-          data: data,
-        );
-        expect(response.statusCode, 200);
-        expect(response.isRedirect, isFalse);
-        expect(response.data['args'], {'id': '12', 'name': 'wendu'});
-        expect(response.data['json'], data);
-        expect(
-          response.data['headers']['Content-Type'],
-          Headers.jsonContentType,
-        );
-      }, testOn: '!browser');
+      test(
+        'GET with content',
+        () async {
+          final response = await dio.getUri(
+            Uri(
+              path: '/anything',
+              queryParameters: {'id': '12', 'name': 'wendu'},
+            ),
+            data: data,
+          );
+          expect(response.statusCode, 200);
+          expect(response.isRedirect, isFalse);
+          expect(response.data['args'], {'id': '12', 'name': 'wendu'});
+          expect(response.data['json'], data);
+          expect(
+            response.data['headers']['Content-Type'],
+            Headers.jsonContentType,
+          );
+        },
+        testOn: '!browser',
+      );
 
       test('POST', () async {
         final response = await dio.postUri(

--- a/dio_test/lib/src/test/redirect_tests.dart
+++ b/dio_test/lib/src/test/redirect_tests.dart
@@ -48,5 +48,27 @@ void redirectTests(
         expect(ri.method, 'GET');
       }
     });
+
+    test(
+      'empty location',
+      () async {
+        final response = await dio.get(
+          '/redirect',
+        );
+        expect(response.isRedirect, isTrue);
+        expect(response.redirects.length, 1);
+
+        final ri = response.redirects.first;
+        expect(ri.statusCode, 302);
+        expect(ri.location.path, '/get');
+        expect(ri.method, 'GET');
+      },
+      skip: 'Httpbun does not support empty location redirects',
+    );
+
+    test('request with redirect', () async {
+      final res = await dio.get('/absolute-redirect/2');
+      expect(res.statusCode, 200);
+    });
   });
 }

--- a/dio_test/lib/src/test/status_code_tests.dart
+++ b/dio_test/lib/src/test/status_code_tests.dart
@@ -13,7 +13,7 @@ void statusCodeTests(
 
   group('status code', () {
     for (final code in [400, 401, 404, 500, 503]) {
-      test('$code', () async {
+      test('$code', () {
         expect(
           dio.get('/status/$code'),
           throwsDioException(
@@ -28,5 +28,34 @@ void statusCodeTests(
         );
       });
     }
+  });
+
+  group(ValidateStatus, () {
+    test('200 with validateStatus => false', () {
+      expect(
+        dio.get(
+          '/status/200',
+          options: Options(validateStatus: (status) => false),
+        ),
+        throwsDioException(
+          DioExceptionType.badResponse,
+          stackTraceContains: kIsWeb ? null : 'test/status_code_tests.dart',
+          matcher: isA<DioException>().having(
+            (e) => e.response!.statusCode,
+            'statusCode',
+            equals(200),
+          ),
+        ),
+      );
+    });
+
+    test('500 with validateStatus => true', () async {
+      final response = await dio.get(
+        '/status/500',
+        options: Options(validateStatus: (status) => true),
+      );
+
+      expect(response.statusCode, 500);
+    });
   });
 }

--- a/dio_test/lib/src/test/suite.dart
+++ b/dio_test/lib/src/test/suite.dart
@@ -6,6 +6,7 @@ typedef TestSuiteFunction = void Function(
 );
 
 const _tests = [
+  basicTests,
   corsTests,
   downloadStreamTests,
   headerTests,

--- a/dio_test/lib/src/test/timeout_tests.dart
+++ b/dio_test/lib/src/test/timeout_tests.dart
@@ -39,35 +39,39 @@ void timeoutTests(
         );
       });
 
-      test('with streamed response', () async {
-        dio.options.receiveTimeout = Duration(seconds: 1);
-        final completer = Completer<void>();
-        final streamedResponse = await dio.get(
-          '/drip',
-          queryParameters: {'delay': 0, 'duration': 20},
-          options: Options(responseType: ResponseType.stream),
-        );
-        (streamedResponse.data as ResponseBody).stream.listen(
-          (event) {},
-          onError: (error) {
-            if (!completer.isCompleted) {
-              completer.completeError(error);
-            }
-          },
-          onDone: () {
-            if (!completer.isCompleted) {
-              completer.complete();
-            }
-          },
-        );
-        await expectLater(
-          completer.future,
-          throwsDioException(
-            DioExceptionType.receiveTimeout,
-            messageContains: dio.options.receiveTimeout.toString(),
-          ),
-        );
-      }, testOn: 'vm');
+      test(
+        'with streamed response',
+        () async {
+          dio.options.receiveTimeout = Duration(seconds: 1);
+          final completer = Completer<void>();
+          final streamedResponse = await dio.get(
+            '/drip',
+            queryParameters: {'delay': 0, 'duration': 20},
+            options: Options(responseType: ResponseType.stream),
+          );
+          (streamedResponse.data as ResponseBody).stream.listen(
+            (event) {},
+            onError: (error) {
+              if (!completer.isCompleted) {
+                completer.completeError(error);
+              }
+            },
+            onDone: () {
+              if (!completer.isCompleted) {
+                completer.complete();
+              }
+            },
+          );
+          await expectLater(
+            completer.future,
+            throwsDioException(
+              DioExceptionType.receiveTimeout,
+              messageContains: dio.options.receiveTimeout.toString(),
+            ),
+          );
+        },
+        testOn: 'vm',
+      );
     });
   });
 

--- a/dio_test/lib/tests.dart
+++ b/dio_test/lib/tests.dart
@@ -1,3 +1,4 @@
+export 'src/test/basic_tests.dart';
 export 'src/test/cors_tests.dart';
 export 'src/test/download_stream_tests.dart';
 export 'src/test/headers_tests.dart';

--- a/plugins/compatibility_layer/dart_test.yaml
+++ b/plugins/compatibility_layer/dart_test.yaml
@@ -11,3 +11,6 @@ override_platforms:
     settings:
       # headless argument has to be set explicitly for non-chrome browsers
       arguments: --headless
+      executable:
+        # https://github.com/dart-lang/test/pull/2195
+        mac_os: '/Applications/Firefox.app/Contents/MacOS/firefox'

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-*None.*
+- Wrap `SocketException` in `DioExceptionType.connectionError`
+  instead of `DioExceptionType.unknown`.
 
 ## 2.5.0
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -58,6 +58,26 @@ class Http2Adapter implements HttpClientAdapter {
         return await onNotSupported!(options, requestStream, cancelFuture, e);
       }
       return await fallbackAdapter.fetch(options, requestStream, cancelFuture);
+    } on SocketException catch (e) {
+      if (e.message.contains('timed out')) {
+        final Duration effectiveTimeout;
+        if (options.connectTimeout != null &&
+            options.connectTimeout! > Duration.zero) {
+          effectiveTimeout = options.connectTimeout!;
+        } else {
+          effectiveTimeout = Duration.zero;
+        }
+        throw DioException.connectionTimeout(
+          requestOptions: options,
+          timeout: effectiveTimeout,
+          error: e,
+        );
+      }
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: e.message,
+        error: e,
+      );
     }
   }
 

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -4,12 +4,6 @@ import 'package:dio_test/util.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('works with non-TLS requests', () async {
-    final dio = Dio()..httpClientAdapter = Http2Adapter(ConnectionManager());
-    await dio.get('https://flutter.cn/');
-    await dio.get('https://flutter.cn/non-exist-destination');
-  });
-
   test('handles gracefully if H2 is not supported', () async {
     const destinationHost = 'www.baidu.com';
     final destination = Uri.https(destinationHost);
@@ -55,39 +49,6 @@ void main() {
     );
   });
 
-  test('adds one to input values', () async {
-    final dio = Dio()
-      ..options.baseUrl = httpbunBaseUrl
-      ..httpClientAdapter = Http2Adapter(
-        ConnectionManager(
-          idleTimeout: Duration(milliseconds: 10),
-          onClientCreate: (_, config) => config.onBadCertificate = (_) => true,
-        ),
-      );
-
-    Response<String> response;
-    response = await dio.get('/get');
-    assert(response.statusCode == 200);
-    response = await dio.get(
-      '/nkjnjknjn.html',
-      options: Options(validateStatus: (status) => true),
-    );
-    assert(response.statusCode == 404);
-  });
-
-  test('request with payload', () async {
-    final dio = Dio()
-      ..options.baseUrl = httpbunBaseUrl
-      ..httpClientAdapter = Http2Adapter(
-        ConnectionManager(
-          idleTimeout: Duration(milliseconds: 10),
-        ),
-      );
-
-    final res = await dio.post('/post', data: 'TEST');
-    expect(res.data.toString(), contains('TEST'));
-  });
-
   test(
     'request with payload via proxy',
     () async {
@@ -130,126 +91,6 @@ void main() {
     }
     final res = await dio.post('/post', data: 'TEST');
     expect(res.data.toString(), contains('TEST'));
-  });
-
-  test('catch DioException when receiveTimeout', () {
-    final dio = Dio(
-      BaseOptions(
-        baseUrl: httpbunBaseUrl,
-        receiveTimeout: Duration(seconds: 5),
-      ),
-    );
-    dio.httpClientAdapter = Http2Adapter(
-      ConnectionManager(
-        idleTimeout: Duration(milliseconds: 10),
-      ),
-    );
-
-    expectLater(
-      dio.get('/drip?delay=10&numbytes=1'),
-      allOf([
-        throwsA(isA<DioException>()),
-        throwsA(predicate(
-            (DioException e) => e.type == DioExceptionType.receiveTimeout)),
-        throwsA(predicate(
-            (DioException e) => e.message!.contains('0:00:05.000000'))),
-      ]),
-    );
-  });
-
-  test('no DioException when receiveTimeout > request duration', () async {
-    final dio = Dio(
-      BaseOptions(
-        baseUrl: httpbunBaseUrl,
-        receiveTimeout: Duration(seconds: 5),
-      ),
-    );
-    dio.httpClientAdapter = Http2Adapter(
-      ConnectionManager(
-        idleTimeout: Duration(milliseconds: 10),
-      ),
-    );
-
-    await dio.get('/drip?delay=1&numbytes=1');
-  });
-
-  group('redirects', () {
-    final dio = Dio()
-      ..options.baseUrl = httpbunBaseUrl
-      ..httpClientAdapter = Http2Adapter(ConnectionManager());
-
-    test('single', () async {
-      final response = await dio.get(
-        '/redirect',
-        queryParameters: {'url': '$httpbunBaseUrl/get'},
-      );
-      expect(response.isRedirect, isTrue);
-      expect(response.redirects.length, 1);
-
-      final ri = response.redirects.first;
-      expect(ri.statusCode, 302);
-      expect(ri.location.path, '/get');
-      expect(ri.method, 'GET');
-    });
-
-    test(
-      'empty location',
-      () async {
-        final response = await dio.get(
-          '/redirect',
-        );
-        expect(response.isRedirect, isTrue);
-        expect(response.redirects.length, 1);
-
-        final ri = response.redirects.first;
-        expect(ri.statusCode, 302);
-        expect(ri.location.path, '/get');
-        expect(ri.method, 'GET');
-      },
-      skip: 'Httpbun does not support empty location redirects',
-    );
-
-    test('multiple', () async {
-      final response = await dio.get(
-        '/redirect/3',
-      );
-      expect(response.isRedirect, isTrue);
-      expect(response.redirects.length, 3);
-
-      final ri = response.redirects.first;
-      expect(ri.statusCode, 302);
-      expect(ri.method, 'GET');
-    });
-
-    test('request with redirect', () async {
-      final res = await dio.get('/absolute-redirect/2');
-      expect(res.statusCode, 200);
-    });
-  });
-
-  test('header value types implicit support', () async {
-    final dio = Dio()
-      ..options.baseUrl = httpbunBaseUrl
-      ..httpClientAdapter = Http2Adapter(ConnectionManager());
-
-    final res = await dio.post(
-      '/post',
-      data: 'TEST',
-      options: Options(
-        headers: {
-          'ListKey': ['1', '2'],
-          'StringKey': '1',
-          'NumKey': 2,
-          'BooleanKey': false,
-        },
-      ),
-    );
-    final content = res.data.toString();
-    expect(content, contains('TEST'));
-    expect(content, contains('Listkey: 1, 2'));
-    expect(content, contains('Stringkey: 1'));
-    expect(content, contains('Numkey: 2'));
-    expect(content, contains('Booleankey: false'));
   });
 
   group(ProxyConnectedPredicate, () {


### PR DESCRIPTION
* move some tests from http2/dio to shared test project
* add some new tests for `validateStatus`
* wrap `SocketException` in `DioExceptionType.connectionError` instead of `DioExceptionType.unknown` in the `Http2Adapter` -> this brings the behavior in line with the default adapters

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
