### PR TITLE
Add constructor for DioExceptionType.badCertificate

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Raise the min Dart SDK version to 2.18.0.
+- Add constructor for `DioExceptionType.badCertificate`.
 
 ## 5.4.3+1
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -189,11 +189,9 @@ class IOHttpClientAdapter implements HttpClientAdapter {
         port,
       );
       if (!isCertApproved) {
-        throw DioException(
+        throw DioException.badCertificate(
           requestOptions: options,
-          type: DioExceptionType.badCertificate,
           error: responseStream.certificate,
-          message: 'The certificate of the response is not approved.',
         );
       }
     }

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -86,10 +86,10 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.badResponse,
-        message: _badResponseExceptionMessage(statusCode),
         requestOptions: requestOptions,
         response: response,
         error: null,
+        message: _badResponseExceptionMessage(statusCode),
       );
 
   factory DioException.connectionTimeout({
@@ -99,14 +99,14 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.connectionTimeout,
+        requestOptions: requestOptions,
+        response: null,
+        error: error,
         message: 'The request connection took longer than $timeout '
             'and it was aborted. '
             'To get rid of this exception, try raising the '
             'RequestOptions.connectTimeout above the duration of $timeout or '
             'improve the response time of the server.',
-        requestOptions: requestOptions,
-        response: null,
-        error: error,
       );
 
   factory DioException.sendTimeout({
@@ -115,14 +115,14 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.sendTimeout,
+        requestOptions: requestOptions,
+        response: null,
+        error: null,
         message: 'The request took longer than $timeout to send data. '
             'It was aborted. '
             'To get rid of this exception, try raising the '
             'RequestOptions.sendTimeout above the duration of $timeout or '
             'improve the response time of the server.',
-        requestOptions: requestOptions,
-        response: null,
-        error: null,
       );
 
   factory DioException.receiveTimeout({
@@ -132,14 +132,14 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.receiveTimeout,
+        requestOptions: requestOptions,
+        response: null,
+        error: error,
         message: 'The request took longer than $timeout to receive data. '
             'It was aborted. '
             'To get rid of this exception, try raising the '
             'RequestOptions.receiveTimeout above the duration of $timeout or '
             'improve the response time of the server.',
-        requestOptions: requestOptions,
-        response: null,
-        error: error,
       );
 
   factory DioException.badCertificate({
@@ -148,10 +148,10 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.badCertificate,
-        message: 'The certificate of the response is not approved.',
         requestOptions: requestOptions,
         response: null,
         error: error,
+        message: 'The certificate of the response is not approved.',
       );
 
   factory DioException.requestCancelled({
@@ -161,11 +161,11 @@ class DioException implements Exception {
   }) =>
       DioException(
         type: DioExceptionType.cancel,
-        message: 'The request was manually cancelled by the user.',
         requestOptions: requestOptions,
         response: null,
         error: reason,
         stackTrace: stackTrace,
+        message: 'The request was manually cancelled by the user.',
       );
 
   factory DioException.connectionError({

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -18,7 +18,7 @@ enum DioExceptionType {
   /// It occurs when url is sent timeout.
   sendTimeout,
 
-  ///It occurs when receiving timeout.
+  /// It occurs when receiving timeout.
   receiveTimeout,
 
   /// Caused by an incorrect certificate as configured by [ValidateCertificate].
@@ -137,6 +137,18 @@ class DioException implements Exception {
             'To get rid of this exception, try raising the '
             'RequestOptions.receiveTimeout above the duration of $timeout or '
             'improve the response time of the server.',
+        requestOptions: requestOptions,
+        response: null,
+        error: error,
+      );
+
+  factory DioException.badCertificate({
+    required RequestOptions requestOptions,
+    Object? error,
+  }) =>
+      DioException(
+        type: DioExceptionType.badCertificate,
+        message: 'The certificate of the response is not approved.',
         requestOptions: requestOptions,
         response: null,
         error: error,

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -51,13 +51,13 @@ class LogInterceptor extends Interceptor {
   /// Log printer; defaults print log to console.
   /// In flutter, you'd better use debugPrint.
   /// you can also write log in a file, for example:
-  ///```dart
+  /// ```dart
   ///  final file=File("./log.txt");
   ///  final sink=file.openWrite();
   ///  dio.interceptors.add(LogInterceptor(logPrint: sink.writeln));
   ///  ...
   ///  await sink.close();
-  ///```
+  /// ```
   void Function(Object object) logPrint;
 
   @override

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -107,6 +107,7 @@ class _ConnectionManager implements ConnectionManager {
         uri.port,
       );
       if (!isCertApproved) {
+        // TODO(EVERYONE): Replace with DioException.badCertificate once upgrade dependencies Dio above 5.4.2.
         throw DioException(
           requestOptions: options,
           type: DioExceptionType.badCertificate,


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

- Improve some document comments.
- Change the parameter position of `DioException`'s constructors to make it most readable.
- Add constructor for `DioExceptionType.badCertificate`. There is also one reference in the plugin `http2_adapter`. But I don't know if changing that with an upgraded version is necessary.
https://github.com/cfug/dio/blob/1c2843a2fab1c3795272df1e81502616761e192e/plugins/http2_adapter/lib/src/connection_manager_imp.dart#L110-L115

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
