### PR TITLE
Transformer documentation updates

### DIFF
--- a/dio/README.md
+++ b/dio/README.md
@@ -723,7 +723,6 @@ Future<void> _repeatedlyRequest() async {
 
 `Transformer` allows changes to the request/response data
 before it is sent/received to/from the server.
-This is only applicable for request methods 'PUT', 'POST', and 'PATCH'.
 Dio has already implemented a `BackgroundTransformer` as default, 
 which calls `jsonDecode` in an isolate if the response is larger than 50 KB.
 If you want to customize the transformation of request/response data,


### PR DESCRIPTION
Updated the documentation to reflect that `BackgroundTransformer` is the new default transformer.

- added information about BackgroundTransformer
- removed the outdated & deprecated code example
- removed outdated info about methods (only applies to transformRequest, as explained in next paragraph)
- updated TOC

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package


