### PR TITLE
Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "infra"
+      - "github-actions"


### PR DESCRIPTION
This should keep our workflows up-to-date.
@AlexV525 You removed the last dependabot configuration while migrating from diox. But I think it would be good to have this on.

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
