### PR TITLE
Fix coverage comment from forks

### DIFF
--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -22,10 +22,16 @@ jobs:
           workflow: tests.yml
           workflow_conclusion: success
           run_id: ${{ github.event.workflow_run.id }}
-          name: code-coverage-results.md
+          name: code-coverage-results
+      - name: Determine PR number
+        id: pr-number
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          echo "Found PR:$PR_NUMBER"
+          echo "value=$PR_NUMBER" >> $GITHUB_OUTPUT
       - name: Add PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.pr-number.outputs.value }}
           recreate: true
           path: code-coverage-results.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,9 +103,14 @@ jobs:
         with:
           artifact_download_workflow_names: 'Verify packages abilities,coverage_baseline'
           filename: 'coverage/cobertura.xml'
+      - name: '[Coverage] Write PR number to file'
+        if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
+        run: echo ${{ github.event.number }} > pr_number.txt
       - name: '[Coverage] Upload'
         if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-results.md
-          path: code-coverage-results.md
+          name: code-coverage-results
+          path: |
+            code-coverage-results.md
+            pr_number.txt


### PR DESCRIPTION
When the coverage_comment workflow is triggered from a PR that originates from a fork, then the workflow event does not contain the PR number. But we need the PR number to attach the sticky coverage comment. So workaround this by storing the PR number in the workflow artifact that also contains the coverage result.

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
