### PR TITLE
Update coverage report action

### DIFF
--- a/.github/workflows/coverage_base.yml
+++ b/.github/workflows/coverage_base.yml
@@ -43,6 +43,6 @@ jobs:
         run: melos run test:flutter
       - name: '[Coverage] Generate report'
         run: melos run coverage:combine
-      - uses: clearlyip/code-coverage-report-action@v4
+      - uses: clearlyip/code-coverage-report-action@v5
         with:
           filename: 'coverage/cobertura.xml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,12 +97,13 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
         run: melos run coverage:show
       - name: '[Coverage] Create Report'
-        uses: clearlyip/code-coverage-report-action@v4
+        uses: clearlyip/code-coverage-report-action@v5
         id: code_coverage_report
         if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
         with:
           artifact_download_workflow_names: 'Verify packages abilities,coverage_baseline'
           filename: 'coverage/cobertura.xml'
+          only_list_changed_files: true
       - name: '[Coverage] Write PR number to file'
         if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
         run: echo ${{ github.event.number }} > pr_number.txt


### PR DESCRIPTION
The new version now supports listing individual changed files, not just packages and adds a flag that hides all files without changes to the coverage. We use that for the PR comment.

With https://github.com/VannaDii/pub-dev/pull/9 the `cobertura` package now also reports the correct line coverage.
 
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
