### PR TITLE
backport improved byte consolidation to SyncTransformer and BackgroundTranformer

### DIFF
--- a/dio/lib/src/transformers/sync_transformer.dart
+++ b/dio/lib/src/transformers/sync_transformer.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import '../adapter.dart';
 import '../headers.dart';
 import '../options.dart';
 import '../transformer.dart';
+import 'util/consolidate_bytes.dart';
 
 @Deprecated('Use BackgroundTransformer instead')
 typedef DefaultTransformer = SyncTransformer;
@@ -38,8 +38,7 @@ class SyncTransformer extends Transformer {
       return responseBody;
     }
 
-    final chunks = await responseBody.stream.toList();
-    final responseBytes = Uint8List.fromList(chunks.expand((c) => c).toList());
+    final responseBytes = await consolidateBytes(responseBody.stream);
 
     // Return the finalized bytes if the response type is bytes.
     if (responseType == ResponseType.bytes) {

--- a/dio/lib/src/transformers/util/consolidate_bytes.dart
+++ b/dio/lib/src/transformers/util/consolidate_bytes.dart
@@ -1,0 +1,12 @@
+import 'dart:typed_data';
+
+/// Consolidates a stream of [Uint8List] into a single [Uint8List]
+Future<Uint8List> consolidateBytes(Stream<Uint8List> stream) async {
+  final builder = BytesBuilder(copy: false);
+
+  await for (final chunk in stream) {
+    builder.add(chunk);
+  }
+
+  return builder.takeBytes();
+}

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:dio/src/transformers/util/consolidate_bytes.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -59,9 +60,7 @@ void main() {
   });
 
   group(FusedTransformer(), () {
-    test(
-        'transformResponse transforms json without content-length set in response',
-        () async {
+    test('transformResponse transforms json without content-length set in response', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.json),
@@ -153,8 +152,7 @@ void main() {
       expect(response, [1, 2, 3]);
     });
 
-    test('transformResponse handles when response stream has multiple chunks',
-        () async {
+    test('transformResponse handles when response stream has multiple chunks', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.bytes),
@@ -252,6 +250,30 @@ void main() {
         ),
       );
       expect(request, '{"foo":"bar"}');
+    });
+  });
+
+  group('consolidate bytes', () {
+    test('consolidates bytes from a stream', () async {
+      final stream = Stream.fromIterable([
+        Uint8List.fromList([1, 2, 3]),
+        Uint8List.fromList([4, 5, 6]),
+        Uint8List.fromList([7, 8, 9]),
+      ]);
+      final bytes = await consolidateBytes(stream);
+      expect(bytes, Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    });
+
+    test('handles empty stream', () async {
+      const stream = Stream<Uint8List>.empty();
+      final bytes = await consolidateBytes(stream);
+      expect(bytes, Uint8List(0));
+    });
+
+    test('handles empty lists', () async {
+      final stream = Stream.value(Uint8List(0));
+      final bytes = await consolidateBytes(stream);
+      expect(bytes, Uint8List(0));
     });
   });
 }

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -60,7 +60,9 @@ void main() {
   });
 
   group(FusedTransformer(), () {
-    test('transformResponse transforms json without content-length set in response', () async {
+    test(
+        'transformResponse transforms json without content-length set in response',
+        () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.json),
@@ -152,7 +154,8 @@ void main() {
       expect(response, [1, 2, 3]);
     });
 
-    test('transformResponse handles when response stream has multiple chunks', () async {
+    test('transformResponse handles when response stream has multiple chunks',
+        () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.bytes),


### PR DESCRIPTION
Follow up to #2239:

The more efficient Stream<UintList> -> Uint8List conversion can be backported to `SyncTransformer` & the extending `BackgroundTransformer`