### PR TITLE
Set FusedTransformer as default

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -11,8 +11,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Fix the type conversion regression when using `MultipartFile.fromBytes`.
 - Split the Web implementation to `package:dio_web_adapter`.
 - Add FusedTransformer for improved performance when decoding JSON.
-- Improves `InterceptorState.toString()`.
 - Set FusedTransformer as the default transformer.
+- Improves `InterceptorState.toString()`.
 
 ## 5.4.3+1
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -12,6 +12,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Split the Web implementation to `package:dio_web_adapter`.
 - Add FusedTransformer for improved performance when decoding JSON.
 - Improves `InterceptorState.toString()`.
+- Set FusedTransformer as the default transformer.
 
 ## 5.4.3+1
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -40,9 +40,13 @@ abstract class DioMixin implements Dio {
 
   /// The default [Transformer] that transfers requests and responses
   /// into corresponding content to send.
+  /// For response bodies greater than 50KB, a new Isolate will be spawned to
+  /// decode the response body to JSON.
+  /// Taken from https://github.com/flutter/flutter/blob/135454af32477f815a7525073027a3ff9eff1bfd/packages/flutter/lib/src/services/asset_bundle.dart#L87-L93
+  /// 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
+  /// on a Pixel 4.
   @override
-  Transformer transformer =
-      FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
+  Transformer transformer = FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
 
   bool _closed = false;
 
@@ -432,8 +436,7 @@ abstract class DioMixin implements Dio {
 
         // The request has already been cancelled,
         // there is no need to listen for another cancellation.
-        if (state.data is DioException &&
-            state.data.type == DioExceptionType.cancel) {
+        if (state.data is DioException && state.data.type == DioExceptionType.cancel) {
           return handleError();
         }
         if (state.type == InterceptorResultType.next ||
@@ -455,9 +458,8 @@ abstract class DioMixin implements Dio {
 
     // Add request interceptors into the request flow.
     for (final interceptor in interceptors) {
-      final fun = interceptor is QueuedInterceptor
-          ? interceptor._handleRequest
-          : interceptor.onRequest;
+      final fun =
+          interceptor is QueuedInterceptor ? interceptor._handleRequest : interceptor.onRequest;
       future = future.then(requestInterceptorWrapper(fun));
     }
 
@@ -479,17 +481,14 @@ abstract class DioMixin implements Dio {
 
     // Add response interceptors into the request flow
     for (final interceptor in interceptors) {
-      final fun = interceptor is QueuedInterceptor
-          ? interceptor._handleResponse
-          : interceptor.onResponse;
+      final fun =
+          interceptor is QueuedInterceptor ? interceptor._handleResponse : interceptor.onResponse;
       future = future.then(responseInterceptorWrapper(fun));
     }
 
     // Add error handlers into the request flow.
     for (final interceptor in interceptors) {
-      final fun = interceptor is QueuedInterceptor
-          ? interceptor._handleError
-          : interceptor.onError;
+      final fun = interceptor is QueuedInterceptor ? interceptor._handleError : interceptor.onError;
       future = future.catchError(errorInterceptorWrapper(fun));
     }
     // Normalize errors, converts errors to [DioException].
@@ -585,8 +584,7 @@ abstract class DioMixin implements Dio {
         r' ABCDEFGHIJKLMNOPQRSTUVWXYZ   ^_'
         r'`abcdefghijklmnopqrstuvwxyz | ~ ';
     for (final int codeUnit in token.codeUnits) {
-      if (codeUnit >= validChars.length ||
-          validChars.codeUnitAt(codeUnit) == 0x20) {
+      if (codeUnit >= validChars.length || validChars.codeUnitAt(codeUnit) == 0x20) {
         return false;
       }
     }
@@ -619,8 +617,7 @@ abstract class DioMixin implements Dio {
           return false;
         });
       } else if (data is FormData) {
-        options.headers[Headers.contentTypeHeader] =
-            '${Headers.multipartFormDataContentType}; '
+        options.headers[Headers.contentTypeHeader] = '${Headers.multipartFormDataContentType}; '
             'boundary=${data.boundary}';
         stream = data.finalize();
         length = data.length;

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -46,8 +46,9 @@ abstract class DioMixin implements Dio {
   /// 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
   /// on a Pixel 4.
   @override
-  Transformer transformer =
-      FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
+  Transformer transformer = FusedTransformer(
+    contentLengthIsolateThreshold: 50 * 1024，
+  );
 
   bool _closed = false;
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -46,7 +46,8 @@ abstract class DioMixin implements Dio {
   /// 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
   /// on a Pixel 4.
   @override
-  Transformer transformer = FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
+  Transformer transformer =
+      FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
 
   bool _closed = false;
 
@@ -436,7 +437,8 @@ abstract class DioMixin implements Dio {
 
         // The request has already been cancelled,
         // there is no need to listen for another cancellation.
-        if (state.data is DioException && state.data.type == DioExceptionType.cancel) {
+        if (state.data is DioException &&
+            state.data.type == DioExceptionType.cancel) {
           return handleError();
         }
         if (state.type == InterceptorResultType.next ||
@@ -458,8 +460,9 @@ abstract class DioMixin implements Dio {
 
     // Add request interceptors into the request flow.
     for (final interceptor in interceptors) {
-      final fun =
-          interceptor is QueuedInterceptor ? interceptor._handleRequest : interceptor.onRequest;
+      final fun = interceptor is QueuedInterceptor
+          ? interceptor._handleRequest
+          : interceptor.onRequest;
       future = future.then(requestInterceptorWrapper(fun));
     }
 
@@ -481,14 +484,17 @@ abstract class DioMixin implements Dio {
 
     // Add response interceptors into the request flow
     for (final interceptor in interceptors) {
-      final fun =
-          interceptor is QueuedInterceptor ? interceptor._handleResponse : interceptor.onResponse;
+      final fun = interceptor is QueuedInterceptor
+          ? interceptor._handleResponse
+          : interceptor.onResponse;
       future = future.then(responseInterceptorWrapper(fun));
     }
 
     // Add error handlers into the request flow.
     for (final interceptor in interceptors) {
-      final fun = interceptor is QueuedInterceptor ? interceptor._handleError : interceptor.onError;
+      final fun = interceptor is QueuedInterceptor
+          ? interceptor._handleError
+          : interceptor.onError;
       future = future.catchError(errorInterceptorWrapper(fun));
     }
     // Normalize errors, converts errors to [DioException].
@@ -584,7 +590,8 @@ abstract class DioMixin implements Dio {
         r' ABCDEFGHIJKLMNOPQRSTUVWXYZ   ^_'
         r'`abcdefghijklmnopqrstuvwxyz | ~ ';
     for (final int codeUnit in token.codeUnits) {
-      if (codeUnit >= validChars.length || validChars.codeUnitAt(codeUnit) == 0x20) {
+      if (codeUnit >= validChars.length ||
+          validChars.codeUnitAt(codeUnit) == 0x20) {
         return false;
       }
     }
@@ -617,7 +624,8 @@ abstract class DioMixin implements Dio {
           return false;
         });
       } else if (data is FormData) {
-        options.headers[Headers.contentTypeHeader] = '${Headers.multipartFormDataContentType}; '
+        options.headers[Headers.contentTypeHeader] =
+            '${Headers.multipartFormDataContentType}; '
             'boundary=${data.boundary}';
         stream = data.finalize();
         length = data.length;

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -47,7 +47,7 @@ abstract class DioMixin implements Dio {
   /// on a Pixel 4.
   @override
   Transformer transformer = FusedTransformer(
-    contentLengthIsolateThreshold: 50 * 1024，
+    contentLengthIsolateThreshold: 50 * 1024,
   );
 
   bool _closed = false;

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -41,7 +41,8 @@ abstract class DioMixin implements Dio {
   /// The default [Transformer] that transfers requests and responses
   /// into corresponding content to send.
   @override
-  Transformer transformer = BackgroundTransformer();
+  Transformer transformer =
+      FusedTransformer(contentLengthIsolateThreshold: 50 * 1024);
 
   bool _closed = false;
 

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -23,7 +23,8 @@ class FusedTransformer extends Transformer {
   FusedTransformer({this.contentLengthIsolateThreshold = -1});
 
   /// Always decode the response in the same isolate
-  factory FusedTransformer.sync() => FusedTransformer(contentLengthIsolateThreshold: -1);
+  factory FusedTransformer.sync() =>
+      FusedTransformer(contentLengthIsolateThreshold: -1);
 
   // whether to switch decoding to an isolate for large responses
   // set to -1 to disable, 0 to always use isolate
@@ -104,9 +105,11 @@ class FusedTransformer extends Transformer {
     RequestOptions options,
     ResponseBody responseBody,
   ) async {
-    final contentLengthHeader = responseBody.headers[Headers.contentLengthHeader];
+    final contentLengthHeader =
+        responseBody.headers[Headers.contentLengthHeader];
 
-    final hasContentLengthHeader = contentLengthHeader != null && contentLengthHeader.isNotEmpty;
+    final hasContentLengthHeader =
+        contentLengthHeader != null && contentLengthHeader.isNotEmpty;
 
     // The content length of the response, either from the content-length header
     // of the response or the length of the eagerly decoded response bytes
@@ -136,8 +139,8 @@ class FusedTransformer extends Transformer {
     // - the content length, calculated from either
     //   the content-length header if present or the eagerly decoded response bytes,
     //   is greater than or equal to contentLengthIsolateThreshold
-    final shouldUseIsolate =
-        !(contentLengthIsolateThreshold < 0) && contentLength >= contentLengthIsolateThreshold;
+    final shouldUseIsolate = !(contentLengthIsolateThreshold < 0) &&
+        contentLength >= contentLengthIsolateThreshold;
     if (shouldUseIsolate) {
       // we can't send the stream to the isolate, so we need to decode the response bytes first
       return compute(

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -105,7 +105,9 @@ class FusedTransformer extends Transformer {
   }
 
   Future<Object?> _fastUtf8JsonDecode(
-      RequestOptions options, ResponseBody responseBody) async {
+    RequestOptions options,
+    ResponseBody responseBody,
+  ) async {
     final contentLengthHeader =
         responseBody.headers[Headers.contentLengthHeader];
 

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -23,8 +23,7 @@ class FusedTransformer extends Transformer {
   FusedTransformer({this.contentLengthIsolateThreshold = -1});
 
   /// Always decode the response in the same isolate
-  factory FusedTransformer.sync() =>
-      FusedTransformer(contentLengthIsolateThreshold: -1);
+  factory FusedTransformer.sync() => FusedTransformer(contentLengthIsolateThreshold: -1);
 
   // whether to switch decoding to an isolate for large responses
   // set to -1 to disable, 0 to always use isolate
@@ -92,9 +91,6 @@ class FusedTransformer extends Transformer {
     } else if (customResponseDecoder != null) {
       return decodedResponse;
     } else {
-      if (responseBytes.isEmpty) {
-        return '';
-      }
       // If the response is not JSON and no custom decoder was specified,
       // assume it is an utf8 string
       return utf8.decode(
@@ -108,11 +104,9 @@ class FusedTransformer extends Transformer {
     RequestOptions options,
     ResponseBody responseBody,
   ) async {
-    final contentLengthHeader =
-        responseBody.headers[Headers.contentLengthHeader];
+    final contentLengthHeader = responseBody.headers[Headers.contentLengthHeader];
 
-    final hasContentLengthHeader =
-        contentLengthHeader != null && contentLengthHeader.isNotEmpty;
+    final hasContentLengthHeader = contentLengthHeader != null && contentLengthHeader.isNotEmpty;
 
     // The content length of the response, either from the content-length header
     // of the response or the length of the eagerly decoded response bytes
@@ -142,8 +136,8 @@ class FusedTransformer extends Transformer {
     // - the content length, calculated from either
     //   the content-length header if present or the eagerly decoded response bytes,
     //   is greater than or equal to contentLengthIsolateThreshold
-    final shouldUseIsolate = !(contentLengthIsolateThreshold < 0) &&
-        contentLength >= contentLengthIsolateThreshold;
+    final shouldUseIsolate =
+        !(contentLengthIsolateThreshold < 0) && contentLength >= contentLengthIsolateThreshold;
     if (shouldUseIsolate) {
       // we can't send the stream to the isolate, so we need to decode the response bytes first
       return compute(

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -20,11 +20,14 @@ import 'util/consolidate_bytes.dart';
 /// but a custom threshold can be set to switch to an isolate for large responses by passing
 /// [contentLengthIsolateThreshold].
 class FusedTransformer extends Transformer {
-  FusedTransformer({this.contentLengthIsolateThreshold = -1});
+  FusedTransformer({
+    this.contentLengthIsolateThreshold = -1,
+  });
 
   /// Always decode the response in the same isolate
-  factory FusedTransformer.sync() =>
-      FusedTransformer(contentLengthIsolateThreshold: -1);
+  factory FusedTransformer.sync() => FusedTransformer(
+        contentLengthIsolateThreshold: -1,
+      );
 
   // whether to switch decoding to an isolate for large responses
   // set to -1 to disable, 0 to always use isolate

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -117,7 +117,8 @@ class FusedTransformer extends Transformer {
 
     // Successful HEAD requests don't have a response body, even if the content-length header
     // present.
-    final contentLengthHeaderImpliesContent = options.method != 'HEAD';
+    final mightNotHaveResponseBodyDespiteContentLength =
+        options.method == 'HEAD';
 
     // The eagerly decoded response bytes
     // which is set if the content length is not specified and
@@ -127,7 +128,8 @@ class FusedTransformer extends Transformer {
     // If the content length is not specified, we need to consolidate the stream
     // and count the bytes to determine if we should use an isolate
     // otherwise we use the content length header
-    if (!hasContentLengthHeader || !contentLengthHeaderImpliesContent) {
+    if (!hasContentLengthHeader ||
+        mightNotHaveResponseBodyDespiteContentLength) {
       responseBytes = await consolidateBytes(responseBody.stream);
       contentLength = responseBytes.length;
     } else {

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -186,6 +186,21 @@ void main() {
       expect(response, 'plain text');
     });
 
+    test('ResponseType.plain takes precedence over content-type', () async {
+      final transformer = FusedTransformer();
+      final response = await transformer.transformResponse(
+        RequestOptions(responseType: ResponseType.plain),
+        ResponseBody.fromString(
+          '{"text": "plain text"}',
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['application/json'],
+          },
+        ),
+      );
+      expect(response, '{"text": "plain text"}');
+    });
+
     test('transformResponse handles streams', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
@@ -253,6 +268,24 @@ void main() {
         ),
       );
       expect(request, '{"foo":"bar"}');
+    });
+
+    test(
+        'HEAD request with content-length but empty body should not return null',
+        () async {
+      final transformer = FusedTransformer();
+      final response = await transformer.transformResponse(
+        RequestOptions(responseType: ResponseType.json, method: 'HEAD'),
+        ResponseBody(
+          Stream.value(Uint8List(0)),
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['application/json'],
+            Headers.contentLengthHeader: ['123'],
+          },
+        ),
+      );
+      expect(response, null);
     });
   });
 

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -59,235 +59,240 @@ void main() {
     expect(jsonResponse, null);
   });
 
-  group(FusedTransformer(), () {
-    test(
-        'transformResponse transforms json without content-length set in response',
-        () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody.fromString(
-          '{"foo": "bar"}',
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-          },
-        ),
-      );
-      expect(response, {'foo': 'bar'});
-    });
-
-    test('transformResponse transforms json with content-length', () async {
-      final transformer = FusedTransformer();
-      const jsonString = '{"foo": "bar"}';
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody.fromString(
-          jsonString,
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-            Headers.contentLengthHeader: [
-              utf8.encode(jsonString).length.toString(),
-            ],
-          },
-        ),
-      );
-      expect(response, {'foo': 'bar'});
-    });
-
-    test('transforms json in background isolate', () async {
-      final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
-      final jsonString = '{"foo": "bar"}';
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody.fromString(
-          jsonString,
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-            Headers.contentLengthHeader: [
-              utf8.encode(jsonString).length.toString(),
-            ],
-          },
-        ),
-      );
-      expect(response, {'foo': 'bar'});
-    });
-
-    test('transformResponse transforms that arrives in many chunks', () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody(
-          Stream.fromIterable(
-              /* utf-8 encoding of {"foo": "bar"} */
-              [
-                Uint8List.fromList([123]),
-                Uint8List.fromList([34]),
-                Uint8List.fromList([102, 111, 111]),
-                Uint8List.fromList([34]),
-                Uint8List.fromList([58]),
-                Uint8List.fromList([34]),
-                Uint8List.fromList([98, 97, 114]),
-                Uint8List.fromList([34]),
-                Uint8List.fromList([125]),
-              ]),
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-          },
-        ),
-      );
-      expect(response, {'foo': 'bar'});
-    });
-
-    test('transformResponse handles bytes', () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.bytes),
-        ResponseBody.fromBytes(
-          [1, 2, 3],
-          200,
-        ),
-      );
-      expect(response, [1, 2, 3]);
-    });
-
-    test('transformResponse handles when response stream has multiple chunks',
-        () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.bytes),
-        ResponseBody(
-          Stream.fromIterable([
-            Uint8List.fromList([1, 2, 3]),
-            Uint8List.fromList([4, 5, 6]),
-            Uint8List.fromList([7, 8, 9]),
-          ]),
-          200,
-        ),
-      );
-      expect(response, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    });
-
-    test('transformResponse handles plain text', () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.plain),
-        ResponseBody.fromString(
-          'plain text',
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['text/plain'],
-          },
-        ),
-      );
-      expect(response, 'plain text');
-    });
-
-    test('ResponseType.plain takes precedence over content-type', () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.plain),
-        ResponseBody.fromString(
-          '{"text": "plain text"}',
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-          },
-        ),
-      );
-      expect(response, '{"text": "plain text"}');
-    });
-
-    test('transformResponse handles streams', () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.stream),
-        ResponseBody.fromBytes(
-          [1, 2, 3],
-          200,
-        ),
-      );
-      expect(response, isA<ResponseBody>());
-    });
-
-    test('null response body only when the response is JSON', () async {
-      final transformer = FusedTransformer();
-      for (final responseType in ResponseType.values) {
+  group(
+    FusedTransformer(),
+    () {
+      test(
+          'transformResponse transforms json without content-length set in response',
+          () async {
+        final transformer = FusedTransformer();
         final response = await transformer.transformResponse(
-          RequestOptions(responseType: responseType),
-          ResponseBody.fromBytes([], 200),
+          RequestOptions(responseType: ResponseType.json),
+          ResponseBody.fromString(
+            '{"foo": "bar"}',
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['application/json'],
+            },
+          ),
         );
-        switch (responseType) {
-          case ResponseType.json:
-          case ResponseType.plain:
-            expect(response, '');
-            break;
-          case ResponseType.stream:
-            expect(response, isA<ResponseBody>());
-            break;
-          case ResponseType.bytes:
-            expect(response, []);
-            break;
-          default:
-            throw AssertionError('Unknown response type: $responseType');
+        expect(response, {'foo': 'bar'});
+      });
+
+      test('transformResponse transforms json with content-length', () async {
+        final transformer = FusedTransformer();
+        const jsonString = '{"foo": "bar"}';
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.json),
+          ResponseBody.fromString(
+            jsonString,
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['application/json'],
+              Headers.contentLengthHeader: [
+                utf8.encode(jsonString).length.toString(),
+              ],
+            },
+          ),
+        );
+        expect(response, {'foo': 'bar'});
+      });
+
+      test('transforms json in background isolate', () async {
+        final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
+        final jsonString = '{"foo": "bar"}';
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.json),
+          ResponseBody.fromString(
+            jsonString,
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['application/json'],
+              Headers.contentLengthHeader: [
+                utf8.encode(jsonString).length.toString(),
+              ],
+            },
+          ),
+        );
+        expect(response, {'foo': 'bar'});
+      });
+
+      test('transformResponse transforms that arrives in many chunks',
+          () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.json),
+          ResponseBody(
+            Stream.fromIterable(
+                /* utf-8 encoding of {"foo": "bar"} */
+                [
+                  Uint8List.fromList([123]),
+                  Uint8List.fromList([34]),
+                  Uint8List.fromList([102, 111, 111]),
+                  Uint8List.fromList([34]),
+                  Uint8List.fromList([58]),
+                  Uint8List.fromList([34]),
+                  Uint8List.fromList([98, 97, 114]),
+                  Uint8List.fromList([34]),
+                  Uint8List.fromList([125]),
+                ]),
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['application/json'],
+            },
+          ),
+        );
+        expect(response, {'foo': 'bar'});
+      });
+
+      test('transformResponse handles bytes', () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.bytes),
+          ResponseBody.fromBytes(
+            [1, 2, 3],
+            200,
+          ),
+        );
+        expect(response, [1, 2, 3]);
+      });
+
+      test('transformResponse handles when response stream has multiple chunks',
+          () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.bytes),
+          ResponseBody(
+            Stream.fromIterable([
+              Uint8List.fromList([1, 2, 3]),
+              Uint8List.fromList([4, 5, 6]),
+              Uint8List.fromList([7, 8, 9]),
+            ]),
+            200,
+          ),
+        );
+        expect(response, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      });
+
+      test('transformResponse handles plain text', () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.plain),
+          ResponseBody.fromString(
+            'plain text',
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['text/plain'],
+            },
+          ),
+        );
+        expect(response, 'plain text');
+      });
+
+      test('ResponseType.plain takes precedence over content-type', () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.plain),
+          ResponseBody.fromString(
+            '{"text": "plain text"}',
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['application/json'],
+            },
+          ),
+        );
+        expect(response, '{"text": "plain text"}');
+      });
+
+      test('transformResponse handles streams', () async {
+        final transformer = FusedTransformer();
+        final response = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.stream),
+          ResponseBody.fromBytes(
+            [1, 2, 3],
+            200,
+          ),
+        );
+        expect(response, isA<ResponseBody>());
+      });
+
+      test('null response body only when the response is JSON', () async {
+        final transformer = FusedTransformer();
+        for (final responseType in ResponseType.values) {
+          final response = await transformer.transformResponse(
+            RequestOptions(responseType: responseType),
+            ResponseBody.fromBytes([], 200),
+          );
+          switch (responseType) {
+            case ResponseType.json:
+            case ResponseType.plain:
+              expect(response, '');
+              break;
+            case ResponseType.stream:
+              expect(response, isA<ResponseBody>());
+              break;
+            case ResponseType.bytes:
+              expect(response, []);
+              break;
+            default:
+              throw AssertionError('Unknown response type: $responseType');
+          }
         }
-      }
-      final jsonResponse = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody.fromBytes(
-          [],
-          200,
-          headers: {
-            Headers.contentTypeHeader: [Headers.jsonContentType],
-          },
-        ),
-      );
-      expect(jsonResponse, null);
-    });
+        final jsonResponse = await transformer.transformResponse(
+          RequestOptions(responseType: ResponseType.json),
+          ResponseBody.fromBytes(
+            [],
+            200,
+            headers: {
+              Headers.contentTypeHeader: [Headers.jsonContentType],
+            },
+          ),
+        );
+        expect(jsonResponse, null);
+      });
 
-    test('transform the request using urlencode', () async {
-      final transformer = FusedTransformer();
+      test('transform the request using urlencode', () async {
+        final transformer = FusedTransformer();
 
-      final request = await transformer.transformRequest(
-        RequestOptions(responseType: ResponseType.json, data: {'foo': 'bar'}),
-      );
-      expect(request, 'foo=bar');
-    });
+        final request = await transformer.transformRequest(
+          RequestOptions(responseType: ResponseType.json, data: {'foo': 'bar'}),
+        );
+        expect(request, 'foo=bar');
+      });
 
-    test('transform the request using json', () async {
-      final transformer = FusedTransformer();
+      test('transform the request using json', () async {
+        final transformer = FusedTransformer();
 
-      final request = await transformer.transformRequest(
-        RequestOptions(
-          responseType: ResponseType.json,
-          data: {'foo': 'bar'},
-          headers: {'Content-Type': 'application/json'},
-        ),
-      );
-      expect(request, '{"foo":"bar"}');
-    });
+        final request = await transformer.transformRequest(
+          RequestOptions(
+            responseType: ResponseType.json,
+            data: {'foo': 'bar'},
+            headers: {'Content-Type': 'application/json'},
+          ),
+        );
+        expect(request, '{"foo":"bar"}');
+      });
 
-    test(
+      test(
         'HEAD request with content-length but empty body should not return null',
         () async {
-      final transformer = FusedTransformer();
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json, method: 'HEAD'),
-        ResponseBody(
-          Stream.value(Uint8List(0)),
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-            Headers.contentLengthHeader: ['123'],
-          },
-        ),
+          final transformer = FusedTransformer();
+          final response = await transformer.transformResponse(
+            RequestOptions(responseType: ResponseType.json, method: 'HEAD'),
+            ResponseBody(
+              Stream.value(Uint8List(0)),
+              200,
+              headers: {
+                Headers.contentTypeHeader: ['application/json'],
+                Headers.contentLengthHeader: ['123'],
+              },
+            ),
+          );
+          expect(response, null);
+        },
       );
-      expect(response, null);
-    });
-  });
+    },
+  );
 
   group('consolidate bytes', () {
     test('consolidates bytes from a stream', () async {


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

Also fix three oversights in the transformer

- Fix parsing content as JSON when Content-Type is like `application/json` but `ResponseType == .plain`

- HEAD requests have an empty body, even when Content-Length is >0. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD . I did not take this into account. This is also fixed now.

- Respect custom decoders returning null 