### PR TITLE
Attempt to fix WASM compile errors

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -7,6 +7,10 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 *None.*
 
+## 5.5.0+1
+
+- Fix WASM compile errors after moving the web implementation to `dio_web_adapter`.
+
 ## 5.5.0
 
 - Raise the min Dart SDK version to 2.18.0.

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,10 +5,6 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
-
-## 5.5.0+1
-
 - Fix WASM compile errors after moving the web implementation to `dio_web_adapter`.
 
 ## 5.5.0

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import 'adapters/io_adapter.dart'
-    if (dart.library.js_interop) 'adapters/browser_adapter.dart'
     if (dart.library.html) 'adapters/browser_adapter.dart' as adapter;
 import 'headers.dart';
 import 'options.dart';

--- a/dio/lib/src/compute/compute.dart
+++ b/dio/lib/src/compute/compute.dart
@@ -25,8 +25,7 @@
 
 import 'dart:async';
 
-import 'compute_io.dart'
-    if (dart.library.html) 'compute_web.dart' as _c;
+import 'compute_io.dart' if (dart.library.html) 'compute_web.dart' as _c;
 
 /// Signature for the callback passed to [compute].
 ///

--- a/dio/lib/src/compute/compute.dart
+++ b/dio/lib/src/compute/compute.dart
@@ -26,7 +26,6 @@
 import 'dart:async';
 
 import 'compute_io.dart'
-    if (dart.library.js_interop) 'compute_web.dart'
     if (dart.library.html) 'compute_web.dart' as _c;
 
 /// Signature for the callback passed to [compute].

--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'adapter.dart';
 import 'cancel_token.dart';
 import 'dio/dio_for_native.dart'
-    if (dart.library.js_interop) 'dio/dio_for_browser.dart'
     if (dart.library.html) 'dio/dio_for_browser.dart';
 import 'dio_mixin.dart';
 import 'headers.dart';

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -16,7 +16,6 @@ import 'headers.dart';
 import 'interceptors/imply_content_type.dart';
 import 'options.dart';
 import 'progress_stream/io_progress_stream.dart'
-    if (dart.library.js_interop) 'progress_stream/browser_progress_stream.dart'
     if (dart.library.html) 'progress_stream/browser_progress_stream.dart';
 import 'response.dart';
 import 'response/response_stream_handler.dart';

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data' show Uint8List;
 import 'package:http_parser/http_parser.dart' show MediaType;
 
 import 'multipart_file/io_multipart_file.dart'
-    if (dart.library.js_interop) 'multipart_file/browser_multipart_file.dart'
     if (dart.library.html) 'multipart_file/browser_multipart_file.dart';
 import 'utils.dart';
 


### PR DESCRIPTION
From what understand, we added conditional `js_interop` imports that force `dart:html` imports into WASM builds.
Since we don't yet support WASM, I don't completely understand how it actually compiled to WASM before change.

For now we can just remove the conditional imports and add them back together with actual WASM support.
Hopefully fixes #2266 

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
