### PR TITLE
fix: improve fallback to null on empty responses

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-- Graceful handling of Responses with nonzero Content-Length, Content-Type json, but empty body
+- Graceful handling of responses with nonzero `Content-Length`, `Content-Type` json, but empty body
   - Empty responses are now transformed to `null`
 
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- graceful handling of Responses with nonzero Content-Length, Content-Type json, but empty body
+
 
 ## 5.6.0
 

--- a/dio/lib/src/transformers/util/transform_empty_to_null.dart
+++ b/dio/lib/src/transformers/util/transform_empty_to_null.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+/// A [StreamTransformer] that replaces an empty stream of Uint8List with a default value
+/// - the utf8-encoded string "null".
+/// Feeding an empty stream to a JSON decoder will throw an exception, so this transformer
+/// is used to prevent that; the JSON decoder will instead return null.
+class DefaultNullIfEmptyStreamTransformer
+    extends StreamTransformerBase<Uint8List, Uint8List> {
+  const DefaultNullIfEmptyStreamTransformer();
+
+  @override
+  Stream<Uint8List> bind(Stream<Uint8List> stream) {
+    return Stream.eventTransformed(
+      stream,
+      (sink) => _DefaultIfEmptyStreamSink(sink),
+    );
+  }
+}
+
+class _DefaultIfEmptyStreamSink implements EventSink<Uint8List> {
+  _DefaultIfEmptyStreamSink(this._outputSink);
+
+  /// Hard-coded constant for replacement value, "null"
+  static final Uint8List _nullUtf8Value =
+      Uint8List.fromList(const [110, 117, 108, 108]);
+
+  final EventSink<Uint8List> _outputSink;
+  bool _hasData = false;
+
+  @override
+  void add(Uint8List data) {
+    _hasData |= data.isNotEmpty;
+    _outputSink.add(data);
+  }
+
+  @override
+  void addError(e, [st]) => _outputSink.addError(e, st);
+
+  @override
+  void close() {
+    if (!_hasData) {
+      _outputSink.add(_nullUtf8Value);
+    }
+
+    _outputSink.close();
+  }
+}

--- a/dio/lib/src/transformers/util/transform_empty_to_null.dart
+++ b/dio/lib/src/transformers/util/transform_empty_to_null.dart
@@ -30,7 +30,7 @@ class _DefaultIfEmptyStreamSink implements EventSink<Uint8List> {
 
   @override
   void add(Uint8List data) {
-    _hasData |= data.isNotEmpty;
+    _hasData = _hasData || data.isNotEmpty;
     _outputSink.add(data);
   }
 

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -71,7 +71,9 @@ void main() {
   });
 
   group(FusedTransformer, () {
-    test('transformResponse transforms json without content-length set in response', () async {
+    test(
+        'transformResponse transforms json without content-length set in response',
+        () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.json),
@@ -187,7 +189,8 @@ void main() {
       expect(response, [1, 2, 3]);
     });
 
-    test('transformResponse handles when response stream has multiple chunks', () async {
+    test('transformResponse handles when response stream has multiple chunks',
+        () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.bytes),

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -71,9 +71,7 @@ void main() {
   });
 
   group(FusedTransformer, () {
-    test(
-        'transformResponse transforms json without content-length set in response',
-        () async {
+    test('transformResponse transforms json without content-length set in response', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.json),
@@ -149,24 +147,6 @@ void main() {
       );
       expect(response, {'foo': 'bar'});
     });
-    test('transforms json in background isolate', () async {
-      final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
-      final jsonString = '{"foo": "bar"}';
-      final response = await transformer.transformResponse(
-        RequestOptions(responseType: ResponseType.json),
-        ResponseBody.fromString(
-          jsonString,
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['application/json'],
-            Headers.contentLengthHeader: [
-              utf8.encode(jsonString).length.toString(),
-            ],
-          },
-        ),
-      );
-      expect(response, {'foo': 'bar'});
-    });
 
     test('transformResponse transforms that arrives in many chunks', () async {
       final transformer = FusedTransformer();
@@ -207,8 +187,7 @@ void main() {
       expect(response, [1, 2, 3]);
     });
 
-    test('transformResponse handles when response stream has multiple chunks',
-        () async {
+    test('transformResponse handles when response stream has multiple chunks', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(
         RequestOptions(responseType: ResponseType.bytes),


### PR DESCRIPTION
fixes #2279 

This improves handling of the following case:

- ResponseType is json
- Server Content-Type is json
- Server Content-Length is nonzero
- Response Body is empty

This can happen in some cases according to HTTP spec (e.g. HEAD requests), but some servers return responses like this (see #2279) also in other cases, even if it violates the HTTP spec.

With #2250, in some of these cases dio would throw an exception, which caused a regression for some users; see #2279
I do believe that dio should handle these cases for gracefully,

This PR brings back the previous behavior of returning null.  

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
