### PR TITLE
Use `@pragma('vm:awaiter-link')` for better stacktraces

### DIFF
--- a/dio/lib/src/cancel_token.dart
+++ b/dio/lib/src/cancel_token.dart
@@ -12,6 +12,7 @@ import 'options.dart';
 class CancelToken {
   CancelToken();
 
+  @pragma('vm:awaiter-link')
   final Completer<DioException> _completer = Completer<DioException>();
 
   /// Whether the [error] is thrown by [cancel].

--- a/dio/lib/src/compute/compute_io.dart
+++ b/dio/lib/src/compute/compute_io.dart
@@ -44,6 +44,7 @@ Future<R> compute<Q, R>(
     Timeline.finishSync();
   }
 
+  @pragma('vm:awaiter-link')
   final Completer<dynamic> completer = Completer<dynamic>();
   port.handler = (dynamic msg) {
     timeEndAndCleanup();

--- a/dio/lib/src/dio/dio_for_native.dart
+++ b/dio/lib/src/dio/dio_for_native.dart
@@ -98,6 +98,7 @@ class DioForNative with DioMixin implements Dio {
     RandomAccessFile raf = file.openSync(mode: FileMode.write);
 
     // Create a Completer to notify the success/error state.
+    @pragma('vm:awaiter-link')
     final completer = Completer<Response>();
     int received = 0;
 

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -22,6 +22,7 @@ const kReleaseMode = bool.fromEnvironment('dart.vm.product');
 /// [stream] is done. Unlike [store], [sink] remains open after [stream] is
 /// done.
 Future<void> writeStreamToSink<T>(Stream<T> stream, EventSink<T> sink) {
+  @pragma('vm:awaiter-link')
   final completer = Completer<void>();
   stream.listen(
     sink.add,

--- a/dio/test/utils.dart
+++ b/dio/test/utils.dart
@@ -186,6 +186,7 @@ class ByteStream extends StreamView<List<int>> {
 
   /// Collects the data of this stream in a [Uint8List].
   Future<Uint8List> toBytes() {
+    @pragma('vm:awaiter-link')
     final completer = Completer<Uint8List>();
     final sink = ByteConversionSink.withCallback(
       (bytes) => completer.complete(Uint8List.fromList(bytes)),

--- a/dio_test/lib/src/test/cancellation_tests.dart
+++ b/dio_test/lib/src/test/cancellation_tests.dart
@@ -48,7 +48,9 @@ void cancellationTests(
     test('cancel multiple requests with single token', () async {
       final token = CancelToken();
 
+      @pragma('vm:awaiter-link')
       final receiveSuccess1 = Completer();
+      @pragma('vm:awaiter-link')
       final receiveSuccess2 = Completer();
       final futures = [
         dio.get(

--- a/dio_test/lib/src/test/download_tests.dart
+++ b/dio_test/lib/src/test/download_tests.dart
@@ -65,6 +65,7 @@ void downloadTests(
           cancelToken.cancel();
         });
 
+        @pragma('vm:awaiter-link')
         final completer = Completer<Never>();
         res.data!.stream.listen(
           (event) {},

--- a/dio_test/lib/src/test/timeout_tests.dart
+++ b/dio_test/lib/src/test/timeout_tests.dart
@@ -44,6 +44,7 @@ void timeoutTests(
         'with streamed response',
         () async {
           dio.options.receiveTimeout = const Duration(seconds: 1);
+          @pragma('vm:awaiter-link')
           final completer = Completer<void>();
           final streamedResponse = await dio.get(
             '/drip',

--- a/plugins/compatibility_layer/lib/src/conversion_layer_adapter.dart
+++ b/plugins/compatibility_layer/lib/src/conversion_layer_adapter.dart
@@ -53,6 +53,7 @@ class ConversionLayerAdapter implements HttpClientAdapter {
         options.method,
         options.uri,
       );
+      @pragma('vm:awaiter-link')
       final completer = Completer<Uint8List>();
       final sink = ByteConversionSink.withCallback(
         (bytes) => completer.complete(

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -194,6 +194,7 @@ class _ConnectionManager implements ConnectionManager {
     proxySocket.write(crlf);
     proxySocket.write(crlf);
 
+    @pragma('vm:awaiter-link')
     final completerProxyInitialization = Completer<void>();
 
     Never onProxyError(Object? error, StackTrace stackTrace) {

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -162,6 +162,7 @@ class Http2Adapter implements HttpClientAdapter {
 
     final responseSink = StreamController<Uint8List>();
     final responseHeaders = Headers();
+    @pragma('vm:awaiter-link')
     final responseCompleter = Completer();
     late StreamSubscription responseSubscription;
     bool needRedirect = false;

--- a/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
@@ -54,6 +54,7 @@ class ConversionLayerAdapter implements HttpClientAdapter {
     request.maxRedirects = options.maxRedirects;
 
     if (requestStream != null) {
+      @pragma('vm:awaiter-link')
       final completer = Completer<Uint8List>();
       final sink = ByteConversionSink.withCallback(
         (bytes) => completer.complete(

--- a/plugins/web_adapter/lib/src/adapter.dart
+++ b/plugins/web_adapter/lib/src/adapter.dart
@@ -61,6 +61,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     final xhrTimeout = (connectTimeout + receiveTimeout).inMilliseconds;
     xhr.timeout = xhrTimeout;
 
+    @pragma('vm:awaiter-link')
     final completer = Completer<ResponseBody>();
 
     xhr.onLoad.first.then((_) {


### PR DESCRIPTION
Added the `@pragma('vm:awaiter-link')` annotation to each instance of `Completer`.
Closes #2291.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

N/A