### PR TITLE
♻️ Use `flutter-io.cn` rather than `neverssl.com`

### DIFF
--- a/dio_test/lib/src/test/basic_tests.dart
+++ b/dio_test/lib/src/test/basic_tests.dart
@@ -17,7 +17,7 @@ void basicTests(
   group('basic request', () {
     test(
       'works with non-TLS requests',
-      () => dio.get('http://flutter.cn/'),
+      () => dio.get('http://flutter-io.cn/'),
       testOn: 'vm',
     );
 

--- a/dio_test/lib/src/test/basic_tests.dart
+++ b/dio_test/lib/src/test/basic_tests.dart
@@ -17,7 +17,7 @@ void basicTests(
   group('basic request', () {
     test(
       'works with non-TLS requests',
-      () => dio.get('http://neverssl.com/'),
+      () => dio.get('http://flutter.cn/'),
       testOn: 'vm',
     );
 


### PR DESCRIPTION
NeverSSL no longer supports H2 headers upgrade without TLS. All alternatives I've searched are not supported:
- http://www.gstatic.com/generate_204
- http://http.badssl.com/
- http://flutter.dev/

Surprisingly, http://flutter-io.cn/ supports all functionality. 😮

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package
