### PR TITLE
chore(native_dio_adapter): support cupertino_http 2.0.0

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Support `cupertino_http` 2.0.0
 
 ## 1.3.0
 

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
     sdk: flutter
 
   dio: ^5.4.0
-  cupertino_http: ^1.0.0
-  cronet_http: '>=0.4.0 <=2.0.0'
+  cupertino_http: '>=1.0.0 <3.0.0'
+  cronet_http: '>=0.4.0 <2.0.0'
   http: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding 
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

supports cupertino_http ^2.0.0, which has to break changes that don't affect this package. 
No code changes. 

Also fix typo (`<=` -> `<` )  in pubspec.yaml which would support cronet_http 2.0.0, which is not released yet and might contain breaking changes which are not compatible with this package