### PR TITLE
Fix: Clarify the behavior of concurrent requests in QueuedInterceptor

### DIFF
--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -374,8 +374,9 @@ class _TaskQueue<T, V extends _BaseHandler> {
 
 /// [Interceptor] in queue.
 ///
-/// Concurrent requests' `onRequest`, `onResponse`, and `onError` are processed in three separate queues.
-/// These queues run in parallel, meaning a new request can be initiated before the previous one has completed.
+/// `onRequest`, `onResponse`, and `onError` are processed in separate queues
+/// when running concurrent requests. These queues run in parallel,
+/// new requests can be initiated before previous have been completed.
 class QueuedInterceptor extends Interceptor {
   final _requestQueue = _TaskQueue<RequestOptions, RequestInterceptorHandler>();
   final _responseQueue = _TaskQueue<Response, ResponseInterceptorHandler>();
@@ -431,7 +432,7 @@ class QueuedInterceptor extends Interceptor {
   }
 }
 
-/// A helper class to create queued-interceptors in ease.
+/// A helper class to create [QueuedInterceptor] in ease.
 ///
 /// See also:
 ///  - [InterceptorsWrapper], creates [Interceptor]s in ease.

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -374,7 +374,8 @@ class _TaskQueue<T, V extends _BaseHandler> {
 
 /// [Interceptor] in queue.
 ///
-/// Concurrent requests will be added to the queue for interceptors.
+/// Concurrent requests' `onRequest`, `onResponse`, and `onError` are processed in three separate queues.
+/// These queues run in parallel, meaning a new request can be initiated before the previous one has completed.
 class QueuedInterceptor extends Interceptor {
   final _requestQueue = _TaskQueue<RequestOptions, RequestInterceptorHandler>();
   final _responseQueue = _TaskQueue<Response, ResponseInterceptorHandler>();


### PR DESCRIPTION
The previous documentation for `QueuedInterceptor` could lead to misunderstandings about how concurrent requests are handled. The explanation suggested that requests would have to wait for the previous request to complete before being initiated.

This update clarifies that requests are processed in three independent queues: `onRequest`, `onResponse`, and `onError`. These queues run in parallel.

<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
