### PR TITLE
🐛 Make cached connections respect redirections

### DIFF
--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Make cached connections respect redirections.
 
 ## 2.5.3
 

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+**Before you upgrade: Breaking changes might happen in major and minor versions of packages.<br/>
+See the [Migration Guide][] for the complete breaking changes list.**
+
 ## Unreleased
 
 - Make cached connections respect redirections.
@@ -80,3 +83,5 @@
 ## 0.0.2 - 2019.9.17
 
 - A Dio HttpAdapter which support Http/2.0.
+
+[Migration Guide]: doc/migration_guide.md

--- a/plugins/http2_adapter/doc/migration_guide.md
+++ b/plugins/http2_adapter/doc/migration_guide.md
@@ -1,0 +1,31 @@
+# Migration Guide
+
+This document gathered all breaking changes and migrations requirement between versions.
+
+<!--
+When new content need to be added to the migration guide, make sure they're following the format:
+1. Add a version in the *Breaking versions* section, with a version anchor.
+2. Use *Summary* and *Details* to introduce the migration.
+-->
+
+## Breaking versions
+
+- [2.6.0](#260)
+
+## 2.6.0
+
+### Summary
+
+- `ConnectionManager.getConnection` now requires redirection records as a parameter.
+
+### Details
+
+#### `ConnectionManager.getConnection`
+
+```diff
+ /// Get the connection(may reuse) for each request.
+ Future<ClientTransportConnection> getConnection(
+   RequestOptions options,
++  List<RedirectRecord> redirects,
+ );
+```

--- a/plugins/http2_adapter/lib/src/connection_manager.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager.dart
@@ -18,7 +18,10 @@ abstract class ConnectionManager {
       );
 
   /// Get the connection(may reuse) for each request.
-  Future<ClientTransportConnection> getConnection(RequestOptions options);
+  Future<ClientTransportConnection> getConnection(
+    RequestOptions options,
+    List<RedirectRecord> redirects,
+  );
 
   void removeConnection(ClientTransportConnection transport);
 

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -97,6 +97,58 @@ void main() {
     expect(res.data.toString(), contains('TEST'));
   });
 
+  group(ConnectionManager, () {
+    test('returns correct connection', () async {
+      final manager = ConnectionManager();
+      final tlsConnection = await manager.getConnection(
+        RequestOptions(path: 'https://flutter.cn'),
+        [],
+      );
+      final tlsWithSameHostRedirects = await manager.getConnection(
+        RequestOptions(path: 'https://flutter.cn'),
+        [
+          RedirectRecord(301, 'GET', Uri.parse('https://flutter.cn/404')),
+        ],
+      );
+      final tlsDifferentHostRedirects = await manager.getConnection(
+        RequestOptions(path: 'https://flutter.cn'),
+        [
+          RedirectRecord(301, 'GET', Uri.parse('https://flutter.dev')),
+        ],
+      );
+      final tlsDifferentHostsRedirects = await manager.getConnection(
+        RequestOptions(path: 'https://flutter.cn'),
+        [
+          RedirectRecord(301, 'GET', Uri.parse('https://flutter.dev')),
+          RedirectRecord(301, 'GET', Uri.parse('https://flutter.dev/404')),
+        ],
+      );
+      final nonTLSConnection = await manager.getConnection(
+        RequestOptions(path: 'http://flutter.cn'),
+        [],
+      );
+      final nonTLSConnectionWithTLSRedirects = await manager.getConnection(
+        RequestOptions(path: 'http://flutter.cn'),
+        [
+          RedirectRecord(301, 'GET', Uri.parse('https://flutter.cn/')),
+        ],
+      );
+      final differentHostConnection = await manager.getConnection(
+        RequestOptions(path: 'https://flutter.dev'),
+        [],
+      );
+      expect(tlsConnection == tlsWithSameHostRedirects, true);
+      expect(tlsConnection == tlsDifferentHostRedirects, false);
+      expect(tlsConnection == tlsDifferentHostsRedirects, false);
+      expect(tlsConnection == nonTLSConnection, false);
+      expect(tlsConnection == nonTLSConnectionWithTLSRedirects, true);
+      expect(tlsConnection == differentHostConnection, false);
+      expect(tlsDifferentHostRedirects == differentHostConnection, true);
+      expect(tlsDifferentHostsRedirects == differentHostConnection, true);
+      expect(nonTLSConnection == nonTLSConnectionWithTLSRedirects, false);
+    });
+  });
+
   group(ProxyConnectedPredicate, () {
     group('defaultProxyConnectedPredicate', () {
       test(

--- a/plugins/http2_adapter/test/redirect_test.dart
+++ b/plugins/http2_adapter/test/redirect_test.dart
@@ -2,15 +2,14 @@ import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(Http2Adapter.resolveRedirectUri, () {
+  group('Http2Adapter.resolveRedirectUri', () {
     test('empty location', () async {
       final current = Uri.parse('https://example.com');
       final result = Http2Adapter.resolveRedirectUri(
         current,
         Uri.parse(''),
       );
-
-      expect(result, current.toString());
+      expect(result.toString(), current.toString());
     });
 
     test('relative location 1', () async {
@@ -19,7 +18,7 @@ void main() {
         Uri.parse('/bar'),
       );
 
-      expect(result, 'https://example.com/bar');
+      expect(result.toString(), 'https://example.com/bar');
     });
 
     test('relative location 2', () async {
@@ -27,8 +26,7 @@ void main() {
         Uri.parse('https://example.com/foo'),
         Uri.parse('../bar'),
       );
-
-      expect(result, 'https://example.com/bar');
+      expect(result.toString(), 'https://example.com/bar');
     });
 
     test('different location', () async {
@@ -38,8 +36,7 @@ void main() {
         current,
         Uri.parse(target),
       );
-
-      expect(result, target);
+      expect(result.toString(), target);
     });
   });
 }


### PR DESCRIPTION
The connection manager now established the transport with the given redirection record rather than reusing the previous transport.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package