### PR TITLE
💚 Fix melos package script

### DIFF
--- a/scripts/melos_packages.dart
+++ b/scripts/melos_packages.dart
@@ -43,8 +43,18 @@ void main() async {
   final current = Version.parse(
     RegExp(r'\d*\.\d*\.\d*').firstMatch(Platform.version)!.group(0)!,
   );
-  final validPackages = packages
-      .where((e) => e.pubSpec.environment!.sdkConstraint!.allows(current));
+  final validPackages = packages.where((e) {
+    final dynamic package = e as dynamic;
+    bool allows;
+    try {
+      // Compatible with melos v6.3.
+      allows = package.pubspec.environment['dart']!.allows(current);
+    } on NoSuchMethodError {
+      // Fallback to previous melos.
+      allows = package.pubSpec.environment!.sdkConstraint!.allows(current);
+    }
+    return allows;
+  });
 
   // Create melos marker files
   for (final package in validPackages) {

--- a/scripts/melos_packages.dart
+++ b/scripts/melos_packages.dart
@@ -48,7 +48,7 @@ void main() async {
     bool allows;
     try {
       // Compatible with melos v6.3.
-      allows = package.pubspec.environment['dart']!.allows(current);
+      allows = package.pubspec.environment['sdk']!.allows(current);
     } on NoSuchMethodError {
       // Fallback to previous melos.
       allows = package.pubSpec.environment!.sdkConstraint!.allows(current);


### PR DESCRIPTION
https://pub.dev/packages/melos/versions/6.3.0/changelog

```console
scripts/melos_packages.dart:47:23: Error: The getter 'pubSpec' isn't defined for the class 'Package'.
 - 'Package' is from 'package:melos/src/package.dart' ('../../../.pub-cache/hosted/pub.dev/melos-6.3.1/lib/src/package.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'pubSpec'.
      .where((e) => e.pubSpec.environment!.sdkConstraint!.allows(current));
                      ^^^^^^^
```
