### PR TITLE
Fix: Resolve ListParam equality issue for caching identical requests

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,6 +9,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Removes redundant warnings when composing request options on Web.
 - Fixes boundary inconsistency in `FormData.clone()`.
 - Support `FileAccessMode` in `Dio.download` and `Dio.downloadUri` to change download file opening mode
+- Fix Ensure `ListParam` equality uses `DeepCollectionEquality` for proper caching and comparison.
 
 ## 5.7.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,7 +9,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Removes redundant warnings when composing request options on Web.
 - Fixes boundary inconsistency in `FormData.clone()`.
 - Support `FileAccessMode` in `Dio.download` and `Dio.downloadUri` to change download file opening mode
-- Fix Ensure `ListParam` equality uses `DeepCollectionEquality` for proper caching and comparison.
+- Fix `ListParam` equality by using the `DeepCollectionEquality`.
 
 ## 5.7.0
 

--- a/dio/lib/src/parameter.dart
+++ b/dio/lib/src/parameter.dart
@@ -32,6 +32,8 @@ class ListParam<T> {
           format == other.format;
 
   @override
-  int get hashCode =>
-      const DeepCollectionEquality().hash(value) ^ format.hashCode;
+  int get hashCode => Object.hash(
+        const DeepCollectionEquality().hash(value),
+        format,
+      );
 }

--- a/dio/lib/src/parameter.dart
+++ b/dio/lib/src/parameter.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'options.dart';
 
 /// Indicates a param being used as queries or form data,
@@ -26,9 +27,10 @@ class ListParam<T> {
       identical(this, other) ||
       other is ListParam &&
           runtimeType == other.runtimeType &&
-          value == other.value &&
+          const DeepCollectionEquality().equals(value, other.value) &&
           format == other.format;
 
   @override
-  int get hashCode => value.hashCode ^ format.hashCode;
+  int get hashCode =>
+      const DeepCollectionEquality().hash(value) ^ format.hashCode;
 }

--- a/dio/lib/src/parameter.dart
+++ b/dio/lib/src/parameter.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+
 import 'options.dart';
 
 /// Indicates a param being used as queries or form data,

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   async: ^2.8.2
-  collection: '^1.16.0'
+  collection: ^1.16.0
   http_parser: ^4.0.0
   meta: ^1.5.0
   path: ^1.8.0

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   path: ^1.8.0
 
   dio_web_adapter: '>=1.0.0 <3.0.0'
+  collection: ^1.19.1
 
 dev_dependencies:
   lints: any

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -24,9 +24,9 @@ dependencies:
   http_parser: ^4.0.0
   meta: ^1.5.0
   path: ^1.8.0
-
+  collection: '>=1.16.0 <2.0.0'
+  
   dio_web_adapter: '>=1.0.0 <3.0.0'
-  collection: ^1.19.1
 
 dev_dependencies:
   lints: any

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -21,11 +21,11 @@ environment:
 
 dependencies:
   async: ^2.8.2
+  collection: '^1.16.0'
   http_parser: ^4.0.0
   meta: ^1.5.0
   path: ^1.8.0
-  collection: '>=1.16.0 <2.0.0'
-  
+
   dio_web_adapter: '>=1.0.0 <3.0.0'
 
 dev_dependencies:

--- a/dio/test/parameter_test.dart
+++ b/dio/test/parameter_test.dart
@@ -1,0 +1,13 @@
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ListParam equality for Map key', () {
+    final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
+    final param2 = const ListParam(['item1', 'item2'], ListFormat.csv);
+
+    final cache = {param1: 'Cached Response'};
+
+    expect(cache.containsKey(param2), true, reason: 'param1 and param2 should be considered equal');
+  });
+}

--- a/dio/test/parameter_test.dart
+++ b/dio/test/parameter_test.dart
@@ -5,6 +5,8 @@ void main() {
   test('ListParam equality for Map key', () {
     final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
     final param2 = const ListParam(['item1', 'item2'], ListFormat.csv);
+    final param3 = const ListParam(['item3', 'item4'], ListFormat.csv);
+    final param4 = const ListParam(['item2', 'item1'], ListFormat.csv);
 
     final cache = {param1: 'Cached Response'};
 
@@ -12,6 +14,19 @@ void main() {
       cache.containsKey(param2),
       true,
       reason: 'param1 and param2 should be considered equal',
+    );
+
+    expect(
+      cache.containsKey(param3),
+      false,
+      reason: 'param1 and param3 should not be considered equal',
+    );
+
+    expect(
+      cache.containsKey(param4),
+      false,
+      reason:
+          'param1 and param4 should not be considered equal as order matters',
     );
   });
 }

--- a/dio/test/parameter_test.dart
+++ b/dio/test/parameter_test.dart
@@ -8,6 +8,10 @@ void main() {
 
     final cache = {param1: 'Cached Response'};
 
-    expect(cache.containsKey(param2), true, reason: 'param1 and param2 should be considered equal');
+    expect(
+      cache.containsKey(param2),
+      true,
+      reason: 'param1 and param2 should be considered equal',
+    );
   });
 }

--- a/dio/test/parameter_test.dart
+++ b/dio/test/parameter_test.dart
@@ -2,31 +2,23 @@ import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('ListParam equality for Map key', () {
-    final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
-    final param2 = const ListParam(['item1', 'item2'], ListFormat.csv);
-    final param3 = const ListParam(['item3', 'item4'], ListFormat.csv);
-    final param4 = const ListParam(['item2', 'item1'], ListFormat.csv);
+  group('ListParam', () {
+    test('param1 and param2 should be considered equal', () {
+      final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
+      final param2 = const ListParam(['item1', 'item2'], ListFormat.csv);
+      expect(param1 == param2, isTrue);
+    });
 
-    final cache = {param1: 'Cached Response'};
+    test('param1 and param3 should not be considered equal', () {
+      final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
+      final param3 = const ListParam(['item3', 'item4'], ListFormat.csv);
+      expect(param1 == param3, isFalse);
+    });
 
-    expect(
-      cache.containsKey(param2),
-      true,
-      reason: 'param1 and param2 should be considered equal',
-    );
-
-    expect(
-      cache.containsKey(param3),
-      false,
-      reason: 'param1 and param3 should not be considered equal',
-    );
-
-    expect(
-      cache.containsKey(param4),
-      false,
-      reason:
-          'param1 and param4 should not be considered equal as order matters',
-    );
+    test('Order matters: param1 and param4 should not be equal', () {
+      final param1 = const ListParam(['item1', 'item2'], ListFormat.csv);
+      final param4 = const ListParam(['item2', 'item1'], ListFormat.csv);
+      expect(param1 == param4, isFalse);
+    });
   });
 }


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### What this PR does

Resolves https://github.com/cfug/dio/issues/2364

This PR addresses an issue with ListParam equality, where identical requests were not recognized as the same due to reference comparison of lists. This caused multiple identical requests to be sent to the server, even when caching was implemented.

### Changes introduced

Updated ListParam's operator == to use DeepCollectionEquality for proper deep equality comparison of list contents.
Added relevant unit tests to validate the fix and ensure no regression.

<br/>

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

