### PR TITLE
Make `LogInterceptor` constant

### DIFF
--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -20,7 +20,7 @@ import '../response.dart';
 /// );
 /// ```
 class LogInterceptor extends Interceptor {
-  LogInterceptor({
+  const LogInterceptor({
     this.request = true,
     this.requestHeader = true,
     this.requestBody = false,
@@ -31,22 +31,22 @@ class LogInterceptor extends Interceptor {
   });
 
   /// Print request [Options]
-  bool request;
+  final bool request;
 
   /// Print request header [Options.headers]
-  bool requestHeader;
+  final bool requestHeader;
 
   /// Print request data [Options.data]
-  bool requestBody;
+  final bool requestBody;
 
   /// Print [Response.data]
-  bool responseBody;
+  final bool responseBody;
 
   /// Print [Response.headers]
-  bool responseHeader;
+  final bool responseHeader;
 
   /// Print error message
-  bool error;
+  final bool error;
 
   /// Log printer; defaults print log to console.
   /// In flutter, you'd better use debugPrint.
@@ -58,7 +58,7 @@ class LogInterceptor extends Interceptor {
   ///  ...
   ///  await sink.close();
   /// ```
-  void Function(Object object) logPrint;
+  final void Function(Object object) logPrint;
 
   @override
   void onRequest(


### PR DESCRIPTION
Just add the `const` keyword for `LogInterceptor` constructor and make all fields `final` for using it as default parameter. 

### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [X] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [X] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package
