### PR TITLE
fixed encode queryParameters to perpercent-encoded

### DIFF
--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -60,7 +60,7 @@ String encodeMap(
   final rightBracket = isQuery || !encode ? ']' : '%5D';
 
   final String Function(String) encodeComponent =
-      encode ? Uri.encodeQueryComponent : (e) => e;
+      encode ? Uri.encodeComponent : (e) => e;
   Object? maybeEncode(Object? value) {
     if (!isQuery || value == null || value is! String) {
       return value;


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

<!-- Provide more context and info about the PR. -->
#1603 
#1445 

现在queryParameters的编码使用的是`Uri.encodeQueryComponent`，这个方法使用的规范并不是常用的，通常使用perpercent-encoded是更常规的做法，比如把

空格转为成"%20"而不是"+"
