### PR TITLE
🐛 Do not allow update the error field after a cancel token has cancelled

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Do not allow update the error field after a cancel token has cancelled.
 
 ## 5.8.0+1
 

--- a/dio/lib/src/cancel_token.dart
+++ b/dio/lib/src/cancel_token.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'dio_exception.dart';
 import 'options.dart';
+import 'utils.dart' show warningLog;
 
 /// {@template dio.CancelToken}
 /// Controls cancellation of [Dio]'s requests.
@@ -36,6 +37,19 @@ class CancelToken {
   /// Cancel the request with the given [reason].
   void cancel([Object? reason]) {
     if (_completer.isCompleted) {
+      if (reason != _cancelError?.error) {
+        final buffer = StringBuffer();
+        buffer.writeln(
+          'The CancelToken was cancelled multiple times with different reason:',
+        );
+        buffer.writeln('=> [Error      ]:');
+        buffer.writeln('   |--- Previous:${_cancelError?.error}');
+        buffer.writeln('   |--- Current :$reason');
+        buffer.writeln('=> [Stack Trace]:');
+        buffer.writeln('   |--- Previous:${_cancelError?.stackTrace}');
+        buffer.writeln('   |--- Current :${StackTrace.current}');
+        warningLog(buffer.toString(), StackTrace.current);
+      }
       return;
     }
     _cancelError = DioException.requestCancelled(

--- a/dio/lib/src/cancel_token.dart
+++ b/dio/lib/src/cancel_token.dart
@@ -35,13 +35,14 @@ class CancelToken {
 
   /// Cancel the request with the given [reason].
   void cancel([Object? reason]) {
+    if (_completer.isCompleted) {
+      return;
+    }
     _cancelError = DioException.requestCancelled(
       requestOptions: requestOptions ?? RequestOptions(),
       reason: reason,
       stackTrace: StackTrace.current,
     );
-    if (!_completer.isCompleted) {
-      _completer.complete(_cancelError);
-    }
+    _completer.complete(_cancelError);
   }
 }

--- a/dio/test/cancel_token_test.dart
+++ b/dio/test/cancel_token_test.dart
@@ -17,15 +17,13 @@ void main() {
       expectLater(
         token.whenCancel,
         completion(
-          (error) {
-            return error is DioException &&
-                error.type == DioExceptionType.cancel &&
-                error.error == reason;
-          },
+          matchesDioException(DioExceptionType.cancel),
         ),
       );
       token.requestOptions = RequestOptions();
       token.cancel(reason);
+      token.cancel('after cancelled');
+      expect(token.cancelError?.error, reason);
     });
 
     test('cancel without use does not throw (#1765)', () async {


### PR DESCRIPTION
Calls `CancelToken.cancel` multiple times will update the internal error field to the last defined.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
