### PR TITLE
docs: fix the return value type.

### DIFF
--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -149,7 +149,7 @@ response = await dio.post('/test', data: {'id': 12, 'name': 'dio'});
 ### 发起多个并发请求
 
 ```dart
-List<Response> responses = await Future.wait<Response>([dio.post('/info'), dio.get('/token')]);
+List<Response> responses = await Future.wait([dio.post('/info'), dio.get('/token')]);
 ```
 
 ### 下载文件

--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -149,7 +149,7 @@ response = await dio.post('/test', data: {'id': 12, 'name': 'dio'});
 ### 发起多个并发请求
 
 ```dart
-response = await Future.wait([dio.post('/info'), dio.get('/token')]);
+List<Response> responses = await Future.wait<Response>([dio.post('/info'), dio.get('/token')]);
 ```
 
 ### 下载文件

--- a/dio/README.md
+++ b/dio/README.md
@@ -133,7 +133,7 @@ response = await dio.post('/test', data: {'id': 12, 'name': 'dio'});
 ### Performing multiple concurrent requests
 
 ```dart
-List<Response> responses = await Future.wait<Response>([dio.post('/info'), dio.get('/token')]);
+List<Response> responses = await Future.wait([dio.post('/info'), dio.get('/token')]);
 ```
 
 ### Downloading a file

--- a/dio/README.md
+++ b/dio/README.md
@@ -133,7 +133,7 @@ response = await dio.post('/test', data: {'id': 12, 'name': 'dio'});
 ### Performing multiple concurrent requests
 
 ```dart
-response = await Future.wait([dio.post('/info'), dio.get('/token')]);
+List<Response> responses = await Future.wait<Response>([dio.post('/info'), dio.get('/token')]);
 ```
 
 ### Downloading a file


### PR DESCRIPTION
Because none of the examples below explicitly declare a type, I believe the intended type is actually the Response response; at the top. However, it is not returning a Response; it is an array type.

It is an array type. When I copy and run it, it actually throws an error.

Although it’s not a big issue, I believe explicitly declaring the type would be better.

https://github.com/cfug/dio/blob/d6888cc4b1b085e6cf94c930ff9cb858c271d144/dio/README.md?plain=1#L115

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package
