### PR TITLE
⚡ Close `CronetEngine` when closing the `CronetClient`

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Close the `CronetEngine` when closing the `CronetClient` by default.
 
 ## 1.4.0
 

--- a/plugins/native_dio_adapter/lib/src/cronet_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/cronet_adapter.dart
@@ -8,11 +8,13 @@ import 'conversion_layer_adapter.dart';
 /// to the native platform by making use of
 /// [cronet_http](https://pub.dev/packages/cronet_http).
 class CronetAdapter implements HttpClientAdapter {
-  CronetAdapter(CronetEngine? engine)
-      : _conversionLayer = ConversionLayerAdapter(
+  CronetAdapter(
+    CronetEngine? engine, {
+    bool closeEngine = true,
+  }) : _conversionLayer = ConversionLayerAdapter(
           engine == null
               ? CronetClient.defaultCronetEngine()
-              : CronetClient.fromCronetEngine(engine),
+              : CronetClient.fromCronetEngine(engine, closeEngine: closeEngine),
         );
 
   final ConversionLayerAdapter _conversionLayer;


### PR DESCRIPTION
Now the `CronetEngine` shall be closed along with the adapter and the client. This reduces the possibility with https://github.com/cfug/dio/issues/2300, learned from https://github.com/dart-lang/http/issues/1136#issuecomment-1960054016.

This PR cannot be effectively tested due to the unpublic closed state.

### Additional context and info (if any)

https://github.com/dart-lang/http/pull/1795 
