### PR TITLE
⚡️ Allow passing an initial interceptors list to the constructor of `Interceptors`

### DIFF
--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -320,6 +320,12 @@ class InterceptorsWrapper extends Interceptor with _InterceptorWrapperMixin {
 ///
 /// Interceptors will be executed with FIFO.
 class Interceptors extends ListMixin<Interceptor> {
+  Interceptors({
+    List<Interceptor> initialInterceptors = const <Interceptor>[],
+  }) {
+    addAll(initialInterceptors);
+  }
+
   /// Define a nullable list to be capable with growable elements.
   final List<Interceptor?> _list = [const ImplyContentTypeInterceptor()];
 


### PR DESCRIPTION
Introduce another way to fill a list of `Interceptor`s by `Interceptors(initialInterceptors: list)`. This does not change the position of the `ImplyContentTypeInterceptor`.