### PR TITLE
⚡️ Improve how `CookieManager` proceed with exceptions

### DIFF
--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-*None.*
+- Proceed better `DioException`s from the cookie manager.
+- Expose `saveCookies` for `CookieManager`.
 
 ## 3.2.0
 


### PR DESCRIPTION
Working towards #2425.

In this PR, the cookie manager now injects `DioException` more precisely and with as many rich fields as possible. Additionally, `saveCookies` is now a public method that allows users to override it.

## Additional Context

Using `Future().then((r) {}, onError: (e, s) {})` is better than `Future().then((r) {}).catchError((e, s) {})` per my discussion with others but I cannot find where the dicsussion is taken place.