### PR TITLE
⚡️ Use `package:mime` to help determine the `content-type` of `MultipartFile` base on the provided `filename`

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,8 +5,9 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-- Do not allow update the error field after a cancel token has cancelled.
+- Do not allow updating the error field after a cancel token has canceled.
 - Allow passing an initial interceptors list to the constructor of `Interceptors`.
+- Use `package:mime` to help determine the `content-type` of `MultipartFile` base on the provided `filename`.
 
 ## 5.8.0+1
 

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -158,14 +158,14 @@ class MultipartFile {
     );
   }
 
-  /// Lookup the media type from the given file [path] based on its extension.
-  static DioMediaType? lookupMediaType(String? path) {
-    path = path?.trim();
-    if (path == null || path.isEmpty) {
+  /// Lookup the media type from the given [filenameOrPath] based on its extension.
+  static DioMediaType? lookupMediaType(String? filenameOrPath) {
+    filenameOrPath = filenameOrPath?.trim();
+    if (filenameOrPath == null || filenameOrPath.isEmpty) {
       return null;
     }
 
-    final mimeType = lookupMimeType(path);
+    final mimeType = lookupMimeType(filenameOrPath);
     if (mimeType == null) {
       return null;
     }

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -2,6 +2,7 @@ import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:http_parser/http_parser.dart' show MediaType;
+import 'package:mime/mime.dart' show lookupMimeType;
 
 import 'multipart_file/io_multipart_file.dart'
     if (dart.library.js_interop) 'multipart_file/browser_multipart_file.dart'
@@ -33,7 +34,9 @@ class MultipartFile {
     Map<String, List<String>>? headers,
   })  : _dataBuilder = (() => stream),
         headers = caseInsensitiveKeyMap(headers),
-        contentType = contentType ?? MediaType('application', 'octet-stream');
+        contentType = contentType ??
+            lookupMediaType(filename) ??
+            DioMediaType('application', 'octet-stream');
 
   /// Creates a new [MultipartFile] from a creation method that creates
   /// chunked [Stream] of bytes. The length of the file in bytes must be known
@@ -50,7 +53,9 @@ class MultipartFile {
     Map<String, List<String>>? headers,
   })  : _dataBuilder = data,
         headers = caseInsensitiveKeyMap(headers),
-        contentType = contentType ?? MediaType('application', 'octet-stream');
+        contentType = contentType ??
+            lookupMediaType(filename) ??
+            DioMediaType('application', 'octet-stream');
 
   /// Creates a new [MultipartFile] from a byte array.
   ///
@@ -84,7 +89,7 @@ class MultipartFile {
     DioMediaType? contentType,
     final Map<String, List<String>>? headers,
   }) {
-    contentType ??= MediaType('text', 'plain');
+    contentType ??= lookupMediaType(filename) ?? DioMediaType('text', 'plain');
     final encoding = encodingForCharset(
       contentType.parameters['charset'],
       utf8,
@@ -151,6 +156,21 @@ class MultipartFile {
       contentType: contentType,
       headers: headers,
     );
+  }
+
+  /// Lookup the media type from the given [path].
+  static DioMediaType? lookupMediaType(String? path) {
+    path = path?.trim();
+    if (path == null || path.isEmpty) {
+      return null;
+    }
+
+    final mimeType = lookupMimeType(path);
+    if (mimeType == null) {
+      return null;
+    }
+
+    return DioMediaType.parse(mimeType);
   }
 
   bool _isFinalized = false;

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -158,7 +158,7 @@ class MultipartFile {
     );
   }
 
-  /// Lookup the media type from the given [path].
+  /// Lookup the media type from the given file [path] based on its extension.
   static DioMediaType? lookupMediaType(String? path) {
     path = path?.trim();
     if (path == null || path.isEmpty) {

--- a/dio/lib/src/multipart_file/io_multipart_file.dart
+++ b/dio/lib/src/multipart_file/io_multipart_file.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import '../multipart_file.dart';
+import '../multipart_file.dart' show MultipartFile, DioMediaType;
 
 Future<MultipartFile> multipartFileFromPath(
   String filePath, {

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   collection: ^1.16.0
   http_parser: ^4.0.0
   meta: ^1.5.0
+  mime: '>1.0.0 <3.0.0'
   path: ^1.8.0
 
   dio_web_adapter: '>=1.1.0 <3.0.0'

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   collection: ^1.16.0
   http_parser: ^4.0.0
   meta: ^1.5.0
-  mime: '>1.0.0 <3.0.0'
+  mime: '>=1.0.0 <3.0.0'
   path: ^1.8.0
 
   dio_web_adapter: '>=1.1.0 <3.0.0'

--- a/dio/test/mock/_formdata
+++ b/dio/test/mock/_formdata
@@ -18,7 +18,7 @@ test: a
 hello world.
 ----dio-boundary-3788753558
 content-disposition: form-data; name="files"; filename="1.txt"
-content-type: application/octet-stream
+content-type: text/plain
 test: b
 
 你好世界，


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional Context

This should not be a breaking change unless the user implied the `application/octet-stream` before.