### PR TITLE
feat: support request cancellation for native HTTP clients

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Support request cancellation for native HTTP clients via use of `AbortableRequest` (introduced in http package from version 1.5.0)
 
 ## 1.5.0
 

--- a/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
@@ -23,7 +23,8 @@ class ConversionLayerAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future<dynamic>? cancelFuture,
   ) async {
-    final request = await _fromOptionsAndStream(options, requestStream);
+    final request =
+        await _fromOptionsAndStream(options, requestStream, cancelFuture);
     final response = await client.send(request);
     return response.toDioResponseBody(options);
   }
@@ -34,10 +35,12 @@ class ConversionLayerAdapter implements HttpClientAdapter {
   Future<BaseRequest> _fromOptionsAndStream(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
   ) async {
-    final request = Request(
+    final request = AbortableRequest(
       options.method,
       options.uri,
+      abortTrigger: cancelFuture,
     );
 
     request.headers.addAll(

--- a/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/conversion_layer_adapter.dart
@@ -23,8 +23,11 @@ class ConversionLayerAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future<dynamic>? cancelFuture,
   ) async {
-    final request =
-        await _fromOptionsAndStream(options, requestStream, cancelFuture);
+    final request = await _fromOptionsAndStream(
+      options,
+      requestStream,
+      cancelFuture,
+    );
     final response = await client.send(request);
     return response.toDioResponseBody(options);
   }

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -21,9 +21,9 @@ dependencies:
     sdk: flutter
 
   dio: ^5.4.0
-  cupertino_http: '>=1.0.0 <3.0.0'
-  cronet_http: '>=0.4.0 <2.0.0'
-  http: ^1.0.0
+  cupertino_http: '>=2.3.0 <3.0.0'
+  cronet_http: '>=1.5.0 <2.0.0'
+  http: ^1.5.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
     sdk: flutter
 
   dio: ^5.4.0
-  cupertino_http: '>=2.3.0 <3.0.0'
-  cronet_http: '>=1.5.0 <2.0.0'
+  cupertino_http: ^2.3.0
+  cronet_http: ^1.5.0
   http: ^1.5.0
 
 dev_dependencies:

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -29,6 +29,7 @@ dev_dependencies:
   lints: ^2.0.0
   flutter_test:
     sdk: flutter
+  async: ^2.13.0
 
 platforms:
   android:

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   lints: ^2.0.0
   flutter_test:
     sdk: flutter
-  async: ^2.13.0
+  async: # transitive
 
 platforms:
   android:

--- a/plugins/native_dio_adapter/test/client_mock.dart
+++ b/plugins/native_dio_adapter/test/client_mock.dart
@@ -1,4 +1,4 @@
-import 'package:async/async.dart';
+import 'package:async/async.dart' show CancelableOperation;
 import 'package:http/http.dart';
 
 class CloseClientMock implements Client {

--- a/plugins/native_dio_adapter/test/client_mock.dart
+++ b/plugins/native_dio_adapter/test/client_mock.dart
@@ -33,6 +33,8 @@ class ClientMock implements Client {
 }
 
 class AbortClientMock implements Client {
+  bool isRequestCanceled = false;
+
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     final cancellable = CancelableOperation.fromFuture(
@@ -43,6 +45,7 @@ class AbortClientMock implements Client {
       request.abortTrigger?.whenComplete(
         () {
           cancellable.cancel();
+          isRequestCanceled = true;
         },
       );
     }

--- a/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
+++ b/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
@@ -63,7 +63,7 @@ void main() {
     expect(await resp.stream.length, 5);
   });
 
-  test('request cancellation', () async {
+  test('request cancellation', () {
     final mock = AbortClientMock();
     final cla = ConversionLayerAdapter(mock);
     final cancelToken = CancelToken();
@@ -74,7 +74,7 @@ void main() {
       },
     );
 
-    expect(
+    expectLater(
       () => cla.fetch(
         RequestOptions(path: ''),
         null,
@@ -84,7 +84,7 @@ void main() {
     );
   });
 
-  test('request cancellation with Dio', () async {
+  test('request cancellation with Dio', () {
     final mock = AbortClientMock();
     final cla = ConversionLayerAdapter(mock);
     final dio = Dio();
@@ -98,15 +98,15 @@ void main() {
       },
     );
 
-    try {
-      await dio.get<ResponseBody>('', cancelToken: cancelToken);
-    } catch (ex) {
-      if (ex is DioException) {
-        expect(ex.type == DioExceptionType.cancel, true);
-        return;
-      }
-    }
-
-    fail('expected DioException');
+    expectLater(
+      () => dio.get<ResponseBody>('', cancelToken: cancelToken),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.type,
+          'type',
+          DioExceptionType.cancel,
+        ),
+      ),
+    );
   });
 }

--- a/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
+++ b/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
@@ -84,7 +84,7 @@ void main() {
     );
   });
 
-  test('request cancellation with Dio', () {
+  test('request cancellation with Dio', () async {
     final mock = AbortClientMock();
     final cla = ConversionLayerAdapter(mock);
     final dio = Dio();
@@ -98,7 +98,7 @@ void main() {
       },
     );
 
-    expectLater(
+    await expectLater(
       () => dio.get<ResponseBody>('', cancelToken: cancelToken),
       throwsA(
         isA<DioException>().having(
@@ -108,5 +108,6 @@ void main() {
         ),
       ),
     );
+    expect(mock.isRequestCanceled, true);
   });
 }

--- a/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
+++ b/plugins/native_dio_adapter/test/conversion_layer_adapter_test.dart
@@ -87,10 +87,10 @@ void main() {
   test('request cancellation with Dio', () async {
     final mock = AbortClientMock();
     final cla = ConversionLayerAdapter(mock);
-
-    final cancelToken = CancelToken();
     final dio = Dio();
     dio.httpClientAdapter = cla;
+
+    final cancelToken = CancelToken();
 
     Future<void>.delayed(const Duration(seconds: 1)).then(
       (value) {


### PR DESCRIPTION
New versions of `http`, `cronet_http` and `cupertino_http` supports request cancellation (just like the `HttpClient` from `dart:io`).

Minor change to use `AbortableRequest` and pass the `cancelFuture` to the `abortTrigger` argument.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

- [Add request cancellation to cupertino_http](https://github.com/dart-lang/http/pull/1779)
- [[cronet] Support aborting requests](https://github.com/dart-lang/http/pull/1797)
- [feat: support aborting HTTP requests](https://github.com/dart-lang/http/pull/1773)

### Testing with ASP.NET Core API

Test Flutter app (Android and iOS only):
https://github.com/zzyzy/dio_lzz_fork_flutter/blob/main/lib/test_dio_request_cancellation.dart

Test API endpoint:
```csharp
    [HttpGet("request-cancellation")]
    public async Task<IActionResult> TestRequestCancellation(CancellationToken cancellationToken)
    {
        try
        {
            _logger.LogInformation("Request started {RequestID} {Platform}", HttpContext.TraceIdentifier,
                Request.Headers["X-App-Platform"]);
            
            await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
            
            _logger.LogInformation("Request end {RequestID} {Platform}", HttpContext.TraceIdentifier,
                Request.Headers["X-App-Platform"]);
        }
        catch (TaskCanceledException)
        {
            _logger.LogInformation("Request canceled {RequestID} {Platform}", HttpContext.TraceIdentifier,
                Request.Headers["X-App-Platform"]);
            // Do nothing            
        }

        return Ok();
    }
```

#### Android

Before:
```
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://0.0.0.0:5292
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\ws\me\repos\my-code-vault\MyToolkit\TestAspNetCoreWebApi
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSG7:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSG8:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSG9:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSGA:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSGB:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB51JJSGC:00000001 Android
```

After:
```
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://0.0.0.0:5292
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\ws\me\repos\my-code-vault\MyToolkit\TestAspNetCoreWebApi
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMAV9NHQ97:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMAV9NHQ97:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMAV9NHQ98:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMAV9NHQ98:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMAV9NHQ99:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMAV9NHQ99:00000001 Android
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMAV9NHQ9A:00000001 Android
```

#### IOS

Before:
```
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://0.0.0.0:5292
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\ws\me\repos\my-code-vault\MyToolkit\TestAspNetCoreWebApi
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN4:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN5:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN6:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN7:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN8:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB42PERN9:00000001 IOS
```

After:
```
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://0.0.0.0:5292
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\ws\me\repos\my-code-vault\MyToolkit\TestAspNetCoreWebApi
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L0:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMB35NC5L0:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L1:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMB35NC5L1:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L2:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMB35NC5L2:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L3:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMB35NC5L3:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L4:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request canceled 0HNEMB35NC5L4:00000001 IOS
info: TestAspNetCoreWebApi.Controllers.TestController[0]
      Request started 0HNEMB35NC5L5:00000001 IOS

```