### PR TITLE
feat: add handshakeTimeout to Http2Adapter's ConnectionManager

### DIFF
--- a/plugins/http2_adapter/lib/src/connection_manager.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager.dart
@@ -7,12 +7,14 @@ part of 'http2_adapter.dart';
 abstract class ConnectionManager {
   factory ConnectionManager({
     Duration idleTimeout = const Duration(seconds: 15),
+    Duration handshakeTimout = const Duration(seconds: 15),
     void Function(Uri uri, ClientSetting)? onClientCreate,
     ProxyConnectedPredicate proxyConnectedPredicate =
         defaultProxyConnectedPredicate,
   }) =>
       _ConnectionManager(
         idleTimeout: idleTimeout,
+        handshakeTimeout: handshakeTimout,
         onClientCreate: onClientCreate,
         proxyConnectedPredicate: proxyConnectedPredicate,
       );

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -4,9 +4,11 @@ part of 'http2_adapter.dart';
 class _ConnectionManager implements ConnectionManager {
   _ConnectionManager({
     Duration? idleTimeout,
+    Duration? handshakeTimeout,
     this.onClientCreate,
     this.proxyConnectedPredicate = defaultProxyConnectedPredicate,
-  }) : _idleTimeout = idleTimeout ?? const Duration(seconds: 1);
+  })  : _idleTimeout = idleTimeout ?? const Duration(seconds: 1),
+        _handshakeTimout = handshakeTimeout ?? const Duration(seconds: 1);
 
   /// Callback when socket created.
   ///
@@ -21,6 +23,9 @@ class _ConnectionManager implements ConnectionManager {
   /// connections. For the sake of socket reuse feature with http/2,
   /// the value should not be less than 1 second.
   final Duration _idleTimeout;
+
+  /// Sets the handshake timeout(milliseconds) for secure socket connections
+  final Duration _handshakeTimout;
 
   /// Saving the reusable connections
   final _transportsMap = <String, _ClientTransportConnectionState>{};
@@ -175,7 +180,7 @@ class _ConnectionManager implements ConnectionManager {
         context: clientConfig.context,
         onBadCertificate: clientConfig.onBadCertificate,
         supportedProtocols: ['h2'],
-      );
+      ).timeout(_handshakeTimout);
       _throwIfH2NotSelected(target, socket);
       return socket;
     }
@@ -252,7 +257,7 @@ class _ConnectionManager implements ConnectionManager {
       context: clientConfig.context,
       onBadCertificate: clientConfig.onBadCertificate,
       supportedProtocols: ['h2'],
-    );
+    ).timeout(_handshakeTimout);
     _throwIfH2NotSelected(target, socket);
 
     proxySubscription.cancel();

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dio_http2_adapter
-version: 2.6.0
+version: 2.7.0
 
 description: An adapter that combines HTTP/2 and dio. Supports reusing connections, header compression, etc.
 topics:


### PR DESCRIPTION
In some situations, like when ISP infrastructure is down or misconfigured, user may end up long-waiting for handshake to complete. In my case it was around 1 minute which is huge. This PR adds an optional param `handshakeTimeout` to `ConnectionManager` that after all returns chains with [this future](https://github.com/dart-lang/sdk/blob/9f2218e4509210576abecc79d7184c94a3ad0e26/sdk/lib/io/secure_socket.dart#L633) in `_RawSecureSocket`

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
