### PR TITLE
[native_dio_adapter] Fall back on `IOClient` when `CronetEngine` initialization fails

### DIFF
--- a/plugins/native_dio_adapter/lib/src/cronet_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/cronet_adapter.dart
@@ -1,7 +1,10 @@
+import 'dart:developer';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:cronet_http/cronet_http.dart';
 import 'package:dio/dio.dart';
+import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'conversion_layer_adapter.dart';
 
 /// A [HttpClientAdapter] for Dio which delegates HTTP requests
@@ -11,16 +14,32 @@ class CronetAdapter implements HttpClientAdapter {
   CronetAdapter(
     CronetEngine? engine, {
     bool closeEngine = true,
-  }) : _conversionLayer = ConversionLayerAdapter(
-          engine == null
-              ? CronetClient.defaultCronetEngine()
-              : CronetClient.fromCronetEngine(engine, closeEngine: closeEngine),
-        );
+  })  : _engine = engine,
+        _closeEngine = closeEngine;
 
-  final ConversionLayerAdapter _conversionLayer;
+  final CronetEngine? _engine;
+  final bool _closeEngine;
 
-  /// The underlying conversion layer adapter.
-  ConversionLayerAdapter get adapter => _conversionLayer;
+  late final ConversionLayerAdapter _conversionLayer = () {
+    Client client;
+
+    try {
+      client = CronetClient.fromCronetEngine(
+        _engine ?? CronetEngine.build(),
+        closeEngine: _closeEngine,
+      );
+    } catch (error, stackTrace) {
+      log(
+        'Failed to create CronetClient, falling back to IOClient',
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+      client = IOClient();
+    }
+
+    return ConversionLayerAdapter(client);
+  }();
 
   @override
   void close({bool force = false}) => _conversionLayer.close(force: force);


### PR DESCRIPTION
Draft for how to solve https://github.com/cfug/dio/issues/2444.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
