### PR TITLE
fix: Http2Adapter does not fail with StateError when connection is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ melos_overrides.yaml
 # FVM Version Cache
 .fvm/
 .fvmrc
+
+# Local history
+.history

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Add `handshakeTimeout` (defaults to 15 seconds) to the `ConnectionManager` to prevent long waiting if there's something wrong with the handshake procedure.
+- Fix `StateError: Bad state: Cannot add event after closing` caused by race condition e.g. when the server closed the connection before receiving the request body. 
 
 ## 2.6.0
 

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -6,7 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Add `handshakeTimeout` (defaults to 15 seconds) to the `ConnectionManager` to prevent long waiting if there's something wrong with the handshake procedure.
-- Fix `StateError: Bad state: Cannot add event after closing` caused by race condition e.g. when the server closed the connection before receiving the request body. 
+- Fix `StateError: Bad state: Cannot add event after closing` caused by race condition e.g. when the server closed the connection before receiving the request body.
 
 ## 2.6.0
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -126,12 +126,6 @@ class Http2Adapter implements HttpClientAdapter {
     final streamWR = WeakReference<ClientTransportStream>(stream);
 
     final hasRequestData = requestStream != null;
-    if (hasRequestData && cancelFuture != null) {
-      cancelFuture.whenComplete(() {
-        streamWR.target?.outgoingMessages.close();
-      });
-    }
-
     List<Uint8List>? list;
     if (!excludeMethods.contains(options.method) && hasRequestData) {
       list = await requestStream.toList();
@@ -139,16 +133,49 @@ class Http2Adapter implements HttpClientAdapter {
     }
 
     if (hasRequestData) {
-      Future<dynamic> requestStreamFuture = requestStream!.listen((data) {
-        //TODO(EVERYONE): Investigate why this statement can cause "StateError: Bad state: Cannot add event after closing"
-        stream.outgoingMessages.add(DataStreamMessage(data));
-      }).asFuture();
+      StreamSubscription<Uint8List>? requestSub;
+      final requestCompleter = Completer<void>();
+
+      requestSub = requestStream!.listen(
+        (Uint8List data) {
+          try {
+            stream.outgoingMessages.add(DataStreamMessage(data));
+          } on StateError {
+            requestSub?.cancel();
+            if (!requestCompleter.isCompleted) {
+              requestCompleter.complete();
+            }
+          }
+        },
+        onError: (Object e, StackTrace st) {
+          if (!requestCompleter.isCompleted) {
+            requestCompleter.completeError(e, st);
+          }
+        },
+        onDone: () {
+          if (!requestCompleter.isCompleted) {
+            requestCompleter.complete();
+          }
+        },
+        cancelOnError: true,
+      );
+
+      if (cancelFuture != null) {
+        cancelFuture.whenComplete(() {
+          requestSub?.cancel().catchError((_) {}).whenComplete(() {
+            streamWR.target?.outgoingMessages.close().catchError((_) {});
+          });
+        });
+      }
+
+      Future<dynamic> requestStreamFuture = requestCompleter.future;
       final sendTimeout = options.sendTimeout ?? Duration.zero;
       if (sendTimeout > Duration.zero) {
         requestStreamFuture = requestStreamFuture.timeout(
           sendTimeout,
           onTimeout: () {
-            stream.outgoingMessages.close().catchError((_) {});
+            requestSub?.cancel().catchError((_) {});
+            streamWR.target?.outgoingMessages.close().catchError((_) {});
             throw DioException.sendTimeout(
               timeout: sendTimeout,
               requestOptions: options,
@@ -156,9 +183,13 @@ class Http2Adapter implements HttpClientAdapter {
           },
         );
       }
+
       await requestStreamFuture;
     }
-    await stream.outgoingMessages.close();
+
+    try {
+      await stream.outgoingMessages.close();
+    } catch (_) {}
 
     final responseSink = StreamController<Uint8List>();
     final responseHeaders = Headers();

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -189,7 +189,11 @@ class Http2Adapter implements HttpClientAdapter {
 
     try {
       await stream.outgoingMessages.close();
-    } catch (_) {}
+    } on StateError {
+      // Ignore StateError, which may occur if the stream is already closed.
+    } catch (_) {
+      rethrow;
+    }
 
     final responseSink = StreamController<Uint8List>();
     final responseHeaders = Headers();

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:dio_test/util.dart';
+import 'package:http2/transport.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -97,6 +100,63 @@ void main() {
     }
     final res = await dio.post('/post', data: 'TEST');
     expect(res.data.toString(), contains('TEST'));
+  });
+
+  test(
+      'request does not fail with StateError when the server closes the stream before client sends body',
+      () async {
+    final serverSocket =
+        await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+
+    serverSocket.listen((rawSocket) {
+      final serverConn = ServerTransportConnection.viaSocket(rawSocket);
+
+      serverConn.incomingStreams.listen((ServerTransportStream stream) async {
+        await for (final msg in stream.incomingMessages) {
+          if (msg is HeadersStreamMessage) {
+            stream.terminate();
+            break;
+          }
+        }
+      });
+    });
+
+    final dio = Dio();
+    final adapter = Http2Adapter(null);
+    dio.httpClientAdapter = adapter;
+
+    final Stream<Uint8List> requestStream = (() async* {
+      for (int i = 0; i < 20; i++) {
+        await Future.delayed(const Duration(milliseconds: 5));
+        yield Uint8List.fromList(List.filled(1024, i));
+      }
+    })();
+
+    final completer = Completer<Object?>();
+
+    runZonedGuarded(() async {
+      await adapter.fetch(
+        RequestOptions(
+          path: '/test',
+          method: 'POST',
+          baseUrl: 'http://127.0.0.1:${serverSocket.port}',
+          headers: {},
+        ),
+        requestStream,
+        null,
+      );
+      completer.complete(null);
+    }, (e, _) {
+      if (!completer.isCompleted) {
+        completer.complete(e);
+      }
+    });
+
+    final result = await completer.future;
+    expect(result, isNot(isA<StateError>()));
+
+    adapter.close(force: true);
+    await serverSocket.close();
   });
 
   group(ConnectionManager, () {

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -115,6 +115,7 @@ void main() {
         await for (final msg in stream.incomingMessages) {
           if (msg is HeadersStreamMessage) {
             stream.terminate();
+            serverConn.terminate();
             break;
           }
         }


### PR DESCRIPTION
Periodically I receive unhandled `StateError:  Bad state: Cannot add event after closing` in Crashlytics:

<details>
<summary>Stack Trace</summary>

```
StateError: Bad state: Cannot add event after closing
  *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** (***)
  pid: 19891, tid: 483148275864, name 1.ui (unparsed)
  android arch: arm64 comp: yes sim: no (os:)
  build_id: '4f1bdaeddbb49260128a5ff3c1e2e0c4' (unparsed)
  isolate_dso_base: 6ca549c000, vm_dso_base: 6ca549c000 (unparsed)
  isolate_instructions: 6ca5622940, vm_instructions: 6ca560c000 (unparsed)
#0      _StreamController.add (third_party/dart/sdk/lib/async/stream_controller.dart:617:24)
#1      _StreamSinkWrapper.add (third_party/dart/sdk/lib/async/stream_controller.dart:898:13)
#2      Http2Adapter._fetch.<anonymous closure> (/Users/vanelizarov/.pub-cache/git/dio-5259d4ae4fb665b8212c343c015e53fcbfe7d0b7/plugins/http2_adapter/lib/src/http2_adapter.dart:144:33)
#3      _RootZone.runUnaryGuarded (third_party/dart/sdk/lib/async/zone.dart:1778:10)
#4      _BufferingStreamSubscription._sendData (third_party/dart/sdk/lib/async/stream_impl.dart:381:11)
#5      _BufferingStreamSubscription._add (third_party/dart/sdk/lib/async/stream_impl.dart:312:7)
#6      _SinkTransformerStreamSubscription._add (third_party/dart/sdk/lib/async/stream_transformers.dart:67:11)
#7      _EventSinkWrapper.add (third_party/dart/sdk/lib/async/stream_transformers.dart:13:11)
#8      _transform.<anonymous closure> (/Users/vanelizarov/.pub-cache/hosted/pub.dev/dio-5.9.0/lib/src/progress_stream/io_progress_stream.dart:33:16)
#9      _HandlerEventSink.add (third_party/dart/sdk/lib/async/stream_transformers.dart:230:17)
#10     _SinkTransformerStreamSubscription._handleData (third_party/dart/sdk/lib/async/stream_transformers.dart:115:24)
#11     _SinkTransformerStreamSubscription._handleData (third_party/dart/sdk/lib/async/stream_transformers.dart:113:3)
#12     _RootZone.runUnaryGuarded (third_party/dart/sdk/lib/async/zone.dart:1778:10)
#13     _BufferingStreamSubscription._sendData (third_party/dart/sdk/lib/async/stream_impl.dart:381:11)
#14     _BufferingStreamSubscription._add (third_party/dart/sdk/lib/async/stream_impl.dart:312:7)
#15     _MultiStreamController.addSync (third_party/dart/sdk/lib/async/stream_impl.dart:1195:36)
#16     new Stream.fromIterable.<anonymous closure>.next (third_party/dart/sdk/lib/async/stream.dart:385:26)
#17     _microtaskLoop (third_party/dart/sdk/lib/async/schedule_microtask.dart:40:35)
#18     _startMicrotaskLoop (third_party/dart/sdk/lib/async/schedule_microtask.dart:49:5)
#19     _startMicrotaskLoop (third_party/dart/sdk/lib/async/schedule_microtask.dart:44:1)
```
</details>

This problem was mentioned earlier by me [in this PR](https://github.com/cfug/dio/pull/2435#discussion_r2380607103).

After investigation, it appears that the error was caused by a race condition, for example, when the server closed the connection before receiving the request body.

This PR introduces a more reliable way to handle such situations. It also includes a test that can be run with the old implementation to reproduce the described issue.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
