### PR TITLE
fix(native_dio_adapter): gracefully fall back when Cronet unavailable

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support request cancellation for native HTTP clients via use of `AbortableRequest` (introduced in http package from version 1.5.0)
 - Add timeout handling for `sendTimeout`, `connectTimeout`, and `receiveTimeout` in `ConversionLayerAdapter`
+- Gracefully fall back to `HttpClientAdapter` when Cronet is unavailable on Android (e.g., devices without Google Play Services)
+- Add `onCronetUnavailable` callback to `NativeAdapter` for notification when fallback occurs
 
 ## 1.5.0
 


### PR DESCRIPTION
## Summary

Fixes #2444

When Google Play Services is unavailable (e.g., on Android emulators without Google APIs or devices without Play Services), `CronetEngine` initialization throws a `JniException`:

> "All available Cronet providers are disabled. A provider should be enabled before it can be used."

This change:
- Wraps `CronetAdapter` creation in a try-catch block
- Falls back to the standard `HttpClientAdapter` (dart:io) when Cronet is unavailable
- Adds an optional `onCronetUnavailable` callback for developers who want to be notified when the fallback occurs

## Changes

- `native_adapter.dart`: Added graceful fallback with try-catch
- `CHANGELOG.md`: Documented the new behavior

## Usage

```dart
// Basic usage - fallback happens silently
final dio = Dio();
dio.httpClientAdapter = NativeAdapter();

// With callback to log or handle the fallback
dio.httpClientAdapter = NativeAdapter(
  onCronetUnavailable: (error) {
    print('Cronet unavailable, using dart:io fallback: $error');
  },
);
```

## Test Plan

- [x] `melos run format` - passes
- [x] `melos run analyze` - passes  
- [x] `flutter test` in native_dio_adapter - all 10 tests pass
- [ ] Manual test on Android emulator without Google Play Services (requires device testing)