### PR TITLE
feat: add custom exception unwrapping in interceptors

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -520,7 +520,14 @@ abstract class DioMixin implements Dio {
           return assureResponse<T>(e.data, requestOptions);
         }
       }
-      throw assureDioException(isState ? e.data : e, requestOptions);
+      final dioException =
+          assureDioException(isState ? e.data : e, requestOptions);
+      // If the exception is marked for unwrapping, throw the inner error
+      // instead of the DioException wrapper.
+      if (dioException.throwInnerErrorOnFinish && dioException.error != null) {
+        throw dioException.error!;
+      }
+      throw dioException;
     }
   }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -97,6 +97,52 @@ class RequestInterceptorHandler extends _BaseHandler {
     );
     _processNextInQueue?.call();
   }
+
+  /// Completes the request by rejecting with a custom [error] that will be
+  /// thrown directly to the caller, bypassing the [DioException] wrapper.
+  ///
+  /// This is useful when you want callers to catch your custom exception type
+  /// directly instead of having to catch [DioException] and extract the error.
+  ///
+  /// The [requestOptions] parameter is required to create the wrapper
+  /// [DioException]. You can obtain it from the [RequestOptions] parameter
+  /// passed to the interceptor.
+  ///
+  /// Example:
+  /// ```dart
+  /// dio.interceptors.add(InterceptorsWrapper(
+  ///   onRequest: (options, handler) {
+  ///     if (!isAuthenticated) {
+  ///       handler.rejectCustomError(
+  ///         UnauthorizedException('Not logged in'),
+  ///         options,
+  ///       );
+  ///       return;
+  ///     }
+  ///     handler.next(options);
+  ///   },
+  /// ));
+  ///
+  /// // Caller can catch the custom exception directly:
+  /// try {
+  ///   await dio.get('/api');
+  /// } on UnauthorizedException catch (e) {
+  ///   // Now works!
+  /// }
+  /// ```
+  void rejectCustomError(
+    Object error,
+    RequestOptions requestOptions, [
+    bool callFollowingErrorInterceptor = false,
+  ]) {
+    reject(
+      DioException.customError(
+        requestOptions: requestOptions,
+        error: error,
+      ),
+      callFollowingErrorInterceptor,
+    );
+  }
 }
 
 /// The handler for interceptors to handle after respond.
@@ -148,6 +194,51 @@ class ResponseInterceptorHandler extends _BaseHandler {
     );
     _processNextInQueue?.call();
   }
+
+  /// Completes the request by rejecting with a custom [error] that will be
+  /// thrown directly to the caller, bypassing the [DioException] wrapper.
+  ///
+  /// This is useful when you want callers to catch your custom exception type
+  /// directly instead of having to catch [DioException] and extract the error.
+  ///
+  /// The [requestOptions] parameter is required to create the wrapper
+  /// [DioException]. You can obtain it from `response.requestOptions`.
+  ///
+  /// Example:
+  /// ```dart
+  /// dio.interceptors.add(InterceptorsWrapper(
+  ///   onResponse: (response, handler) {
+  ///     if (response.statusCode == 401) {
+  ///       handler.rejectCustomError(
+  ///         UnauthorizedException('Token expired'),
+  ///         response.requestOptions,
+  ///       );
+  ///       return;
+  ///     }
+  ///     handler.next(response);
+  ///   },
+  /// ));
+  ///
+  /// // Caller can catch the custom exception directly:
+  /// try {
+  ///   await dio.get('/api');
+  /// } on UnauthorizedException catch (e) {
+  ///   // Now works!
+  /// }
+  /// ```
+  void rejectCustomError(
+    Object error,
+    RequestOptions requestOptions, [
+    bool callFollowingErrorInterceptor = false,
+  ]) {
+    reject(
+      DioException.customError(
+        requestOptions: requestOptions,
+        error: error,
+      ),
+      callFollowingErrorInterceptor,
+    );
+  }
 }
 
 /// The handler for interceptors to handle error occurred during the request.
@@ -185,6 +276,46 @@ class ErrorInterceptorHandler extends _BaseHandler {
       error.stackTrace,
     );
     _processNextInQueue?.call();
+  }
+
+  /// Completes the request by rejecting with a custom [error] that will be
+  /// thrown directly to the caller, bypassing the [DioException] wrapper.
+  ///
+  /// This is useful when you want callers to catch your custom exception type
+  /// directly instead of having to catch [DioException] and extract the error.
+  ///
+  /// The [requestOptions] parameter is required to create the wrapper
+  /// [DioException]. You can obtain it from `error.requestOptions`.
+  ///
+  /// Example:
+  /// ```dart
+  /// dio.interceptors.add(InterceptorsWrapper(
+  ///   onError: (error, handler) {
+  ///     if (error.response?.statusCode == 401) {
+  ///       handler.rejectCustomError(
+  ///         UnauthorizedException('Token expired'),
+  ///         error.requestOptions,
+  ///       );
+  ///       return;
+  ///     }
+  ///     handler.next(error);
+  ///   },
+  /// ));
+  ///
+  /// // Caller can catch the custom exception directly:
+  /// try {
+  ///   await dio.get('/api');
+  /// } on UnauthorizedException catch (e) {
+  ///   // Now works!
+  /// }
+  /// ```
+  void rejectCustomError(Object error, RequestOptions requestOptions) {
+    reject(
+      DioException.customError(
+        requestOptions: requestOptions,
+        error: error,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds mechanism to throw custom exceptions directly from interceptors instead of wrapping them in `DioException`
- Implements solution for issue #1950

## Changes

- Add `throwInnerErrorOnFinish` flag to `DioException` (default `false`)
- Add `DioException.customError()` factory constructor for convenient creation
- Add `rejectCustomError()` method to `RequestInterceptorHandler`, `ResponseInterceptorHandler`, and `ErrorInterceptorHandler`
- Unwrap marked exceptions in `fetch()` final catch block

## Example Usage

```dart
// In interceptor
dio.interceptors.add(InterceptorsWrapper(
  onResponse: (response, handler) {
    if (response.statusCode == 401) {
      handler.rejectCustomError(
        UnauthorizedException('Token expired'),
        response.requestOptions,
      );
      return;
    }
    handler.next(response);
  },
));

// Caller can now catch custom exception directly:
try {
  await dio.get('/api');
} on UnauthorizedException catch (e) {
  // Now works!
}
```

## Test plan

- [x] Added tests for `rejectCustomError()` from all three handler types
- [x] Added test verifying regular `reject()` still wraps in `DioException`
- [x] Added tests for `DioException.customError()` factory
- [x] Added tests for `copyWith()` preserving the flag
- [x] Added test for `callFollowingErrorInterceptor` parameter
- [x] Added test for `QueuedInterceptor` support
- [x] All existing tests pass

Closes #1950