### PR TITLE
fix(cookie_manager): deduplicate cookies when request is retried

### DIFF
--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Fix duplicate cookies when requests are retried with the same `RequestOptions`.
 
 ## 3.4.0
 

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -133,12 +133,6 @@ class CookieManager extends Interceptor {
     }
   }
 
-  /// Returns a key that uniquely identifies a cookie per RFC 6265 Section 5.3:
-  /// a cookie is identified by (name, domain, path).
-  static String _cookieIdentity(Cookie c) {
-    return '${c.name}|${c.domain ?? ''}|${c.path ?? ''}';
-  }
-
   Cookie? _fromSetCookieValue(String value) {
     try {
       return Cookie.fromSetCookieValue(value);
@@ -155,28 +149,20 @@ class CookieManager extends Interceptor {
     final savedCookies = await cookieJar.loadForRequest(options.uri);
     final previousCookies =
         options.headers[HttpHeaders.cookieHeader] as String?;
-    // Deduplicate per RFC 6265 Section 5.3: a cookie is uniquely
-    // identified by (name, domain, path). Cookies parsed from the
-    // Cookie header lack domain/path, so we fall back to name-only
-    // matching against saved cookies (which are already scoped to
-    // the request URI by cookieJar.loadForRequest).
-    final savedCookieIdentities =
-        savedCookies.map((c) => _cookieIdentity(c)).toSet();
+    // Per RFC 6265 Section 4.2, the Cookie header carries only name=value
+    // pairs without domain or path. The saved cookies are already scoped
+    // to the request URI by cookieJar.loadForRequest, so matching by name
+    // is sufficient to detect duplicates from a retried request.
     final savedCookieNames = savedCookies.map((c) => c.name).toSet();
+    final previousList = previousCookies
+        ?.split(';')
+        .where((e) => e.isNotEmpty)
+        .map((c) => _fromSetCookieValue(c))
+        .whereType<Cookie>() // Use .nonNulls when the minimum SDK is 3.0.
+        .where((c) => !savedCookieNames.contains(c.name))
+        .toList();
     final cookies = getCookies([
-      ...?previousCookies
-          ?.split(';')
-          .where((e) => e.isNotEmpty)
-          .map((c) => _fromSetCookieValue(c))
-          .whereType<Cookie>() // Use .nonNulls when the minimum SDK is 3.0.
-          .where((c) {
-        // Header cookies lack domain/path metadata, so match by name
-        // against saved cookies that are already URI-scoped.
-        if (c.domain == null && c.path == null) {
-          return !savedCookieNames.contains(c.name);
-        }
-        return !savedCookieIdentities.contains(_cookieIdentity(c));
-      }),
+      ...?previousList,
       ...savedCookies,
     ]);
     return cookies;

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -149,12 +149,14 @@ class CookieManager extends Interceptor {
     final savedCookies = await cookieJar.loadForRequest(options.uri);
     final previousCookies =
         options.headers[HttpHeaders.cookieHeader] as String?;
+    final savedCookieNames = savedCookies.map((c) => c.name).toSet();
     final cookies = getCookies([
       ...?previousCookies
           ?.split(';')
           .where((e) => e.isNotEmpty)
           .map((c) => _fromSetCookieValue(c))
-          .whereType<Cookie>(), // Use .nonNulls when the minimum SDK is 3.0.
+          .whereType<Cookie>() // Use .nonNulls when the minimum SDK is 3.0.
+          .where((c) => !savedCookieNames.contains(c.name)),
       ...savedCookies,
     ]);
     return cookies;

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -160,9 +160,8 @@ class CookieManager extends Interceptor {
     // Cookie header lack domain/path, so we fall back to name-only
     // matching against saved cookies (which are already scoped to
     // the request URI by cookieJar.loadForRequest).
-    final savedCookieIdentities = savedCookies
-        .map((c) => _cookieIdentity(c))
-        .toSet();
+    final savedCookieIdentities =
+        savedCookies.map((c) => _cookieIdentity(c)).toSet();
     final savedCookieNames = savedCookies.map((c) => c.name).toSet();
     final cookies = getCookies([
       ...?previousCookies

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -136,7 +136,7 @@ class CookieManager extends Interceptor {
   /// Returns a key that uniquely identifies a cookie per RFC 6265 Section 5.3:
   /// a cookie is identified by (name, domain, path).
   static String _cookieIdentity(Cookie c) {
-    return '${c.name}\0${c.domain ?? ''}\0${c.path ?? ''}';
+    return '${c.name}|${c.domain ?? ''}|${c.path ?? ''}';
   }
 
   Cookie? _fromSetCookieValue(String value) {

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -133,6 +133,12 @@ class CookieManager extends Interceptor {
     }
   }
 
+  /// Returns a key that uniquely identifies a cookie per RFC 6265 Section 5.3:
+  /// a cookie is identified by (name, domain, path).
+  static String _cookieIdentity(Cookie c) {
+    return '${c.name}\0${c.domain ?? ''}\0${c.path ?? ''}';
+  }
+
   Cookie? _fromSetCookieValue(String value) {
     try {
       return Cookie.fromSetCookieValue(value);
@@ -149,6 +155,14 @@ class CookieManager extends Interceptor {
     final savedCookies = await cookieJar.loadForRequest(options.uri);
     final previousCookies =
         options.headers[HttpHeaders.cookieHeader] as String?;
+    // Deduplicate per RFC 6265 Section 5.3: a cookie is uniquely
+    // identified by (name, domain, path). Cookies parsed from the
+    // Cookie header lack domain/path, so we fall back to name-only
+    // matching against saved cookies (which are already scoped to
+    // the request URI by cookieJar.loadForRequest).
+    final savedCookieIdentities = savedCookies
+        .map((c) => _cookieIdentity(c))
+        .toSet();
     final savedCookieNames = savedCookies.map((c) => c.name).toSet();
     final cookies = getCookies([
       ...?previousCookies
@@ -156,7 +170,14 @@ class CookieManager extends Interceptor {
           .where((e) => e.isNotEmpty)
           .map((c) => _fromSetCookieValue(c))
           .whereType<Cookie>() // Use .nonNulls when the minimum SDK is 3.0.
-          .where((c) => !savedCookieNames.contains(c.name)),
+          .where((c) {
+        // Header cookies lack domain/path metadata, so match by name
+        // against saved cookies that are already URI-scoped.
+        if (c.domain == null && c.path == null) {
+          return !savedCookieNames.contains(c.name);
+        }
+        return !savedCookieIdentities.contains(_cookieIdentity(c));
+      }),
       ...savedCookies,
     ]);
     return cookies;

--- a/plugins/cookie_manager/test/cookies_test.dart
+++ b/plugins/cookie_manager/test/cookies_test.dart
@@ -262,6 +262,43 @@ void main() {
     await cookieManager.onRequest(firstOptions, retryHandler);
   });
 
+  test('same-name cookies with different paths are preserved on retry',
+      () async {
+    // RFC 6265 Section 5.3: cookies are identified by (name, domain, path).
+    // Two cookies with the same name but different paths must both be kept.
+    const List<String> mockResponseCookies = [
+      'session=abc; Path=/',
+      'session=xyz; Path=/api',
+    ];
+    const exampleUrl = 'https://example.com/api/endpoint';
+
+    final cookieJar = CookieJar();
+    final cookieManager = CookieManager(cookieJar);
+
+    final requestOptions = RequestOptions(baseUrl: exampleUrl);
+    final mockResponse = Response(
+      requestOptions: requestOptions,
+      headers: Headers.fromMap(
+        {HttpHeaders.setCookieHeader: mockResponseCookies},
+      ),
+    );
+    await cookieManager.onResponse(
+      mockResponse,
+      MockResponseInterceptorHandler(),
+    );
+
+    // First request: both cookies should be sent.
+    final firstOptions = RequestOptions(baseUrl: exampleUrl);
+    final firstHandler =
+        MockRequestInterceptorHandler('session=xyz; session=abc');
+    await cookieManager.onRequest(firstOptions, firstHandler);
+
+    // Retry: same cookies, no duplicates.
+    final retryHandler =
+        MockRequestInterceptorHandler('session=xyz; session=abc');
+    await cookieManager.onRequest(firstOptions, retryHandler);
+  });
+
   test('cookies replacement', () async {
     final cookies = [
       Cookie('foo', 'bar')..path = '/',

--- a/plugins/cookie_manager/test/cookies_test.dart
+++ b/plugins/cookie_manager/test/cookies_test.dart
@@ -228,6 +228,40 @@ void main() {
     });
   });
 
+  test('no duplicate cookies on retry', () async {
+    const List<String> mockResponseCookies = [
+      'a=1; Path=/',
+      'b=2; Path=/',
+    ];
+    const exampleUrl = 'https://example.com';
+
+    final cookieJar = CookieJar();
+    final cookieManager = CookieManager(cookieJar);
+
+    // Save cookies from a response.
+    final requestOptions = RequestOptions(baseUrl: exampleUrl);
+    final mockResponse = Response(
+      requestOptions: requestOptions,
+      headers: Headers.fromMap(
+        {HttpHeaders.setCookieHeader: mockResponseCookies},
+      ),
+    );
+    await cookieManager.onResponse(
+      mockResponse,
+      MockResponseInterceptorHandler(),
+    );
+
+    // First request sets cookie header.
+    final firstOptions = RequestOptions(baseUrl: exampleUrl);
+    final firstHandler = MockRequestInterceptorHandler('a=1; b=2');
+    await cookieManager.onRequest(firstOptions, firstHandler);
+
+    // Simulate retry: onRequest is called again on the same RequestOptions
+    // which already has the cookie header from the first attempt.
+    final retryHandler = MockRequestInterceptorHandler('a=1; b=2');
+    await cookieManager.onRequest(firstOptions, retryHandler);
+  });
+
   test('cookies replacement', () async {
     final cookies = [
       Cookie('foo', 'bar')..path = '/',


### PR DESCRIPTION
## Summary

Fixes #2442.

When a request is retried (e.g. after token refresh), `loadCookies` merges `previousCookies` from the existing header with `savedCookies` from the cookie jar without checking for duplicates. This causes cookies to accumulate on each retry attempt:

```
1st attempt: a=1; b=2
2nd attempt: a=1; b=2; a=1; b=2
3rd attempt: a=1; b=2; a=1; b=2; a=1; b=2
```

The fix filters out `previousCookies` entries whose names already exist in `savedCookies`, so jar cookies take precedence and no duplicates are produced.

The deduplication is done in `loadCookies` rather than `getCookies` to preserve the existing RFC 6265 behavior where same-name cookies with different paths are valid.

## Test plan

- Added `no duplicate cookies on retry` test that simulates the retry scenario
- All existing tests pass (16/16)
- `dart format` and `dart analyze` clean