### PR TITLE
fix(dio): prevent request hang when async interceptor throws

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
 
 ## 5.9.2
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -420,7 +420,9 @@ abstract class DioMixin implements Dio {
               createInterceptorZone(
                 handler,
                 (error) => handler.reject(
-                    assureDioException(error, requestOptions), true),
+                  assureDioException(error, requestOptions),
+                  true,
+                ),
               ).run(() => cb(state.data as RequestOptions, handler));
               return handler.future;
             }),
@@ -446,7 +448,9 @@ abstract class DioMixin implements Dio {
               createInterceptorZone(
                 handler,
                 (error) => handler.reject(
-                    assureDioException(error, requestOptions), true),
+                  assureDioException(error, requestOptions),
+                  true,
+                ),
               ).run(() => cb(state.data as Response, handler));
               return handler.future;
             }),

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -386,6 +386,25 @@ abstract class DioMixin implements Dio {
       }
     }
 
+    // Create an error zone that catches uncaught async errors from
+    // interceptor callbacks. This prevents requests from hanging when
+    // an async interceptor throws without calling the handler.
+    // Synchronous exceptions are not caught here and propagate normally.
+    Zone createInterceptorZone(
+      _BaseHandler handler,
+      void Function(Object error) onUncaughtError,
+    ) {
+      return Zone.current.fork(
+        specification: ZoneSpecification(
+          handleUncaughtError: (self, parent, zone, error, stackTrace) {
+            if (!handler.isCompleted) {
+              onUncaughtError(error);
+            }
+          },
+        ),
+      );
+    }
+
     // Convert the request interceptor to a functional callback in which
     // we can handle the return value of interceptor callback.
     FutureOr Function(dynamic) requestInterceptorWrapper(
@@ -398,7 +417,11 @@ abstract class DioMixin implements Dio {
             requestOptions.cancelToken,
             Future(() async {
               final handler = RequestInterceptorHandler();
-              cb(state.data as RequestOptions, handler);
+              createInterceptorZone(
+                handler,
+                (error) => handler.reject(
+                    assureDioException(error, requestOptions), true),
+              ).run(() => cb(state.data as RequestOptions, handler));
               return handler.future;
             }),
           );
@@ -420,7 +443,11 @@ abstract class DioMixin implements Dio {
             requestOptions.cancelToken,
             Future(() async {
               final handler = ResponseInterceptorHandler();
-              cb(state.data as Response, handler);
+              createInterceptorZone(
+                handler,
+                (error) => handler.reject(
+                    assureDioException(error, requestOptions), true),
+              ).run(() => cb(state.data as Response, handler));
               return handler.future;
             }),
           );
@@ -440,7 +467,10 @@ abstract class DioMixin implements Dio {
             : InterceptorState(assureDioException(error, requestOptions));
         Future<InterceptorState> handleError() async {
           final handler = ErrorInterceptorHandler();
-          cb(state.data, handler);
+          createInterceptorZone(
+            handler,
+            (error) => handler.next(assureDioException(error, requestOptions)),
+          ).run(() => cb(state.data, handler));
           return handler.future;
         }
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -390,15 +390,20 @@ abstract class DioMixin implements Dio {
     // interceptor callbacks. This prevents requests from hanging when
     // an async interceptor throws without calling the handler.
     // Synchronous exceptions are not caught here and propagate normally.
+    // If the handler was already completed (e.g. a fire-and-forget future
+    // inside the callback failed), forward the error to the parent zone
+    // so it isn't silently swallowed.
     Zone createInterceptorZone(
       _BaseHandler handler,
-      void Function(Object error) onUncaughtError,
+      void Function(Object error, StackTrace stackTrace) onUncaughtError,
     ) {
       return Zone.current.fork(
         specification: ZoneSpecification(
           handleUncaughtError: (self, parent, zone, error, stackTrace) {
             if (!handler.isCompleted) {
-              onUncaughtError(error);
+              onUncaughtError(error, stackTrace);
+            } else {
+              parent.handleUncaughtError(zone, error, stackTrace);
             }
           },
         ),
@@ -419,8 +424,8 @@ abstract class DioMixin implements Dio {
               final handler = RequestInterceptorHandler();
               createInterceptorZone(
                 handler,
-                (error) => handler.reject(
-                  assureDioException(error, requestOptions),
+                (error, stackTrace) => handler.reject(
+                  assureDioException(error, requestOptions, stackTrace),
                   true,
                 ),
               ).run(() => cb(state.data as RequestOptions, handler));
@@ -447,8 +452,8 @@ abstract class DioMixin implements Dio {
               final handler = ResponseInterceptorHandler();
               createInterceptorZone(
                 handler,
-                (error) => handler.reject(
-                  assureDioException(error, requestOptions),
+                (error, stackTrace) => handler.reject(
+                  assureDioException(error, requestOptions, stackTrace),
                   true,
                 ),
               ).run(() => cb(state.data as Response, handler));
@@ -473,7 +478,9 @@ abstract class DioMixin implements Dio {
           final handler = ErrorInterceptorHandler();
           createInterceptorZone(
             handler,
-            (error) => handler.next(assureDioException(error, requestOptions)),
+            (error, stackTrace) => handler.next(
+              assureDioException(error, requestOptions, stackTrace),
+            ),
           ).run(() => cb(state.data, handler));
           return handler.future;
         }
@@ -750,14 +757,16 @@ abstract class DioMixin implements Dio {
   @internal
   static DioException assureDioException(
     Object error,
-    RequestOptions requestOptions,
-  ) {
+    RequestOptions requestOptions, [
+    StackTrace? stackTrace,
+  ]) {
     if (error is DioException) {
       return error;
     }
     return DioException(
       requestOptions: requestOptions,
       error: error,
+      stackTrace: stackTrace,
     );
   }
 

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -426,6 +426,80 @@ void main() {
       );
     });
 
+    test('Async interceptor error does not hang the request', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter();
+      const errorMsg = 'async interceptor error';
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          // ignore: void_checks
+          onRequest: (options, handler) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            throw UnsupportedError(errorMsg);
+          },
+        ),
+      );
+      await expectLater(
+        dio.get('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<UnsupportedError>()
+                .having((e) => e.message, 'message', errorMsg),
+          ),
+        ),
+      );
+    });
+
+    test('Async onResponse error does not hang the request', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter();
+      const errorMsg = 'async response error';
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          // ignore: void_checks
+          onResponse: (response, handler) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            throw UnsupportedError(errorMsg);
+          },
+        ),
+      );
+      await expectLater(
+        dio.get('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<UnsupportedError>()
+                .having((e) => e.message, 'message', errorMsg),
+          ),
+        ),
+      );
+    });
+
+    test('Async onError interceptor error does not hang', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter();
+      const errorMsg = 'async error interceptor error';
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          // ignore: void_checks
+          onError: (err, handler) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            throw UnsupportedError(errorMsg);
+          },
+        ),
+      );
+      await expectLater(
+        dio.get('/test-not-found'),
+        throwsA(isA<DioException>()),
+      );
+    });
+
     group(ImplyContentTypeInterceptor, () {
       Dio createDio() {
         final dio = Dio();

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -435,7 +435,7 @@ void main() {
         InterceptorsWrapper(
           // ignore: void_checks
           onRequest: (options, handler) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await Future<void>.value();
             throw UnsupportedError(errorMsg);
           },
         ),
@@ -462,7 +462,7 @@ void main() {
         InterceptorsWrapper(
           // ignore: void_checks
           onResponse: (response, handler) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await Future<void>.value();
             throw UnsupportedError(errorMsg);
           },
         ),
@@ -489,7 +489,7 @@ void main() {
         InterceptorsWrapper(
           // ignore: void_checks
           onError: (err, handler) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await Future<void>.value();
             throw UnsupportedError(errorMsg);
           },
         ),

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -496,7 +496,14 @@ void main() {
       );
       await expectLater(
         dio.get('/test-not-found'),
-        throwsA(isA<DioException>()),
+        throwsA(
+          isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<UnsupportedError>()
+                .having((e) => e.message, 'message', errorMsg),
+          ),
+        ),
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes #2138.

When an interceptor overrides `onRequest`/`onResponse`/`onError` with an `async` implementation and throws after an `await` without calling the handler, the request hangs indefinitely. The handler's `Completer` is never completed because:

1. The callback typedef is `void`, so the returned `Future` is discarded
2. The unhandled async error goes to the zone's uncaught error handler
3. Nobody ever calls `handler.next()`/`reject()`/`resolve()`

```dart
// This hangs forever:
class MyInterceptor extends Interceptor {
  @override
  void onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
    await refreshToken(); // throws
    handler.next(options); // never reached
  }
}
```

### Approach

Each interceptor callback is now invoked inside a forked `Zone` with a custom `handleUncaughtError`. When an uncaught async error occurs and the handler hasn't been completed yet, the zone handler calls `handler.reject()` (or `handler.next()` for error interceptors) to unblock the request.

This approach differs from the reverted PR #2139 which changed the callback typedefs to `FutureOr<void>` and awaited the return value. That changed the microtask ordering and broke multi-interceptor chains (#2167). `Zone.fork()` does **not** await the callback -- it only catches async errors that would otherwise be lost, preserving the original execution order.

### Why this works

| Scenario | Before | After |
|----------|--------|-------|
| Sync interceptor, calls handler | Works | Works (no change) |
| Sync interceptor, throws | Works (propagates via Future) | Works (sync errors pass through Zone.run) |
| Async interceptor, calls handler | Works | Works (zone has no effect) |
| Async interceptor, throws | **Hangs forever** | Zone catches error, rejects handler |
| Duplicate handler.next() calls | Throws StateError | Throws StateError (sync, passes through) |

## Test plan

- Added 3 new tests for async throw scenarios (onRequest, onResponse, onError)
- All 218 existing tests pass
- All 32 interceptor-specific tests pass (including "duplicate handler calls" and the existing "Caught exceptions before handler called" test)
- `dart format` and `dart analyze` clean