### PR TITLE
fix: parse single-string JSON response (#2509)

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -563,6 +563,22 @@ abstract class DioMixin implements Dio {
           reqOpt,
           responseBody,
         );
+        if (data is String &&
+            data.isNotEmpty &&
+            T == String &&
+            reqOpt.responseType == ResponseType.plain &&
+            Transformer.isJsonMimeType(
+              responseBody.headers[Headers.contentTypeHeader]?.first,
+            )) {
+          try {
+            final decoded = jsonDecode(data);
+            if (decoded is String) {
+              data = decoded;
+            }
+          } on FormatException {
+            // Keep the original plain string when it is not valid JSON.
+          }
+        }
         // Make the response as null before returned as JSON.
         if (data is String &&
             data.isEmpty &&

--- a/dio/test/mock/adapters.dart
+++ b/dio/test/mock/adapters.dart
@@ -90,6 +90,14 @@ class MockAdapter implements HttpClientAdapter {
               Headers.contentTypeHeader: [Headers.textPlainContentType],
             },
           );
+        case '/test-json-string-content-type':
+          return ResponseBody.fromString(
+            '"adc89802-9c92-418f-b2ce-8f89308571f9"',
+            200,
+            headers: {
+              Headers.contentTypeHeader: [Headers.jsonContentType],
+            },
+          );
         case '/test-timeout':
           await Future.delayed(const Duration(days: 365));
           return ResponseBody.fromString('', 200);

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -372,6 +372,19 @@ void main() {
     );
   });
 
+  test('String generic decodes JSON string responses', () async {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: MockAdapter.mockBase,
+        contentType: Headers.jsonContentType,
+      ),
+    )..httpClientAdapter = MockAdapter();
+
+    final response = await dio.get<String>('/test-json-string-content-type');
+
+    expect(response.data, 'adc89802-9c92-418f-b2ce-8f89308571f9');
+  });
+
   test('option invalid base url', () {
     final invalidUrls = <String>[
       'blob:http://localhost/xyz123',


### PR DESCRIPTION
Fixes #2509.

`ResponseType.json` with a single JSON string value (e.g. `"ok"`) was not parsed correctly.
This updates parsing in `dio_mixin` and adds regression tests in `options_test.dart` (with adapter support in `test/mock/adapters.dart`).

Checklist:
✅ tests added
✅ branch up to date (you are)
✅ run tests first, then mark done