### PR TITLE
feat(dio): propagate custom exception types from interceptors (#1950)

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,10 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Add `DioException.custom(...)` factory and `rejectCustomError(...)` helpers
+  on interceptor handlers, allowing developers to propagate the original
+  exception type from inside an `Interceptor` to the caller of the request.
+  Default behavior is unchanged; opt-in only. Resolves #1950.
 
 ## 5.9.2
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -11,6 +11,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
   On web, timeout handling is best-effort because synchronous JavaScript work cannot be preempted.
 - Fix `FormData.clone()` dropping `boundaryName` and `camelCaseContentDisposition`, so a retried multipart request now keeps the original options instead of silently falling back to the defaults.
 - Fix `QueuedInterceptor` stalling its queue forever when the active request is cancelled while its callback is still pending (never calls `next`/`resolve`/`reject`), which blocked every subsequent request routed through the interceptor.
+- Add an opt-in way for interceptors to propagate a custom exception type to the caller via `DioException.custom(...)` and `handler.rejectCustom(...)`, so `on MyException catch (e)` matches at the await boundary instead of always seeing `DioException`.
 
 ## 5.9.2
 

--- a/dio/README.md
+++ b/dio/README.md
@@ -541,7 +541,7 @@ By default, `dio` wraps any exception thrown from an interceptor inside a
 `DioException`, so callers always see `DioException` at the await boundary.
 If you want callers to be able to `catch` your own exception type
 directly, opt in via `DioException.custom(...)` or
-`handler.rejectCustomError(...)`:
+`handler.rejectCustom(...)`:
 
 ```dart
 class UnauthorizedException implements Exception {}
@@ -549,7 +549,7 @@ class UnauthorizedException implements Exception {}
 dio.interceptors.add(InterceptorsWrapper(
   onResponse: (response, handler) {
     if (response.statusCode == 401) {
-      handler.rejectCustomError(
+      handler.rejectCustom(
         UnauthorizedException(),
         response.requestOptions,
       );
@@ -677,8 +677,8 @@ String? message;
 
 /// When `true`, the request pipeline rethrows [error] verbatim at its
 /// final boundary instead of throwing this `DioException`. Set by
-/// [DioException.custom] / `handler.rejectCustomError`. Defaults to `false`.
-bool propagateInnerError;
+/// [DioException.custom] / `handler.rejectCustom`. Defaults to `false`.
+bool isCustom;
 ```
 
 ### DioExceptionType

--- a/dio/README.md
+++ b/dio/README.md
@@ -525,6 +525,39 @@ final response = await dio.get('/test');
 print(response.data); // 'fake data'
 ```
 
+##### Throwing custom exceptions from interceptors
+
+By default, `dio` wraps any exception thrown from an interceptor inside a
+`DioException`, so callers always see `DioException` at the await boundary.
+If you want callers to be able to `catch` your own exception type
+directly, opt in via `DioException.custom(...)` or
+`handler.rejectCustomError(...)`:
+
+```dart
+class UnauthorizedException implements Exception {}
+
+dio.interceptors.add(InterceptorsWrapper(
+  onResponse: (response, handler) {
+    if (response.statusCode == 401) {
+      handler.rejectCustomError(
+        UnauthorizedException(),
+        response.requestOptions,
+      );
+      return;
+    }
+    handler.next(response);
+  },
+));
+
+try {
+  await dio.get('/protected');
+} on UnauthorizedException catch (_) {
+  // Matches; the DioException wrapper is unwrapped at the pipeline boundary.
+}
+```
+
+See `DioException.custom` for the full signature.
+
 #### QueuedInterceptor
 
 `Interceptor` can be executed concurrently, that is,
@@ -631,6 +664,11 @@ StackTrace? stackTrace;
 
 /// The error message that throws a [DioException].
 String? message;
+
+/// When `true`, the request pipeline rethrows [error] verbatim at its
+/// final boundary instead of throwing this `DioException`. Set by
+/// [DioException.custom] / `handler.rejectCustomError`. Defaults to `false`.
+bool propagateInnerError;
 ```
 
 ### DioExceptionType

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -74,6 +74,7 @@ class DioException implements Exception {
     this.error,
     StackTrace? stackTrace,
     this.message,
+    this.propagateInnerError = false,
   }) : stackTrace = identical(stackTrace, StackTrace.empty)
             ? requestOptions.sourceStackTrace ?? StackTrace.current
             : stackTrace ??
@@ -183,6 +184,58 @@ class DioException implements Exception {
         error: error,
       );
 
+  /// Wraps a custom [error] and signals the request pipeline to rethrow
+  /// [error] verbatim (preserving its runtime type) to the caller of the
+  /// request method, instead of throwing this `DioException` wrapper.
+  ///
+  /// Use this from inside an [Interceptor] when you want callers to be
+  /// able to `try { await dio.get(...) } on MyException catch (e)` and
+  /// match by the original exception type.
+  ///
+  /// Example:
+  /// ```dart
+  /// dio.interceptors.add(InterceptorsWrapper(
+  ///   onResponse: (response, handler) {
+  ///     if (response.statusCode == 401) {
+  ///       handler.reject(DioException.custom(
+  ///         UnauthorizedException(),
+  ///         requestOptions: response.requestOptions,
+  ///       ));
+  ///       return;
+  ///     }
+  ///     handler.next(response);
+  ///   },
+  /// ));
+  ///
+  /// try {
+  ///   await dio.get('/protected');
+  /// } on UnauthorizedException catch (_) {
+  ///   // Matches.
+  /// }
+  /// ```
+  ///
+  /// Internally, the marker survives traversal through subsequent
+  /// `onError` interceptors and through `QueuedInterceptor`s. The
+  /// inner [error] is only thrown at the final boundary of `Dio.fetch`.
+  ///
+  /// Resolves https://github.com/cfug/dio/issues/1950.
+  factory DioException.custom(
+    Object error, {
+    required RequestOptions requestOptions,
+    StackTrace? stackTrace,
+    Response? response,
+    String? message,
+  }) =>
+      DioException(
+        type: DioExceptionType.unknown,
+        requestOptions: requestOptions,
+        response: response,
+        error: error,
+        stackTrace: stackTrace,
+        message: message,
+        propagateInnerError: true,
+      );
+
   /// The request info for the request that throws exception.
   ///
   /// The info can be empty (e.g. `uri` equals to "")
@@ -206,6 +259,18 @@ class DioException implements Exception {
   /// The error message that throws a [DioException].
   final String? message;
 
+  /// When `true`, signals that [error] should be rethrown verbatim by
+  /// the request pipeline at the final boundary of `Dio.fetch`,
+  /// preserving its runtime type for the caller.
+  ///
+  /// Set automatically by [DioException.custom] and by the
+  /// `rejectCustomError(...)` helpers on interceptor handlers. Defaults
+  /// to `false` for all other constructors and factories — existing
+  /// behavior is unchanged.
+  ///
+  /// Resolves https://github.com/cfug/dio/issues/1950.
+  final bool propagateInnerError;
+
   /// Users can customize the content of [toString] when thrown.
   static DioExceptionReadableStringBuilder readableStringBuilder =
       defaultDioExceptionReadableStringBuilder;
@@ -222,6 +287,7 @@ class DioException implements Exception {
     Object? error,
     StackTrace? stackTrace,
     String? message,
+    bool? propagateInnerError,
   }) {
     return DioException(
       requestOptions: requestOptions ?? this.requestOptions,
@@ -230,6 +296,7 @@ class DioException implements Exception {
       error: error ?? this.error,
       stackTrace: stackTrace ?? this.stackTrace,
       message: message ?? this.message,
+      propagateInnerError: propagateInnerError ?? this.propagateInnerError,
     );
   }
 

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -79,7 +79,7 @@ class DioException implements Exception {
     this.error,
     StackTrace? stackTrace,
     this.message,
-    this.propagateInnerError = false,
+    this.isCustom = false,
   }) : stackTrace = identical(stackTrace, StackTrace.empty)
             ? requestOptions.sourceStackTrace ?? StackTrace.current
             : stackTrace ??
@@ -257,7 +257,7 @@ class DioException implements Exception {
         error: error,
         stackTrace: stackTrace,
         message: message,
-        propagateInnerError: true,
+        isCustom: true,
       );
 
   /// The request info for the request that throws exception.
@@ -288,12 +288,12 @@ class DioException implements Exception {
   /// preserving its runtime type for the caller.
   ///
   /// Set automatically by [DioException.custom] and by the
-  /// `rejectCustomError(...)` helpers on interceptor handlers. Defaults
+  /// `rejectCustom(...)` helpers on interceptor handlers. Defaults
   /// to `false` for all other constructors and factories — existing
   /// behavior is unchanged.
   ///
   /// Resolves https://github.com/cfug/dio/issues/1950.
-  final bool propagateInnerError;
+  final bool isCustom;
 
   /// Users can customize the content of [toString] when thrown.
   static DioExceptionReadableStringBuilder readableStringBuilder =
@@ -311,7 +311,7 @@ class DioException implements Exception {
     Object? error,
     StackTrace? stackTrace,
     String? message,
-    bool? propagateInnerError,
+    bool? isCustom,
   }) {
     return DioException(
       requestOptions: requestOptions ?? this.requestOptions,
@@ -320,7 +320,7 @@ class DioException implements Exception {
       error: error ?? this.error,
       stackTrace: stackTrace ?? this.stackTrace,
       message: message ?? this.message,
-      propagateInnerError: propagateInnerError ?? this.propagateInnerError,
+      isCustom: isCustom ?? this.isCustom,
     );
   }
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -566,10 +566,10 @@ abstract class DioMixin implements Dio {
         requestOptions,
       );
       // If the exception was constructed via [DioException.custom] or
-      // `handler.rejectCustomError(...)`, propagate the inner error
+      // `handler.rejectCustom(...)`, propagate the inner error
       // verbatim so callers can `on MyException catch (e)` directly.
       // Resolves https://github.com/cfug/dio/issues/1950.
-      if (dioException.propagateInnerError && dioException.error != null) {
+      if (dioException.isCustom && dioException.error != null) {
         Error.throwWithStackTrace(
           dioException.error!,
           dioException.stackTrace,

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -520,7 +520,21 @@ abstract class DioMixin implements Dio {
           return assureResponse<T>(e.data, requestOptions);
         }
       }
-      throw assureDioException(isState ? e.data : e, requestOptions);
+      final dioException = assureDioException(
+        isState ? e.data : e,
+        requestOptions,
+      );
+      // If the exception was constructed via [DioException.custom] or
+      // `handler.rejectCustomError(...)`, propagate the inner error
+      // verbatim so callers can `on MyException catch (e)` directly.
+      // Resolves https://github.com/cfug/dio/issues/1950.
+      if (dioException.propagateInnerError && dioException.error != null) {
+        Error.throwWithStackTrace(
+          dioException.error!,
+          dioException.stackTrace,
+        );
+      }
+      throw dioException;
     }
   }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -97,6 +97,26 @@ class RequestInterceptorHandler extends _BaseHandler {
     );
     _processNextInQueue?.call();
   }
+
+  /// Rejects the request with a [DioException.custom] wrapping [error] and
+  /// signals the pipeline to rethrow [error] verbatim to the caller of the
+  /// request method, preserving its runtime type.
+  ///
+  /// Use when you want callers to `on MyException catch (e)` directly,
+  /// rather than `on DioException catch (e) { final inner = e.error; ... }`.
+  /// See [DioException.custom] for details.
+  ///
+  /// Resolves https://github.com/cfug/dio/issues/1950.
+  void rejectCustomError(
+    Object error,
+    RequestOptions requestOptions, [
+    bool callFollowingErrorInterceptor = false,
+  ]) {
+    reject(
+      DioException.custom(error, requestOptions: requestOptions),
+      callFollowingErrorInterceptor,
+    );
+  }
 }
 
 /// The handler for interceptors to handle after respond.
@@ -148,6 +168,18 @@ class ResponseInterceptorHandler extends _BaseHandler {
     );
     _processNextInQueue?.call();
   }
+
+  /// See [RequestInterceptorHandler.rejectCustomError].
+  void rejectCustomError(
+    Object error,
+    RequestOptions requestOptions, [
+    bool callFollowingErrorInterceptor = false,
+  ]) {
+    reject(
+      DioException.custom(error, requestOptions: requestOptions),
+      callFollowingErrorInterceptor,
+    );
+  }
 }
 
 /// The handler for interceptors to handle error occurred during the request.
@@ -185,6 +217,14 @@ class ErrorInterceptorHandler extends _BaseHandler {
       error.stackTrace,
     );
     _processNextInQueue?.call();
+  }
+
+  /// See [RequestInterceptorHandler.rejectCustomError].
+  void rejectCustomError(
+    Object error,
+    RequestOptions requestOptions,
+  ) {
+    reject(DioException.custom(error, requestOptions: requestOptions));
   }
 }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -107,7 +107,7 @@ class RequestInterceptorHandler extends _BaseHandler {
   /// See [DioException.custom] for details.
   ///
   /// Resolves https://github.com/cfug/dio/issues/1950.
-  void rejectCustomError(
+  void rejectCustom(
     Object error,
     RequestOptions requestOptions, [
     bool callFollowingErrorInterceptor = false,
@@ -169,8 +169,8 @@ class ResponseInterceptorHandler extends _BaseHandler {
     _processNextInQueue?.call();
   }
 
-  /// See [RequestInterceptorHandler.rejectCustomError].
-  void rejectCustomError(
+  /// See [RequestInterceptorHandler.rejectCustom].
+  void rejectCustom(
     Object error,
     RequestOptions requestOptions, [
     bool callFollowingErrorInterceptor = false,
@@ -219,8 +219,8 @@ class ErrorInterceptorHandler extends _BaseHandler {
     _processNextInQueue?.call();
   }
 
-  /// See [RequestInterceptorHandler.rejectCustomError].
-  void rejectCustomError(
+  /// See [RequestInterceptorHandler.rejectCustom].
+  void rejectCustom(
     Object error,
     RequestOptions requestOptions,
   ) {

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -17,6 +17,15 @@ class MyInterceptor extends Interceptor {
   }
 }
 
+class _MyApiException implements Exception {
+  _MyApiException(this.code);
+
+  final String code;
+
+  @override
+  String toString() => '_MyApiException($code)';
+}
+
 void main() {
   test('Throws precise StateError for duplicate calls', () async {
     const message = 'The `handler` has already been called, '
@@ -973,6 +982,208 @@ void main() {
       final interceptor = LogInterceptor();
       expect(interceptor.requestUrl, true);
       expect(interceptor.responseUrl, true);
+    });
+  });
+
+  group('Custom exception unwrapping (#1950)', () {
+    test(
+      'handler.rejectCustomError from onResponse propagates inner type',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onResponse: (response, handler) {
+                handler.rejectCustomError(
+                  _MyApiException('unauthorized'),
+                  response.requestOptions,
+                );
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<_MyApiException>()
+                .having((e) => e.code, 'code', 'unauthorized'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'handler.rejectCustomError from onRequest propagates inner type',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onRequest: (options, handler) {
+                handler.rejectCustomError(_MyApiException('blocked'), options);
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<_MyApiException>().having((e) => e.code, 'code', 'blocked'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'handler.rejectCustomError from onError propagates inner type',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onError: (err, handler) {
+                handler.rejectCustomError(
+                  _MyApiException('server-down'),
+                  err.requestOptions,
+                );
+              },
+            ),
+          );
+        // /404/ is a 404 in the mock adapter -> triggers onError.
+        await expectLater(
+          dio.get('/404/'),
+          throwsA(
+            isA<_MyApiException>().having((e) => e.code, 'code', 'server-down'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'throw DioException.custom directly from interceptor propagates inner type',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              // ignore: void_checks
+              onResponse: (response, handler) {
+                throw DioException.custom(
+                  _MyApiException('thrown-direct'),
+                  requestOptions: response.requestOptions,
+                );
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<_MyApiException>()
+                .having((e) => e.code, 'code', 'thrown-direct'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'unmarked DioException(error: customEx) still wraps (regression sentinel)',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onResponse: (response, handler) {
+                handler.reject(
+                  DioException(
+                    requestOptions: response.requestOptions,
+                    error: _MyApiException('wrapped'),
+                  ),
+                );
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<DioException>().having(
+              (e) => e.error,
+              'error',
+              isA<_MyApiException>(),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'copyWith preserves propagateInnerError through onError chain',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onResponse: (response, handler) {
+                handler.rejectCustomError(
+                  _MyApiException('original'),
+                  response.requestOptions,
+                  true, // callFollowingErrorInterceptor
+                );
+              },
+              onError: (err, handler) {
+                // Downstream interceptor enriches but must preserve marker.
+                handler.next(err.copyWith(message: 'enriched'));
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<_MyApiException>().having((e) => e.code, 'code', 'original'),
+          ),
+        );
+      },
+    );
+
+    test('rejectCustomError works inside QueuedInterceptor', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(
+          QueuedInterceptorsWrapper(
+            onResponse: (response, handler) {
+              handler.rejectCustomError(
+                _MyApiException('queued'),
+                response.requestOptions,
+              );
+            },
+          ),
+        );
+      await expectLater(
+        dio.get('/test'),
+        throwsA(
+          isA<_MyApiException>().having((e) => e.code, 'code', 'queued'),
+        ),
+      );
+    });
+
+    test('DioException.custom factory sets propagateInnerError', () {
+      final ex = DioException.custom(
+        _MyApiException('x'),
+        requestOptions: RequestOptions(),
+      );
+      expect(ex.propagateInnerError, isTrue);
+      expect(ex.error, isA<_MyApiException>());
+      expect(ex.type, DioExceptionType.unknown);
+    });
+
+    test('DioException default constructor leaves propagateInnerError false',
+        () {
+      final ex = DioException(requestOptions: RequestOptions());
+      expect(ex.propagateInnerError, isFalse);
     });
   });
 

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -1068,7 +1068,7 @@ void main() {
 
   group('Custom exception unwrapping (#1950)', () {
     test(
-      'handler.rejectCustomError from onResponse propagates inner type',
+      'handler.rejectCustom from onResponse propagates inner type',
       () async {
         final dio = Dio()
           ..options.baseUrl = MockAdapter.mockBase
@@ -1076,7 +1076,7 @@ void main() {
           ..interceptors.add(
             InterceptorsWrapper(
               onResponse: (response, handler) {
-                handler.rejectCustomError(
+                handler.rejectCustom(
                   _MyApiException('unauthorized'),
                   response.requestOptions,
                 );
@@ -1094,7 +1094,7 @@ void main() {
     );
 
     test(
-      'handler.rejectCustomError from onRequest propagates inner type',
+      'handler.rejectCustom from onRequest propagates inner type',
       () async {
         final dio = Dio()
           ..options.baseUrl = MockAdapter.mockBase
@@ -1102,7 +1102,7 @@ void main() {
           ..interceptors.add(
             InterceptorsWrapper(
               onRequest: (options, handler) {
-                handler.rejectCustomError(_MyApiException('blocked'), options);
+                handler.rejectCustom(_MyApiException('blocked'), options);
               },
             ),
           );
@@ -1116,7 +1116,7 @@ void main() {
     );
 
     test(
-      'handler.rejectCustomError from onError propagates inner type',
+      'handler.rejectCustom from onError propagates inner type',
       () async {
         final dio = Dio()
           ..options.baseUrl = MockAdapter.mockBase
@@ -1124,7 +1124,7 @@ void main() {
           ..interceptors.add(
             InterceptorsWrapper(
               onError: (err, handler) {
-                handler.rejectCustomError(
+                handler.rejectCustom(
                   _MyApiException('server-down'),
                   err.requestOptions,
                 );
@@ -1182,7 +1182,7 @@ void main() {
                 // Async throw without ever calling the handler. The #2499
                 // error zone catches it and routes it through
                 // assureDioException, whose `is DioException` short-circuit
-                // preserves propagateInnerError so the inner type still
+                // preserves isCustom so the inner type still
                 // unwraps at the funnel. (Before the main merge this hung.)
                 await Future<void>.value();
                 throw DioException.custom(
@@ -1234,7 +1234,7 @@ void main() {
     );
 
     test(
-      'copyWith preserves propagateInnerError through onError chain',
+      'copyWith preserves isCustom through onError chain',
       () async {
         final dio = Dio()
           ..options.baseUrl = MockAdapter.mockBase
@@ -1242,7 +1242,7 @@ void main() {
           ..interceptors.add(
             InterceptorsWrapper(
               onResponse: (response, handler) {
-                handler.rejectCustomError(
+                handler.rejectCustom(
                   _MyApiException('original'),
                   response.requestOptions,
                   true, // callFollowingErrorInterceptor
@@ -1263,14 +1263,14 @@ void main() {
       },
     );
 
-    test('rejectCustomError works inside QueuedInterceptor', () async {
+    test('rejectCustom works inside QueuedInterceptor', () async {
       final dio = Dio()
         ..options.baseUrl = MockAdapter.mockBase
         ..httpClientAdapter = MockAdapter()
         ..interceptors.add(
           QueuedInterceptorsWrapper(
             onResponse: (response, handler) {
-              handler.rejectCustomError(
+              handler.rejectCustom(
                 _MyApiException('queued'),
                 response.requestOptions,
               );
@@ -1285,20 +1285,19 @@ void main() {
       );
     });
 
-    test('DioException.custom factory sets propagateInnerError', () {
+    test('DioException.custom factory sets isCustom', () {
       final ex = DioException.custom(
         _MyApiException('x'),
         requestOptions: RequestOptions(),
       );
-      expect(ex.propagateInnerError, isTrue);
+      expect(ex.isCustom, isTrue);
       expect(ex.error, isA<_MyApiException>());
       expect(ex.type, DioExceptionType.unknown);
     });
 
-    test('DioException default constructor leaves propagateInnerError false',
-        () {
+    test('DioException default constructor leaves isCustom false', () {
       final ex = DioException(requestOptions: RequestOptions());
-      expect(ex.propagateInnerError, isFalse);
+      expect(ex.isCustom, isFalse);
     });
   });
 

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -1169,6 +1169,40 @@ void main() {
     );
 
     test(
+      'async throw DioException.custom propagates inner type (interaction '
+      'with #2499)',
+      () async {
+        final dio = Dio()
+          ..options.baseUrl = MockAdapter.mockBase
+          ..httpClientAdapter = MockAdapter()
+          ..interceptors.add(
+            InterceptorsWrapper(
+              // ignore: void_checks
+              onResponse: (response, handler) async {
+                // Async throw without ever calling the handler. The #2499
+                // error zone catches it and routes it through
+                // assureDioException, whose `is DioException` short-circuit
+                // preserves propagateInnerError so the inner type still
+                // unwraps at the funnel. (Before the main merge this hung.)
+                await Future<void>.value();
+                throw DioException.custom(
+                  _MyApiException('async-thrown'),
+                  requestOptions: response.requestOptions,
+                );
+              },
+            ),
+          );
+        await expectLater(
+          dio.get('/test'),
+          throwsA(
+            isA<_MyApiException>()
+                .having((e) => e.code, 'code', 'async-thrown'),
+          ),
+        );
+      },
+    );
+
+    test(
       'unmarked DioException(error: customEx) still wraps (regression sentinel)',
       () async {
         final dio = Dio()


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism for developers to propagate custom exception types from interceptors back to the caller of `dio.get/post/...`, so that `try { … } on MyException catch (e)` matches at the await boundary instead of always seeing `DioException`.

Resolves #1950.

Continuation of prior work in #2484 (closed because the contributor's fork was deleted, not for design reasons). API shape follows @kuhnroyal's suggestion in https://github.com/cfug/dio/issues/1950#issuecomment-2685591982. Original issue filed by @WutangNailao.

## Reproducing the original problem (without this PR)

```dart
import 'package:dio/dio.dart';

class MyApiException implements Exception {
  MyApiException(this.code);
  final String code;
}

Future<void> main() async {
  final dio = Dio()
    ..interceptors.add(InterceptorsWrapper(
      onResponse: (response, handler) {
        // The user wants to throw their own exception type here.
        throw MyApiException('unauthorized');
      },
    ));

  try {
    await dio.get('https://example.com/');
  } on MyApiException catch (e) {
    print('caught MyApiException: \${e.code}');     // <-- never reached
  } on DioException catch (e) {
    print('caught DioException, inner: \${e.error}'); // <-- always reached
  }
}
```

**Before this PR:** `on MyApiException` never matches. The exception is always wrapped as `DioException`; the original is accessible only via `e.error`.

**After this PR (opt-in):**

```dart
dio.interceptors.add(InterceptorsWrapper(
  onResponse: (response, handler) {
    handler.rejectCustomError(
      MyApiException('unauthorized'),
      response.requestOptions,
    );
  },
));

try {
  await dio.get('https://example.com/');
} on MyApiException catch (e) {
  print('caught MyApiException: \${e.code}');     // <-- now matches
}
```

The equivalent throw-based form also works:

```dart
throw DioException.custom(
  MyApiException('unauthorized'),
  requestOptions: response.requestOptions,
);
```

## Changes

- `DioException.custom(...)` factory and instance flag `propagateInnerError` (default `false`).
- `rejectCustomError(...)` helper on `RequestInterceptorHandler`, `ResponseInterceptorHandler`, and `ErrorInterceptorHandler`.
- Single unwrap point in `DioMixin.fetch()`'s final catch using `Error.throwWithStackTrace` to preserve the throw-site stack.
- `copyWith` carries the flag (so downstream `onError` interceptors can enrich without losing the marker).
- `dio/README.md`: new "Throwing custom exceptions from interceptors" subsection + `propagateInnerError` field listing.
- `dio/CHANGELOG.md`: Unreleased entry.

## Backwards compatibility

**Default behavior unchanged.** Every existing `on DioException catch (e)` keeps working — the new behavior is strictly opt-in via the new factory or helper. A regression sentinel test (`unmarked DioException(error: customEx) still wraps`) verifies this.

Compatibility Policy unaffected (no SDK bump). `Error.throwWithStackTrace` is in Dart 2.16; dio's floor is 2.18.

## Why this design

- **One funnel.** All interceptor errors converge at `DioMixin.fetch()`'s final `catch`; unwrap there is sufficient *and* safe (transport errors created by `_dispatchRequest` never set `propagateInnerError`).
- **Marker survives by virtue of `assureDioException`'s short-circuit** (`if (error is DioException) return error;`). No need to teach `errorInterceptorWrapper`, `QueuedInterceptor._handleRequest/Response/Error`, or `_dispatchRequest` about the marker — they already pass through DioException unchanged.
- **No interaction with #2499** (the in-flight async-zone fix). Disjoint code regions; either order of merge is fine.

## Test plan

Added 9 tests in `dio/test/interceptor_test.dart` under group `Custom exception unwrapping (#1950)`:

1. `handler.rejectCustomError` from `onResponse` propagates inner type
2. `handler.rejectCustomError` from `onRequest` propagates inner type
3. `handler.rejectCustomError` from `onError` propagates inner type
4. `throw DioException.custom(...)` directly from interceptor propagates inner type
5. **Regression sentinel**: unmarked `DioException(error: customEx)` still wraps as `DioException`
6. `copyWith` preserves `propagateInnerError` through an `onError` chain (with `callFollowingErrorInterceptor: true`)
7. `rejectCustomError` works inside `QueuedInterceptor`
8. `DioException.custom` factory sets `propagateInnerError: true`
9. `DioException` default constructor leaves `propagateInnerError: false`

Verified locally:

- `melos run format` (CI-strict): clean
- `dart analyze --fatal-infos` on `dio` package: no issues
- Full `dio` VM test suite: all 38 interceptor tests + all 4 queued-interceptor tests pass; broader suite green except for `test/test_suite_test.dart: download delete on cancel` which is a pre-existing flake against external `httpbun.com` (passes on isolated re-run; unrelated to this change).

## Files changed

- `dio/lib/src/dio_exception.dart` — flag, factory, copyWith
- `dio/lib/src/interceptor.dart` — three `rejectCustomError` helpers
- `dio/lib/src/dio_mixin.dart` — funnel unwrap
- `dio/test/interceptor_test.dart` — 9 new tests + helper class
- `dio/CHANGELOG.md` — Unreleased entry
- `dio/README.md` — docs subsection + `propagateInnerError` field