### PR TITLE
fix(dio): start receiveTimeout timer immediately after headers, not on first body byte

### DIFF
--- a/dio/lib/src/response/response_stream_handler.dart
+++ b/dio/lib/src/response/response_stream_handler.dart
@@ -67,6 +67,10 @@ Stream<Uint8List> handleResponseStream(
     });
   }
 
+  // Also start watching before the first chunk to cover the gap between
+  // headers and body (see onData below for per-chunk reset).
+  watchReceiveTimeout();
+
   responseSubscription = source.listen(
     (data) {
       watchReceiveTimeout();

--- a/dio/test/response/response_stream_test.dart
+++ b/dio/test/response/response_stream_test.dart
@@ -238,6 +238,26 @@ void main() {
       });
     });
 
+    test('emits receiveTimeout when no body bytes arrive after headers',
+        () async {
+      final stream = handleResponseStream(
+        RequestOptions(
+          receiveTimeout: const Duration(milliseconds: 100),
+        ),
+        ResponseBody(source.stream, 200),
+      );
+
+      await expectLater(
+        stream,
+        emitsInOrder([
+          emitsError(
+            matchesDioException(DioExceptionType.receiveTimeout),
+          ),
+          emitsDone,
+        ]),
+      );
+    });
+
     test('not watching the receive timeout after cancelled', () async {
       bool timerCancelled = false;
       final cancelToken = CancelToken();


### PR DESCRIPTION
## Problem

`receiveTimeout` is not triggered when a server sends response headers but does not send any body bytes.

In `handleResponseStream`, `watchReceiveTimeout()` is only called inside the `onData` callback. If the server sends headers but then goes silent and does not send any body bytes, `onData` is never called, the timer never starts, and the request hangs indefinitely despite `receiveTimeout` being configured.

This is especially common in networks with Deep Packet Inspection (DPI) and blocking systems — they may allow the TCP connection and response headers through, but block or indefinitely delay the response body.

## Fix

Call `watchReceiveTimeout()` once before `source.listen()` so the timer starts immediately after response headers are received.

A regression test is included that verifies `receiveTimeout` fires even when no body bytes arrive.