### PR TITLE
🐛 Fix QueuedInterceptor queue stalling when the active request is cancelled

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -10,6 +10,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.
   On web, timeout handling is best-effort because synchronous JavaScript work cannot be preempted.
 - Fix `FormData.clone()` dropping `boundaryName` and `camelCaseContentDisposition`, so a retried multipart request now keeps the original options instead of silently falling back to the defaults.
+- Fix `QueuedInterceptor` stalling its queue forever when the active request is cancelled while its callback is still pending (never calls `next`/`resolve`/`reject`), which blocked every subsequent request routed through the interceptor.
 
 ## 5.9.2
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -443,20 +443,67 @@ class QueuedInterceptor extends Interceptor {
     void Function(T, V) callback,
     void Function(Object, V) onError,
   ) {
-    final task = _InterceptorParams<T, V>(data, handler);
-    task.handler._processNextInQueue = () {
-      if (taskQueue.queue.isNotEmpty) {
-        final next = taskQueue.queue.removeFirst();
-        assert(next.handler._processNextInQueue != null);
-        callback(next.data, next.handler);
-      } else {
-        taskQueue.processing = false;
+    // Runs [task] as the active task and wires up how the queue advances to
+    // the next task once this one is done.
+    void runTask(_InterceptorParams<T, V> task) {
+      // Hold the task in a clearable reference so that the `whenCancel`
+      // closure registered below — which cannot be detached from the
+      // [CancelToken]'s internal completer — stops pinning the request
+      // payload ([RequestOptions]/[Response]/[DioException] and its handler)
+      // once the queue has advanced. The closure observes `taskRef == null`
+      // and then holds only a null reference, so for a [CancelToken] shared
+      // across many requests (a supported usage pattern documented on
+      // [CancelToken]) per-task allocations are released as each task
+      // completes, instead of accumulating until the token is cancelled.
+      //
+      // A `WeakReference` is intentionally NOT used here: while a task is the
+      // active one, this cell is its only strong reference (the queue has
+      // already removed it and the pending callback captured `task.data`/
+      // `task.handler`, not the wrapper). A weak reference could be collected
+      // mid-flight, so a later cancellation would see a null target, skip
+      // `advance()`, and never release the queue slot — reintroducing the stall
+      // this guards against. The clearable cell keeps the task reachable for
+      // exactly as long as it is active and releases it deterministically when
+      // `advance()` runs.
+      _InterceptorParams<T, V>? taskRef = task;
+
+      // Advancing the queue must happen exactly once per task: either when the
+      // handler is completed (next/resolve/reject) or when the request is
+      // cancelled before the handler is ever called. `advanced` guards against
+      // both paths firing for the same task.
+      bool advanced = false;
+      void advance() {
+        if (advanced) {
+          return;
+        }
+        advanced = true;
+        taskRef = null;
+        if (taskQueue.queue.isNotEmpty) {
+          runTask(taskQueue.queue.removeFirst());
+        } else {
+          taskQueue.processing = false;
+        }
       }
-    };
-    taskQueue.queue.add(task);
-    if (!taskQueue.processing) {
-      taskQueue.processing = true;
-      final task = taskQueue.queue.removeFirst();
+
+      task.handler._processNextInQueue = advance;
+
+      // If the request is cancelled while the interceptor callback is still
+      // pending — i.e. it never calls next/resolve/reject, e.g. an async
+      // `onRequest` awaiting a token refresh that gets cancelled — the
+      // handler's completer would never complete. Since the queue only
+      // advances through the handler, the active slot would never be released
+      // and every subsequent request routed through this interceptor would
+      // stall forever. Releasing the slot on cancellation keeps the queue
+      // moving; `advance` is idempotent, so a later normal completion (if the
+      // callback eventually resumes) is a no-op. The hook is only registered
+      // for the active task, so a queued task is never advanced out of turn.
+      _cancelTokenOf(task.data)?.whenCancel.then((_) {
+        final ref = taskRef;
+        if (ref != null && !ref.handler.isCompleted) {
+          advance();
+        }
+      });
+
       try {
         callback(task.data, task.handler);
       } catch (e) {
@@ -466,6 +513,28 @@ class QueuedInterceptor extends Interceptor {
         onError(e, task.handler);
       }
     }
+
+    taskQueue.queue.add(_InterceptorParams<T, V>(data, handler));
+    if (!taskQueue.processing) {
+      taskQueue.processing = true;
+      runTask(taskQueue.queue.removeFirst());
+    }
+  }
+
+  /// Extracts the [CancelToken] associated with a queued task's payload
+  /// ([RequestOptions], [Response] or [DioException]), if any, so the queue
+  /// can be released when the underlying request is cancelled.
+  static CancelToken? _cancelTokenOf(Object? data) {
+    if (data is RequestOptions) {
+      return data.cancelToken;
+    }
+    if (data is Response) {
+      return data.requestOptions.cancelToken;
+    }
+    if (data is DioException) {
+      return data.requestOptions.cancelToken;
+    }
+    return null;
   }
 }
 

--- a/dio/test/queued_interceptor_test.dart
+++ b/dio/test/queued_interceptor_test.dart
@@ -91,6 +91,121 @@ void main() {
       fail('Thrown unexpected error: $e');
     }
   });
+
+  test(
+      'QueuedInterceptor should not stall the queue when the active request is '
+      'cancelled mid-callback', () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _MockAdapter();
+
+    final tokenA = CancelToken();
+    final aOnRequestStarted = Completer<void>();
+
+    dio.interceptors.add(
+      QueuedInterceptorsWrapper(
+        onRequest: (options, handler) async {
+          // Simulate a slow async step (e.g. refreshing auth) that has NOT yet
+          // called handler.next when the request is cancelled.
+          if (options.path.contains('reqA')) {
+            aOnRequestStarted.complete();
+            await Future.delayed(const Duration(seconds: 5));
+          }
+          handler.next(options);
+        },
+      ),
+    );
+
+    // A becomes the active queued task; it is expected to be cancelled.
+    final futureA = dio.get(
+      'https://example.com/test?reqA',
+      cancelToken: tokenA,
+    );
+    // Install the rejection expectation up-front so its error listener is
+    // attached to [futureA] before the cancellation propagates. Without this
+    // the unawaited rejection would leak as an unhandled async error into
+    // subsequent tests; the returned future is awaited at the end of the
+    // test so the assertion is actually verified.
+    final aRejected = expectLater(
+      futureA,
+      throwsA(
+        isA<DioException>()
+            .having((e) => e.type, 'type', DioExceptionType.cancel),
+      ),
+    );
+
+    await aOnRequestStarted.future;
+
+    // B is an independent request with NO cancel token, queued behind A on the
+    // same QueuedInterceptor.
+    final futureB = dio.get('https://example.com/test?reqB');
+
+    // Cancel A while it is the active queued task.
+    tokenA.cancel('cancel A');
+
+    // B must complete promptly; if the queue stalled this times out.
+    final response = await futureB.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError(
+        'Queue stalled: a non-cancelled request never ran after the active '
+        'queued task was cancelled.',
+      ),
+    );
+    expect(response.statusCode, 200);
+
+    await aRejected;
+  });
+
+  test(
+      'QueuedInterceptor should not stall the response queue when the active '
+      'response is cancelled mid-callback', () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _MockAdapter();
+
+    final tokenA = CancelToken();
+    final aOnResponseStarted = Completer<void>();
+
+    dio.interceptors.add(
+      QueuedInterceptorsWrapper(
+        onResponse: (response, handler) async {
+          if (response.requestOptions.path.contains('reqA')) {
+            aOnResponseStarted.complete();
+            await Future.delayed(const Duration(seconds: 5));
+          }
+          handler.next(response);
+        },
+      ),
+    );
+
+    final futureA = dio.get(
+      'https://example.com/test?reqA',
+      cancelToken: tokenA,
+    );
+    // See test above: install the rejection assertion up-front so its
+    // listener is attached before cancellation, then await it at the end.
+    final aRejected = expectLater(
+      futureA,
+      throwsA(
+        isA<DioException>()
+            .having((e) => e.type, 'type', DioExceptionType.cancel),
+      ),
+    );
+
+    await aOnResponseStarted.future;
+
+    final futureB = dio.get('https://example.com/test?reqB');
+    tokenA.cancel('cancel A');
+
+    final response = await futureB.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => throw StateError(
+        'Response queue stalled: a non-cancelled request never ran after the '
+        'active queued response task was cancelled.',
+      ),
+    );
+    expect(response.statusCode, 200);
+
+    await aRejected;
+  });
 }
 
 class _MockAdapter implements HttpClientAdapter {


### PR DESCRIPTION
## Summary

When a request is cancelled (via `CancelToken`) while it is the **active** task in a `QueuedInterceptor`'s internal queue — i.e. its `onRequest`/`onResponse`/`onError` callback is still running an async step and has **not yet** called `handler.next`/`resolve`/`reject` — the queue stalls permanently. Every subsequent request routed through the same `QueuedInterceptor`, **including requests with no cancel token**, then hangs forever.

This hits a very common, real-world setup: a `QueuedInterceptor` that refreshes an auth token in an async `onRequest` (the canonical reason to use a *queued* interceptor), where the user cancels the in-flight request.

## Root cause

`QueuedInterceptor._handleQueue` only advances the queue from inside the handler's `next`/`resolve`/`reject` (via `_processNextInQueue`). Cancellation completes the **request** future (through `listenCancelForAsyncTask`) without ever completing the queued **handler**, so the active task is never released, `processing` stays `true`, and no further task is dequeued.

## Fix

Each task now arms a one-shot cancel hook — registered **only while it is the active task**, so a queued task is never advanced out of turn — that releases the queue slot if the request is cancelled before the handler completes. Queue advancement is made **idempotent** (an `advanced` guard) so a normal completion and a cancellation can't double-advance. No public API change; behaviour for non-cancelled requests is unchanged.

## Tests

Added two regression tests in `queued_interceptor_test.dart` (request queue + response queue): they cancel the active task mid-callback and assert that an independent, **un-cancelled** request still completes promptly. Both **fail (time out / "queue stalled") on `main`** and pass with this change.

- Full `dart test` suite: **221 passed, 6 network-gated skips, 0 failures**
- `dart format` and `dart analyze`: clean
- No public API change; `CHANGELOG.md` updated.