### PR TITLE
fix: add transform timeout for background decoding

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,7 +6,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
-- Add `transformTimeout` to abort long-running response transformations, including background JSON decoding.
+- Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.
+  On web, timeout handling is best-effort because synchronous JavaScript work cannot be preempted.
 
 ## 5.9.2
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,7 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
-- Fix background JSON decoding hanging indefinitely when `receiveTimeout` is configured.
+- Add `transformTimeout` to abort long-running response transformations, including background JSON decoding.
 
 ## 5.9.2
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,9 +6,9 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
+- Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 - Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.
   On web, timeout handling is best-effort because synchronous JavaScript work cannot be preempted.
-- Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 
 ## 5.9.2
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
+- Fix background JSON decoding hanging indefinitely when `receiveTimeout` is configured.
 
 ## 5.9.2
 

--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -328,6 +328,8 @@ Duration? receiveTimeout;
 ///
 /// 超时时会抛出类型为 [DioExceptionType.transformTimeout] 的
 /// [DioException]。
+/// 在 Web 上，超时处理是 best-effort，因为同步 JavaScript
+/// 任务无法被抢占中断。
 ///
 /// `null` 或 `Duration.zero` 即不设置超时。
 Duration? transformTimeout;

--- a/dio/README-ZH.md
+++ b/dio/README-ZH.md
@@ -324,6 +324,14 @@ Duration? sendTimeout;
 /// `null` 或 `Duration.zero` 即不设置超时。
 Duration? receiveTimeout;
 
+/// 转换响应数据的超时设置。
+///
+/// 超时时会抛出类型为 [DioExceptionType.transformTimeout] 的
+/// [DioException]。
+///
+/// `null` 或 `Duration.zero` 即不设置超时。
+Duration? transformTimeout;
+
 /// 可以在 [Interceptor]、[Transformer] 和
 /// [Response.requestOptions] 中获取到的自定义对象。
 Map<String, dynamic>? extra;

--- a/dio/README.md
+++ b/dio/README.md
@@ -311,6 +311,14 @@ Duration? sendTimeout;
 /// `null` or `Duration.zero` means no timeout limit.
 Duration? receiveTimeout;
 
+/// Timeout when transforming response data.
+///
+/// Throws the [DioException] with
+/// [DioExceptionType.transformTimeout] type when timed out.
+///
+/// `null` or `Duration.zero` means no timeout limit.
+Duration? transformTimeout;
+
 /// Custom field that you can retrieve it later in [Interceptor],
 /// [Transformer] and the [Response.requestOptions] object.
 Map<String, dynamic>? extra;

--- a/dio/README.md
+++ b/dio/README.md
@@ -315,6 +315,8 @@ Duration? receiveTimeout;
 ///
 /// Throws the [DioException] with
 /// [DioExceptionType.transformTimeout] type when timed out.
+/// On web, timeout handling is best-effort because synchronous JavaScript
+/// work cannot be preempted.
 ///
 /// `null` or `Duration.zero` means no timeout limit.
 Duration? transformTimeout;

--- a/dio/lib/src/compute/compute.dart
+++ b/dio/lib/src/compute/compute.dart
@@ -67,6 +67,7 @@ typedef ComputeImpl = Future<R> Function<Q, R>(
   ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
+  Duration? timeout,
 });
 
 /// A function that spawns an isolate and runs the provided `callback` on that

--- a/dio/lib/src/compute/compute.dart
+++ b/dio/lib/src/compute/compute.dart
@@ -67,6 +67,12 @@ typedef ComputeImpl = Future<R> Function<Q, R>(
   ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
+});
+
+typedef ComputeWithTimeoutImpl = Future<R> Function<Q, R>(
+  ComputeCallback<Q, R> callback,
+  Q message, {
+  String? debugLabel,
   Duration? timeout,
 });
 
@@ -139,3 +145,5 @@ typedef ComputeImpl = Future<R> Function<Q, R>(
 ///
 ///   * [ComputeImpl], for the [compute] function's signature.
 const ComputeImpl compute = _c.compute;
+
+const ComputeWithTimeoutImpl computeWithTimeout = _c.computeWithTimeout;

--- a/dio/lib/src/compute/compute_io.dart
+++ b/dio/lib/src/compute/compute_io.dart
@@ -30,6 +30,7 @@ Future<R> compute<Q, R>(
   c.ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
+  Duration? timeout,
 }) async {
   debugLabel ??= kReleaseMode ? 'compute' : callback.toString();
 
@@ -38,20 +39,40 @@ Future<R> compute<Q, R>(
   final RawReceivePort port = RawReceivePort();
   Timeline.finishSync();
 
+  Timer? timeoutTimer;
+  bool cleanedUp = false;
   void timeEndAndCleanup() {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    timeoutTimer?.cancel();
     Timeline.startSync('$debugLabel: end', flow: Flow.end(flow.id));
     port.close();
     Timeline.finishSync();
   }
 
   final Completer<dynamic> completer = Completer<dynamic>();
+  Isolate? isolate;
+
+  void completeWithError(Object error, [StackTrace? stackTrace]) {
+    if (completer.isCompleted) {
+      return;
+    }
+    timeEndAndCleanup();
+    completer.completeError(error, stackTrace);
+  }
+
   port.handler = (dynamic msg) {
+    if (completer.isCompleted) {
+      return;
+    }
     timeEndAndCleanup();
     completer.complete(msg);
   };
 
   try {
-    await Isolate.spawn<_IsolateConfiguration<Q, R>>(
+    isolate = await Isolate.spawn<_IsolateConfiguration<Q, R>>(
       _spawn,
       _IsolateConfiguration<Q, R>(
         callback,
@@ -68,6 +89,15 @@ Future<R> compute<Q, R>(
   } on Object {
     timeEndAndCleanup();
     rethrow;
+  }
+
+  if (timeout != null && timeout > Duration.zero && !completer.isCompleted) {
+    timeoutTimer = Timer(timeout, () {
+      isolate?.kill(priority: Isolate.immediate);
+      completeWithError(
+        TimeoutException('Computation timed out after $timeout.', timeout),
+      );
+    });
   }
 
   final dynamic response = await completer.future;

--- a/dio/lib/src/compute/compute_io.dart
+++ b/dio/lib/src/compute/compute_io.dart
@@ -30,6 +30,14 @@ Future<R> compute<Q, R>(
   c.ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
+}) {
+  return computeWithTimeout(callback, message, debugLabel: debugLabel);
+}
+
+Future<R> computeWithTimeout<Q, R>(
+  c.ComputeCallback<Q, R> callback,
+  Q message, {
+  String? debugLabel,
   Duration? timeout,
 }) async {
   debugLabel ??= kReleaseMode ? 'compute' : callback.toString();

--- a/dio/lib/src/compute/compute_web.dart
+++ b/dio/lib/src/compute/compute_web.dart
@@ -11,14 +11,37 @@ Future<R> computeWithTimeout<Q, R>(
   Q message, {
   String? debugLabel,
   Duration? timeout,
-}) {
+}) async {
   final result = web_adapter.compute(
     callback,
     message,
     debugLabel: debugLabel,
   );
-  if (timeout != null && timeout > Duration.zero) {
-    return result.timeout(timeout);
+  if (timeout == null || timeout <= Duration.zero) {
+    return result;
   }
-  return result;
+
+  final stopwatch = Stopwatch()..start();
+  try {
+    final value = await result.timeout(
+      timeout,
+      onTimeout: () => throw _timeoutException(timeout),
+    );
+    if (stopwatch.elapsed > timeout) {
+      throw _timeoutException(timeout);
+    }
+    return value;
+  } catch (error) {
+    if (error is TimeoutException) {
+      rethrow;
+    }
+    if (stopwatch.elapsed > timeout) {
+      throw _timeoutException(timeout);
+    }
+    rethrow;
+  }
+}
+
+TimeoutException _timeoutException(Duration timeout) {
+  return TimeoutException('Computation timed out after $timeout.', timeout);
 }

--- a/dio/lib/src/compute/compute_web.dart
+++ b/dio/lib/src/compute/compute_web.dart
@@ -1,1 +1,24 @@
+import 'dart:async';
+
+import 'package:dio_web_adapter/dio_web_adapter.dart' as web_adapter;
+
+import 'compute.dart' as c;
+
 export 'package:dio_web_adapter/dio_web_adapter.dart' show compute;
+
+Future<R> computeWithTimeout<Q, R>(
+  c.ComputeCallback<Q, R> callback,
+  Q message, {
+  String? debugLabel,
+  Duration? timeout,
+}) {
+  final result = web_adapter.compute(
+    callback,
+    message,
+    debugLabel: debugLabel,
+  );
+  if (timeout != null && timeout > Duration.zero) {
+    return result.timeout(timeout);
+  }
+  return result;
+}

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -22,9 +22,6 @@ enum DioExceptionType {
   /// It occurs when receiving timeout.
   receiveTimeout,
 
-  /// It occurs when transforming timeout.
-  transformTimeout,
-
   /// Caused by an incorrect certificate as configured by [ValidateCertificate].
   badCertificate,
 
@@ -41,6 +38,9 @@ enum DioExceptionType {
   /// Default error type, Some other [Error]. In this case, you can use the
   /// [DioException.error] if it is not null.
   unknown,
+
+  /// It occurs when transforming timeout.
+  transformTimeout,
 }
 
 extension _DioExceptionTypeExtension on DioExceptionType {

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -22,6 +22,9 @@ enum DioExceptionType {
   /// It occurs when receiving timeout.
   receiveTimeout,
 
+  /// It occurs when transforming timeout.
+  transformTimeout,
+
   /// Caused by an incorrect certificate as configured by [ValidateCertificate].
   badCertificate,
 
@@ -49,6 +52,8 @@ extension _DioExceptionTypeExtension on DioExceptionType {
         return 'send timeout';
       case DioExceptionType.receiveTimeout:
         return 'receive timeout';
+      case DioExceptionType.transformTimeout:
+        return 'transform timeout';
       case DioExceptionType.badCertificate:
         return 'bad certificate';
       case DioExceptionType.badResponse:
@@ -141,6 +146,23 @@ class DioException implements Exception {
             'To get rid of this exception, try raising the '
             'RequestOptions.receiveTimeout above the duration of $timeout or '
             'improve the response time of the server.',
+      );
+
+  factory DioException.transformTimeout({
+    required Duration timeout,
+    required RequestOptions requestOptions,
+    Object? error,
+  }) =>
+      DioException(
+        type: DioExceptionType.transformTimeout,
+        requestOptions: requestOptions,
+        response: null,
+        error: error,
+        message: 'The request took longer than $timeout to transform data. '
+            'It was aborted. '
+            'To get rid of this exception, try raising the '
+            'RequestOptions.transformTimeout above the duration of $timeout or '
+            'improve the response data transformation.',
       );
 
   factory DioException.badCertificate({

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -116,6 +116,7 @@ class LogInterceptor extends Interceptor {
       _printKV('connectTimeout', options.connectTimeout);
       _printKV('sendTimeout', options.sendTimeout);
       _printKV('receiveTimeout', options.receiveTimeout);
+      _printKV('transformTimeout', options.transformTimeout);
       _printKV(
         'receiveDataWhenStatusError',
         options.receiveDataWhenStatusError,

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -144,6 +144,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     Duration? connectTimeout,
     super.receiveTimeout,
     super.sendTimeout,
+    super.transformTimeout,
     String baseUrl = '',
     Map<String, dynamic>? queryParameters,
     super.extra,
@@ -174,6 +175,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     Duration? connectTimeout,
     Duration? receiveTimeout,
     Duration? sendTimeout,
+    Duration? transformTimeout,
     Map<String, Object?>? extra,
     Map<String, Object?>? headers,
     bool? preserveHeaderCase,
@@ -195,6 +197,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
       connectTimeout: connectTimeout ?? this.connectTimeout,
       receiveTimeout: receiveTimeout ?? this.receiveTimeout,
       sendTimeout: sendTimeout ?? this.sendTimeout,
+      transformTimeout: transformTimeout ?? this.transformTimeout,
       extra: extra ?? Map.from(this.extra),
       headers: headers ?? Map.from(this.headers),
       preserveHeaderCase: preserveHeaderCase ?? this.preserveHeaderCase,
@@ -220,6 +223,7 @@ class Options {
     this.method,
     Duration? sendTimeout,
     Duration? receiveTimeout,
+    Duration? transformTimeout,
     Duration? connectTimeout,
     this.extra,
     this.headers,
@@ -238,6 +242,8 @@ class Options {
         _receiveTimeout = receiveTimeout,
         assert(sendTimeout == null || !sendTimeout.isNegative),
         _sendTimeout = sendTimeout,
+        assert(transformTimeout == null || !transformTimeout.isNegative),
+        _transformTimeout = transformTimeout,
         assert(connectTimeout == null || !connectTimeout.isNegative),
         _connectTimeout = connectTimeout;
 
@@ -246,6 +252,7 @@ class Options {
     String? method,
     Duration? sendTimeout,
     Duration? receiveTimeout,
+    Duration? transformTimeout,
     Duration? connectTimeout,
     Map<String, Object?>? extra,
     Map<String, Object?>? headers,
@@ -284,6 +291,7 @@ class Options {
       method: method ?? this.method,
       sendTimeout: sendTimeout ?? this.sendTimeout,
       receiveTimeout: receiveTimeout ?? this.receiveTimeout,
+      transformTimeout: transformTimeout ?? this.transformTimeout,
       connectTimeout: connectTimeout ?? this.connectTimeout,
       extra: extra ?? effectiveExtra,
       headers: headers ?? effectiveHeaders,
@@ -345,6 +353,7 @@ class Options {
       connectTimeout: connectTimeout ?? baseOpt.connectTimeout,
       sendTimeout: sendTimeout ?? baseOpt.sendTimeout,
       receiveTimeout: receiveTimeout ?? baseOpt.receiveTimeout,
+      transformTimeout: transformTimeout ?? baseOpt.transformTimeout,
       responseType: responseType ?? baseOpt.responseType,
       validateStatus: validateStatus ?? baseOpt.validateStatus,
       receiveDataWhenStatusError:
@@ -420,6 +429,26 @@ class Options {
       throw ArgumentError.value(value, 'receiveTimeout', 'should be positive');
     }
     _receiveTimeout = value;
+  }
+
+  /// Timeout when transforming response data.
+  ///
+  /// Throws the [DioException] with
+  /// [DioExceptionType.transformTimeout] type when timed out.
+  ///
+  /// `null` or `Duration.zero` means no timeout limit.
+  Duration? get transformTimeout => _transformTimeout;
+  Duration? _transformTimeout;
+
+  set transformTimeout(Duration? value) {
+    if (value != null && value.isNegative) {
+      throw ArgumentError.value(
+        value,
+        'transformTimeout',
+        'should be positive',
+      );
+    }
+    _transformTimeout = value;
   }
 
   /// Timeout when opening a request.
@@ -516,6 +545,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     super.method,
     super.sendTimeout,
     super.receiveTimeout,
+    super.transformTimeout,
     Duration? connectTimeout,
     Map<String, dynamic>? queryParameters,
     String? baseUrl,
@@ -546,6 +576,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     String? method,
     Duration? sendTimeout,
     Duration? receiveTimeout,
+    Duration? transformTimeout,
     Duration? connectTimeout,
     dynamic data,
     String? path,
@@ -583,6 +614,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
       method: method ?? this.method,
       sendTimeout: sendTimeout ?? this.sendTimeout,
       receiveTimeout: receiveTimeout ?? this.receiveTimeout,
+      transformTimeout: transformTimeout ?? this.transformTimeout,
       connectTimeout: connectTimeout ?? this.connectTimeout,
       data: data ?? this.data,
       path: path ?? this.path,
@@ -668,6 +700,7 @@ class _RequestConfig {
   _RequestConfig({
     Duration? receiveTimeout,
     Duration? sendTimeout,
+    Duration? transformTimeout,
     String? method,
     Map<String, dynamic>? extra,
     Map<String, dynamic>? headers,
@@ -686,6 +719,8 @@ class _RequestConfig {
         _receiveTimeout = receiveTimeout,
         assert(sendTimeout == null || !sendTimeout.isNegative),
         _sendTimeout = sendTimeout,
+        assert(transformTimeout == null || !transformTimeout.isNegative),
+        _transformTimeout = transformTimeout,
         method = method ?? 'GET',
         preserveHeaderCase = preserveHeaderCase ?? false,
         listFormat = listFormat ?? ListFormat.multi,
@@ -747,6 +782,16 @@ class _RequestConfig {
       throw StateError('receiveTimeout should be positive');
     }
     _receiveTimeout = value;
+  }
+
+  Duration? get transformTimeout => _transformTimeout;
+  Duration? _transformTimeout;
+
+  set transformTimeout(Duration? value) {
+    if (value != null && value.isNegative) {
+      throw StateError('transformTimeout should be positive');
+    }
+    _transformTimeout = value;
   }
 
   String? _defaultContentType;

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -435,6 +435,8 @@ class Options {
   ///
   /// Throws the [DioException] with
   /// [DioExceptionType.transformTimeout] type when timed out.
+  /// On web, timeout handling is best-effort because synchronous JavaScript
+  /// work cannot be preempted.
   ///
   /// `null` or `Duration.zero` means no timeout limit.
   Duration? get transformTimeout => _transformTimeout;

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -147,7 +147,7 @@ class FusedTransformer extends Transformer {
       // we can't send the stream to the isolate, so we need to decode the response bytes first
       final transformTimeout = options.transformTimeout;
       try {
-        return await compute(
+        return await computeWithTimeout(
           _decodeUtf8ToJson,
           responseBytes ?? await consolidateBytes(responseBody.stream),
           timeout: transformTimeout,

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import '../adapter.dart';
 import '../compute/compute.dart';
+import '../dio_exception.dart';
 import '../headers.dart';
 import '../options.dart';
 import '../transformer.dart';
@@ -144,10 +145,22 @@ class FusedTransformer extends Transformer {
         contentLength >= contentLengthIsolateThreshold;
     if (shouldUseIsolate) {
       // we can't send the stream to the isolate, so we need to decode the response bytes first
-      return compute(
-        _decodeUtf8ToJson,
-        responseBytes ?? await consolidateBytes(responseBody.stream),
-      );
+      final receiveTimeout = options.receiveTimeout;
+      try {
+        return await compute(
+          _decodeUtf8ToJson,
+          responseBytes ?? await consolidateBytes(responseBody.stream),
+          timeout: receiveTimeout,
+        );
+      } on TimeoutException {
+        if (receiveTimeout != null && receiveTimeout > Duration.zero) {
+          throw DioException.receiveTimeout(
+            timeout: receiveTimeout,
+            requestOptions: options,
+          );
+        }
+        rethrow;
+      }
     } else {
       if (responseBytes != null) {
         if (responseBytes.isEmpty) {

--- a/dio/lib/src/transformers/fused_transformer.dart
+++ b/dio/lib/src/transformers/fused_transformer.dart
@@ -145,18 +145,19 @@ class FusedTransformer extends Transformer {
         contentLength >= contentLengthIsolateThreshold;
     if (shouldUseIsolate) {
       // we can't send the stream to the isolate, so we need to decode the response bytes first
-      final receiveTimeout = options.receiveTimeout;
+      final transformTimeout = options.transformTimeout;
       try {
         return await compute(
           _decodeUtf8ToJson,
           responseBytes ?? await consolidateBytes(responseBody.stream),
-          timeout: receiveTimeout,
+          timeout: transformTimeout,
         );
-      } on TimeoutException {
-        if (receiveTimeout != null && receiveTimeout > Duration.zero) {
-          throw DioException.receiveTimeout(
-            timeout: receiveTimeout,
+      } on TimeoutException catch (e) {
+        if (transformTimeout != null && transformTimeout > Duration.zero) {
+          throw DioException.transformTimeout(
+            timeout: transformTimeout,
             requestOptions: options,
+            error: e,
           );
         }
         rethrow;

--- a/dio/test/compute_test.dart
+++ b/dio/test/compute_test.dart
@@ -11,6 +11,15 @@ Future<void> _neverCompletesInVm(Object? _) {
   return Future<void>.delayed(const Duration(days: 1));
 }
 
+int _blocksFor(Duration duration) {
+  final stopwatch = Stopwatch()..start();
+  var value = 0;
+  while (stopwatch.elapsed < duration) {
+    value++;
+  }
+  return value;
+}
+
 int _twice(int value) {
   return value * 2;
 }
@@ -35,6 +44,25 @@ void main() {
             _neverCompletesInBrowser,
             null,
             timeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+
+        expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+      },
+      testOn: 'browser',
+    );
+
+    test(
+      'computeWithTimeout times out after a synchronous browser callback',
+      () async {
+        final stopwatch = Stopwatch()..start();
+
+        await expectLater(
+          computeWithTimeout(
+            _blocksFor,
+            const Duration(milliseconds: 50),
+            timeout: const Duration(milliseconds: 1),
           ),
           throwsA(isA<TimeoutException>()),
         );

--- a/dio/test/compute_test.dart
+++ b/dio/test/compute_test.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:dio/src/compute/compute.dart';
+import 'package:test/test.dart';
+
+FutureOr<String> _echo(String message) => message;
+
+Future<void> _neverCompletes(Object? _) {
+  return Future<void>.delayed(const Duration(days: 1));
+}
+
+void main() {
+  group(
+    'compute',
+    () {
+      test('returns the callback result', () async {
+        expect(await compute(_echo, 'ok'), 'ok');
+      });
+
+      test('times out when the callback never completes', () async {
+        final stopwatch = Stopwatch()..start();
+
+        await expectLater(
+          compute(
+            _neverCompletes,
+            null,
+            timeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+
+        expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+      });
+    },
+    testOn: 'vm',
+  );
+}

--- a/dio/test/compute_test.dart
+++ b/dio/test/compute_test.dart
@@ -11,11 +11,12 @@ void main() {
   group(
     'compute',
     () {
-      test('times out when the callback never completes', () async {
+      test('computeWithTimeout times out when callback never completes',
+          () async {
         final stopwatch = Stopwatch()..start();
 
         await expectLater(
-          compute(
+          computeWithTimeout(
             _neverCompletes,
             null,
             timeout: const Duration(milliseconds: 50),

--- a/dio/test/compute_test.dart
+++ b/dio/test/compute_test.dart
@@ -3,8 +3,6 @@ import 'dart:async';
 import 'package:dio/src/compute/compute.dart';
 import 'package:test/test.dart';
 
-FutureOr<String> _echo(String message) => message;
-
 Future<void> _neverCompletes(Object? _) {
   return Future<void>.delayed(const Duration(days: 1));
 }
@@ -13,10 +11,6 @@ void main() {
   group(
     'compute',
     () {
-      test('returns the callback result', () async {
-        expect(await compute(_echo, 'ok'), 'ok');
-      });
-
       test('times out when the callback never completes', () async {
         final stopwatch = Stopwatch()..start();
 

--- a/dio/test/compute_test.dart
+++ b/dio/test/compute_test.dart
@@ -3,21 +3,36 @@ import 'dart:async';
 import 'package:dio/src/compute/compute.dart';
 import 'package:test/test.dart';
 
-Future<void> _neverCompletes(Object? _) {
+Future<void> _neverCompletesInBrowser(Object? _) {
+  return Completer<void>().future;
+}
+
+Future<void> _neverCompletesInVm(Object? _) {
   return Future<void>.delayed(const Duration(days: 1));
 }
 
+int _twice(int value) {
+  return value * 2;
+}
+
 void main() {
-  group(
-    'compute',
-    () {
-      test('computeWithTimeout times out when callback never completes',
-          () async {
+  group('compute', () {
+    test('compute completes callback', () async {
+      expect(await compute(_twice, 21), 42);
+    });
+
+    test('computeWithTimeout completes callback without timeout', () async {
+      expect(await computeWithTimeout(_twice, 21), 42);
+    });
+
+    test(
+      'computeWithTimeout times out in the browser',
+      () async {
         final stopwatch = Stopwatch()..start();
 
         await expectLater(
           computeWithTimeout(
-            _neverCompletes,
+            _neverCompletesInBrowser,
             null,
             timeout: const Duration(milliseconds: 50),
           ),
@@ -25,8 +40,27 @@ void main() {
         );
 
         expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
-      });
-    },
-    testOn: 'vm',
-  );
+      },
+      testOn: 'browser',
+    );
+
+    test(
+      'computeWithTimeout times out in the VM',
+      () async {
+        final stopwatch = Stopwatch()..start();
+
+        await expectLater(
+          computeWithTimeout(
+            _neverCompletesInVm,
+            null,
+            timeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+
+        expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+      },
+      testOn: 'vm',
+    );
+  });
 }

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -12,6 +12,18 @@ void main() {
     expect(error, isA<Exception>());
   });
 
+  test('DioExceptionType keeps existing enum indices stable', () {
+    expect(DioExceptionType.connectionTimeout.index, 0);
+    expect(DioExceptionType.sendTimeout.index, 1);
+    expect(DioExceptionType.receiveTimeout.index, 2);
+    expect(DioExceptionType.badCertificate.index, 3);
+    expect(DioExceptionType.badResponse.index, 4);
+    expect(DioExceptionType.cancel.index, 5);
+    expect(DioExceptionType.connectionError.index, 6);
+    expect(DioExceptionType.unknown.index, 7);
+    expect(DioExceptionType.transformTimeout.index, 8);
+  });
+
   test(
     'catch DioException: hostname mismatch',
     () async {

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -19,6 +19,7 @@ void main() {
       connectTimeout: const Duration(seconds: 2),
       receiveTimeout: const Duration(seconds: 2),
       sendTimeout: const Duration(seconds: 2),
+      transformTimeout: const Duration(seconds: 2),
       baseUrl: 'http://localhost',
       queryParameters: map,
       extra: map,
@@ -31,6 +32,7 @@ void main() {
       method: 'post',
       receiveTimeout: const Duration(seconds: 3),
       sendTimeout: const Duration(seconds: 3),
+      transformTimeout: const Duration(seconds: 3),
       baseUrl: 'https://pub.dev',
       extra: mapOverride,
       headers: mapOverride,
@@ -39,6 +41,7 @@ void main() {
     expect(opt1.method, 'post');
     expect(opt1.receiveTimeout, const Duration(seconds: 3));
     expect(opt1.connectTimeout, const Duration(seconds: 2));
+    expect(opt1.transformTimeout, const Duration(seconds: 3));
     expect(opt1.followRedirects, false);
     expect(opt1.persistentConnection, false);
     expect(opt1.baseUrl, 'https://pub.dev');
@@ -51,6 +54,7 @@ void main() {
       method: 'get',
       receiveTimeout: const Duration(seconds: 2),
       sendTimeout: const Duration(seconds: 2),
+      transformTimeout: const Duration(seconds: 2),
       extra: map,
       headers: map,
       contentType: 'application/json',
@@ -62,6 +66,7 @@ void main() {
       method: 'post',
       receiveTimeout: const Duration(seconds: 3),
       sendTimeout: const Duration(seconds: 3),
+      transformTimeout: const Duration(seconds: 3),
       extra: mapOverride,
       headers: mapOverride,
       contentType: 'text/html',
@@ -69,6 +74,7 @@ void main() {
 
     expect(opt3.method, 'post');
     expect(opt3.receiveTimeout, const Duration(seconds: 3));
+    expect(opt3.transformTimeout, const Duration(seconds: 3));
     expect(opt3.followRedirects, false);
     expect(opt3.persistentConnection, false);
     expect(opt3.headers!['b'], '6');
@@ -78,6 +84,7 @@ void main() {
     final opt4 = RequestOptions(
       path: '/xxx',
       sendTimeout: const Duration(seconds: 2),
+      transformTimeout: const Duration(seconds: 2),
       followRedirects: false,
       persistentConnection: false,
     );
@@ -85,6 +92,7 @@ void main() {
       method: 'post',
       receiveTimeout: const Duration(seconds: 3),
       sendTimeout: const Duration(seconds: 3),
+      transformTimeout: const Duration(seconds: 3),
       extra: mapOverride,
       headers: mapOverride,
       data: 'xx=5',
@@ -93,6 +101,7 @@ void main() {
     );
     expect(opt5.method, 'post');
     expect(opt5.receiveTimeout, const Duration(seconds: 3));
+    expect(opt5.transformTimeout, const Duration(seconds: 3));
     expect(opt5.followRedirects, false);
     expect(opt5.persistentConnection, false);
     expect(opt5.contentType, 'text/html');

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -159,6 +159,54 @@ void main() {
     expect(opt4.connectTimeout, Duration.zero);
   });
 
+  test('options transformTimeout', () {
+    final opt1 = Options(
+      method: 'get',
+      transformTimeout: const Duration(seconds: 10),
+    );
+    expect(opt1.transformTimeout, const Duration(seconds: 10));
+
+    final opt2 = opt1.copyWith(
+      transformTimeout: const Duration(seconds: 20),
+    );
+    expect(opt2.transformTimeout, const Duration(seconds: 20));
+
+    final opt3 = opt1.copyWith(method: 'post');
+    expect(opt3.transformTimeout, const Duration(seconds: 10));
+
+    final baseOptions = BaseOptions(
+      transformTimeout: const Duration(seconds: 5),
+      baseUrl: 'http://localhost',
+    );
+    final options = Options(transformTimeout: const Duration(seconds: 10));
+    final requestOptions = options.compose(baseOptions, '/test');
+    expect(requestOptions.transformTimeout, const Duration(seconds: 10));
+
+    final options2 = Options();
+    final requestOptions2 = options2.compose(baseOptions, '/test');
+    expect(requestOptions2.transformTimeout, const Duration(seconds: 5));
+
+    final opt4 = Options();
+    opt4.transformTimeout = const Duration(seconds: 30);
+    expect(opt4.transformTimeout, const Duration(seconds: 30));
+    opt4.transformTimeout = Duration.zero;
+    expect(opt4.transformTimeout, Duration.zero);
+    expect(
+      () => opt4.transformTimeout = const Duration(seconds: -1),
+      throwsA(isA<ArgumentError>()),
+    );
+
+    final baseOptions2 = BaseOptions();
+    baseOptions2.transformTimeout = const Duration(seconds: 30);
+    expect(baseOptions2.transformTimeout, const Duration(seconds: 30));
+    baseOptions2.transformTimeout = Duration.zero;
+    expect(baseOptions2.transformTimeout, Duration.zero);
+    expect(
+      () => baseOptions2.transformTimeout = const Duration(seconds: -1),
+      throwsStateError,
+    );
+  });
+
   test('options content-type', () {
     const contentType = 'text/html';
     const contentTypeJson = 'application/json';

--- a/dio/test/options_timeout_integration_test.dart
+++ b/dio/test/options_timeout_integration_test.dart
@@ -98,6 +98,7 @@ void main() {
         connectTimeout: const Duration(seconds: 5),
         sendTimeout: const Duration(seconds: 5),
         receiveTimeout: const Duration(seconds: 5),
+        transformTimeout: const Duration(seconds: 5),
         baseUrl: 'http://example.com',
       );
 
@@ -105,6 +106,7 @@ void main() {
         connectTimeout: const Duration(seconds: 10),
         sendTimeout: const Duration(seconds: 15),
         receiveTimeout: const Duration(seconds: 20),
+        transformTimeout: const Duration(seconds: 25),
         method: 'POST',
       );
 
@@ -114,6 +116,7 @@ void main() {
       expect(requestOptions.connectTimeout, const Duration(seconds: 10));
       expect(requestOptions.sendTimeout, const Duration(seconds: 15));
       expect(requestOptions.receiveTimeout, const Duration(seconds: 20));
+      expect(requestOptions.transformTimeout, const Duration(seconds: 25));
       expect(requestOptions.method, 'POST');
       expect(requestOptions.baseUrl, 'http://example.com');
     });

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -150,6 +150,42 @@ void main() {
       expect(response, {'foo': 'bar'});
     });
 
+    test(
+      'throws receiveTimeout when background isolate JSON decode times out',
+      () async {
+        final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
+        final jsonString = '${''.padLeft(8 * 1024 * 1024)}{"foo":"bar"}';
+        final responseBytes = utf8.encode(jsonString);
+
+        await expectLater(
+          transformer.transformResponse(
+            RequestOptions(
+              responseType: ResponseType.json,
+              receiveTimeout: const Duration(microseconds: 1),
+            ),
+            ResponseBody.fromBytes(
+              responseBytes,
+              200,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+                Headers.contentLengthHeader: [
+                  responseBytes.length.toString(),
+                ],
+              },
+            ),
+          ),
+          throwsA(
+            isA<DioException>().having(
+              (e) => e.type,
+              'type',
+              DioExceptionType.receiveTimeout,
+            ),
+          ),
+        );
+      },
+      testOn: 'vm',
+    );
+
     test('transformResponse transforms that arrives in many chunks', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -215,6 +215,42 @@ void main() {
       testOn: 'vm',
     );
 
+    test(
+      'throws transformTimeout when web transform completes after timeout',
+      () async {
+        final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
+        final jsonString = '${''.padLeft(8 * 1024 * 1024)}{"foo":"bar"}';
+        final responseBytes = utf8.encode(jsonString);
+
+        await expectLater(
+          transformer.transformResponse(
+            RequestOptions(
+              responseType: ResponseType.json,
+              transformTimeout: const Duration(microseconds: 1),
+            ),
+            ResponseBody.fromBytes(
+              responseBytes,
+              200,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+                Headers.contentLengthHeader: [
+                  responseBytes.length.toString(),
+                ],
+              },
+            ),
+          ),
+          throwsA(
+            isA<DioException>().having(
+              (e) => e.type,
+              'type',
+              DioExceptionType.transformTimeout,
+            ),
+          ),
+        );
+      },
+      testOn: 'browser',
+    );
+
     test('transformResponse transforms that arrives in many chunks', () async {
       final transformer = FusedTransformer();
       final response = await transformer.transformResponse(

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -150,15 +150,49 @@ void main() {
       expect(response, {'foo': 'bar'});
     });
 
-    test(
-      'throws receiveTimeout when background isolate JSON decode times out',
-      () async {
-        final transformer = FusedTransformer(contentLengthIsolateThreshold: 0);
-        final jsonString = '${''.padLeft(8 * 1024 * 1024)}{"foo":"bar"}';
-        final responseBytes = utf8.encode(jsonString);
+    group(
+      'background isolate JSON decode timeout',
+      () {
+        test('throws transformTimeout when transform times out', () async {
+          final transformer =
+              FusedTransformer(contentLengthIsolateThreshold: 0);
+          final jsonString = '${''.padLeft(8 * 1024 * 1024)}{"foo":"bar"}';
+          final responseBytes = utf8.encode(jsonString);
 
-        await expectLater(
-          transformer.transformResponse(
+          await expectLater(
+            transformer.transformResponse(
+              RequestOptions(
+                responseType: ResponseType.json,
+                transformTimeout: const Duration(microseconds: 1),
+              ),
+              ResponseBody.fromBytes(
+                responseBytes,
+                200,
+                headers: {
+                  Headers.contentTypeHeader: [Headers.jsonContentType],
+                  Headers.contentLengthHeader: [
+                    responseBytes.length.toString(),
+                  ],
+                },
+              ),
+            ),
+            throwsA(
+              isA<DioException>().having(
+                (e) => e.type,
+                'type',
+                DioExceptionType.transformTimeout,
+              ),
+            ),
+          );
+        });
+
+        test('does not use receiveTimeout for transform timeout', () async {
+          final transformer =
+              FusedTransformer(contentLengthIsolateThreshold: 0);
+          final jsonString = '${''.padLeft(8 * 1024 * 1024)}{"foo":"bar"}';
+          final responseBytes = utf8.encode(jsonString);
+
+          final response = await transformer.transformResponse(
             RequestOptions(
               responseType: ResponseType.json,
               receiveTimeout: const Duration(microseconds: 1),
@@ -173,15 +207,10 @@ void main() {
                 ],
               },
             ),
-          ),
-          throwsA(
-            isA<DioException>().having(
-              (e) => e.type,
-              'type',
-              DioExceptionType.receiveTimeout,
-            ),
-          ),
-        );
+          );
+
+          expect(response, {'foo': 'bar'});
+        });
       },
       testOn: 'vm',
     );

--- a/plugins/web_adapter/lib/src/compute_impl.dart
+++ b/plugins/web_adapter/lib/src/compute_impl.dart
@@ -28,15 +28,10 @@ Future<R> compute<Q, R>(
   c.ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
-  Duration? timeout,
 }) async {
   // To avoid blocking the UI immediately for an expensive function call, we
   // pump a single frame to allow the framework to complete the current set
   // of work.
   await null;
-  final result = Future<R>.sync(() => callback(message));
-  if (timeout != null && timeout > Duration.zero) {
-    return result.timeout(timeout);
-  }
-  return result;
+  return Future<R>.sync(() => callback(message));
 }

--- a/plugins/web_adapter/lib/src/compute_impl.dart
+++ b/plugins/web_adapter/lib/src/compute_impl.dart
@@ -19,6 +19,8 @@
 // The file is intentionally not refactored so that it is easier to keep the
 // compute package up to date with Flutter's implementation.
 
+import 'dart:async';
+
 import 'package:dio/src/compute/compute.dart' as c;
 
 /// The dart:html implementation of [c.compute].
@@ -26,10 +28,15 @@ Future<R> compute<Q, R>(
   c.ComputeCallback<Q, R> callback,
   Q message, {
   String? debugLabel,
+  Duration? timeout,
 }) async {
   // To avoid blocking the UI immediately for an expensive function call, we
   // pump a single frame to allow the framework to complete the current set
   // of work.
   await null;
-  return callback(message);
+  final result = Future<R>.sync(() => callback(message));
+  if (timeout != null && timeout > Duration.zero) {
+    return result.timeout(timeout);
+  }
+  return result;
 }


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

Fixes background JSON decoding hanging indefinitely by adding a dedicated `transformTimeout` option.

The timeout is independent from `receiveTimeout`, so existing receive timeout semantics stay focused on network receive timing. By default `transformTimeout` is `null`, which means no transform timeout limit and preserves existing behavior unless users opt in.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

This adds:
- `RequestOptions.transformTimeout`
- `Options.transformTimeout`
- `BaseOptions.transformTimeout`
- `DioExceptionType.transformTimeout`

When `transformTimeout` is set and response transformation exceeds the duration, Dio throws `DioExceptionType.transformTimeout`.

Existing users that do not set `transformTimeout` are unaffected. `receiveTimeout` continues to represent receiving response bytes/chunk timing and is no longer used to limit background JSON transformation.

Verified with:
- `dart analyze --fatal-infos` in `dio`
- `dart analyze --fatal-infos` in `plugins/web_adapter`
- `dart test --chain-stack-traces` in `dio`