### PR TITLE
🐛 Fix FormData.clone() dropping boundaryName and camelCaseContentDisposition

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,6 +9,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 - Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 - Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.
   On web, timeout handling is best-effort because synchronous JavaScript work cannot be preempted.
+- Fix `FormData.clone()` dropping `boundaryName` and `camelCaseContentDisposition`, so a retried multipart request now keeps the original options instead of silently falling back to the defaults.
 
 ## 5.9.2
 

--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -209,7 +209,15 @@ class FormData {
 
   // Convenience method to clone finalized FormData when retrying requests.
   FormData clone() {
-    final clone = FormData();
+    // Forward the constructor options so that the clone produces a wire
+    // representation equivalent to the original — most notably the
+    // `Content-Disposition` header casing chosen via
+    // [camelCaseContentDisposition]. Without this, a retried multipart
+    // request would silently downgrade to the default lowercase header.
+    final clone = FormData(
+      boundaryName: boundaryName,
+      camelCaseContentDisposition: camelCaseContentDisposition,
+    );
     clone._boundary = _boundary;
     clone.fields.addAll(fields);
     for (final file in files) {

--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -207,13 +207,19 @@ class FormData {
     );
   }
 
-  // Convenience method to clone finalized FormData when retrying requests.
+  /// Clones this finalized [FormData] so it can be re-sent, for example when
+  /// a request is retried.
+  ///
+  /// The clone forwards the constructor options — [boundaryName] and
+  /// [camelCaseContentDisposition] — so it yields a wire representation
+  /// equivalent to the original, most notably the `Content-Disposition`
+  /// header casing. Without this, a retried multipart request would silently
+  /// downgrade to the default lowercase header.
+  ///
+  /// [files] are deep-cloned, while [fields] are copied as immutable
+  /// key/value entries into a new list. Updating this instance's [fields]
+  /// after calling [clone] does not propagate to the returned clone.
   FormData clone() {
-    // Forward the constructor options so that the clone produces a wire
-    // representation equivalent to the original — most notably the
-    // `Content-Disposition` header casing chosen via
-    // [camelCaseContentDisposition]. Without this, a retried multipart
-    // request would silently downgrade to the default lowercase header.
     final clone = FormData(
       boundaryName: boundaryName,
       camelCaseContentDisposition: camelCaseContentDisposition,

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -181,6 +181,34 @@ void main() async {
       testOn: 'vm',
     );
 
+    test('clone() preserves boundaryName and camelCaseContentDisposition',
+        () async {
+      // Regression test: previously clone() called `FormData()` with default
+      // arguments, dropping both options. A retried multipart upload would
+      // therefore emit the wrong `content-disposition` header casing and
+      // expose the default boundary name via the getter.
+      final fm = FormData(
+        boundaryName: '--custom-boundary',
+        camelCaseContentDisposition: true,
+      );
+      fm.fields.add(const MapEntry('name', 'value'));
+
+      final fm1 = fm.clone();
+      expect(fm1.boundaryName, fm.boundaryName);
+      expect(fm1.boundaryName, '--custom-boundary');
+      expect(
+        fm1.camelCaseContentDisposition,
+        fm.camelCaseContentDisposition,
+      );
+      expect(fm1.camelCaseContentDisposition, isTrue);
+
+      // The cloned wire representation must use the same header casing as
+      // the original; before the fix it silently switched to lower-case.
+      final body = utf8.decode(await fm1.readAsBytes(), allowMalformed: true);
+      expect(body, contains('Content-Disposition: form-data; name="name"'));
+      expect(body, isNot(contains('content-disposition:')));
+    });
+
     test('encodes maps correctly', () async {
       final fd = FormData.fromMap(
         {


### PR DESCRIPTION
Follow-on to merged #2305 and merged #2008. `FormData.clone()` still drops two of the original constructor options, so a retried multipart request silently re-serialises with the defaults.

### 1. Bug

`clone()` builds the new instance via the no-arg `FormData()` constructor:

```dart
FormData clone() {
  final clone = FormData();           // ← resets options to defaults
  clone._boundary = _boundary;        // (added by #2305)
  ...
}
```

That resets two options that the original may have set:

| Option | Added in | Symptom on a cloned (retried) request |
| --- | --- | --- |
| `boundaryName` | original API | `clone.boundaryName` returns the dio default, not the user's label |
| `camelCaseContentDisposition` | #2008 | wire bytes contain `content-disposition: form-data; …` instead of `Content-Disposition: …` |

The header-casing regression is the user-visible one: any server that matches `Content-Disposition` case-sensitively (some signing gateways, some upload validators) accepts the first attempt and rejects the retry.

### 2. Fix

Forward both options through `clone()`:

```dart
FormData clone() {
  final clone = FormData(
    boundaryName: boundaryName,
    camelCaseContentDisposition: camelCaseContentDisposition,
  );
  clone._boundary = _boundary;
  clone.fields.addAll(fields);
  for (final file in files) {
    clone.files.add(MapEntry(file.key, file.value.clone()));
  }
  return clone;
}
```

One-line behavioural change, no new public API.

### 3. Test

New regression test in `dio/test/formdata_test.dart` (`clone() preserves boundaryName and camelCaseContentDisposition`):

- builds a `FormData` with `boundaryName: '--custom-boundary'` and `camelCaseContentDisposition: true`,
- clones it,
- asserts both getters round-trip,
- decodes `readAsBytes()` on the clone and asserts the body contains `Content-Disposition: form-data; name="name"` and **does not** contain the lower-case `content-disposition:` form.

Fail-before / pass-after verified locally:

- **before the fix**: the new test fails on the wire-body assertions (clone emits `content-disposition:` lower-case).
- **after the fix**: full `dio/test/formdata_test.dart` suite green (8/8).

### 4. CI

- `dart format --output=none --set-exit-if-changed .` on `dio/` — clean (0 of 63 files changed).
- `dart analyze` on `dio/lib/src/form_data.dart` and `dio/test/formdata_test.dart` — no issues.
- Full `dart test` on the `dio/` package — 220 passed / 6 network-gated skipped / 0 failed.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package
