### PR TITLE
fix: classify incomplete response header as connection error

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 ## Unreleased
 
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
+- Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 
 ## 5.9.2
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -172,7 +172,22 @@ class IOHttpClientAdapter implements HttpClientAdapter {
         },
       );
     }
-    final responseStream = await future;
+    late final HttpClientResponse responseStream;
+    try {
+      responseStream = await future;
+    } on HttpException catch (e, s) {
+      if (e.message.contains(
+        'Connection closed before full header was received',
+      )) {
+        throw DioException.connectionError(
+          requestOptions: options,
+          reason: e.message,
+          error: e,
+          stackTrace: s,
+        );
+      }
+      rethrow;
+    }
 
     if (validateCertificate != null) {
       final host = options.uri.host;

--- a/dio/lib/src/dio_exception.dart
+++ b/dio/lib/src/dio_exception.dart
@@ -173,6 +173,7 @@ class DioException implements Exception {
     required RequestOptions requestOptions,
     required String reason,
     Object? error,
+    StackTrace? stackTrace,
   }) =>
       DioException(
         type: DioExceptionType.connectionError,
@@ -181,6 +182,7 @@ class DioException implements Exception {
         requestOptions: requestOptions,
         response: null,
         error: error,
+        stackTrace: stackTrace,
       );
 
   /// The request info for the request that throws exception.

--- a/dio/test/stacktrace_test.dart
+++ b/dio/test/stacktrace_test.dart
@@ -220,6 +220,55 @@ void main() async {
     );
     group('DioExceptionType.connectionError', () {
       test(
+        'HttpException before response headers on download',
+        () async {
+          final uri = Uri.parse('https://does.not.exist/test');
+          final request = MockHttpClientRequest();
+          final client = MockHttpClient();
+          final originalStackTrace = StackTrace.fromString(
+            'original response header stack trace',
+          );
+          final tmp = Directory.systemTemp.createTempSync('dio_test_');
+          addTearDown(() {
+            tmp.deleteSync(recursive: true);
+          });
+
+          when(client.openUrl(any, any)).thenAnswer((_) async => request);
+          when(request.close()).thenAnswer(
+            (_) => Future.error(
+              HttpException(
+                'Connection closed before full header was received',
+                uri: uri,
+              ),
+              originalStackTrace,
+            ),
+          );
+
+          final dio = Dio()
+            ..options.baseUrl = 'https://does.not.exist'
+            ..httpClientAdapter = IOHttpClientAdapter(
+              createHttpClient: () => client,
+            );
+
+          await expectLater(
+            dio.download('/test', '${tmp.path}/download.bin'),
+            throwsA(
+              allOf([
+                isA<DioException>(),
+                (e) => e.type == DioExceptionType.connectionError,
+                (e) => e.error is HttpException,
+                (e) => (e.error as HttpException)
+                    .message
+                    .contains('Connection closed before full header'),
+                (e) => e.stackTrace.toString() == originalStackTrace.toString(),
+              ]),
+            ),
+          );
+        },
+        testOn: 'vm',
+      );
+
+      test(
         'SocketException on request',
         () async {
           final dio = Dio()


### PR DESCRIPTION
Fixes the Dio-side error classification for #2405.

When `dart:io` fails with `HttpException: Connection closed before full header was received`, Dio currently wraps it as `DioExceptionType.unknown`. This happens while `IOHttpClientAdapter` is awaiting `HttpClientRequest.close()`, before a `HttpClientResponse` is available.

That phase is still part of establishing/receiving the response headers. Since no response headers or status code are available, this is closer to a connection-level failure than an unknown application error. This PR maps that specific `HttpException` to `DioExceptionType.connectionError` while preserving the original `HttpException` in `DioException.error`.

### Why this strategy

This intentionally does not add automatic retry.

The reported user-visible symptom is a failed download, but retrying inside `IOHttpClientAdapter` would be a larger behavioral change:
- requests may be non-idempotent;
- request bodies/streams may not be replayable;
- download progress, cancellation, and partial file handling would need separate policy decisions;
- users may already have retry behavior in interceptors or higher-level download managers.

So this PR keeps the fix narrowly scoped to Dio's error classification. It gives callers a stable `connectionError` signal so application-level retry policies can decide whether and how to retry.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

Added a regression test that simulates `HttpClientRequest.close()` throwing:

`HttpException: Connection closed before full header was received`

The test goes through `dio.download()` to match the reported scenario and verifies:
- the thrown error is `DioExceptionType.connectionError`;
- the original `HttpException` is preserved;
- stack trace behavior remains covered.