### PR TITLE
test: scope coverage sources by package/platform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,6 @@ jobs:
         with:
           artifact_download_workflow_names: 'Verify packages abilities,coverage_baseline'
           filename: 'coverage/cobertura.xml'
-          only_list_changed_files: true
       - name: '[Coverage] Write PR number to file'
         if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
         run: echo ${{ github.event.number }} > pr_number.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           artifact_download_workflow_names: 'Verify packages abilities,coverage_baseline'
           filename: 'coverage/cobertura.xml'
+          only_list_changed_files: true
       - name: '[Coverage] Write PR number to file'
         if: ${{ matrix.sdk == 'stable' && github.actor != 'dependabot[bot]'}}
         run: echo ${{ github.event.number }} > pr_number.txt

--- a/melos.yaml
+++ b/melos.yaml
@@ -94,7 +94,11 @@ scripts:
       if [ "$TARGET_DART_SDK" = "min" ]; then
         dart test --platform ${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces
       else
-        dart test --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces
+        if [ "${MELOS_PACKAGE_NAME:-}" = "dio_web_adapter" ] && [ "${TEST_PLATFORM}" = "chrome" ]; then
+          dart test --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces
+        else
+          dart test --platform ${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces
+        fi
         if [ "$WITH_WASM" = "true" ]; then
           dart test --platform ${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces --compiler=dart2wasm
         fi

--- a/melos.yaml
+++ b/melos.yaml
@@ -96,7 +96,7 @@ scripts:
       else
         dart test --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces
         if [ "$WITH_WASM" = "true" ]; then
-          dart test --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces --compiler=dart2wasm
+          dart test --platform ${TEST_PLATFORM} --preset=${TEST_PRESET:-default},${TARGET_DART_SDK:-stable} --chain-stack-traces --compiler=dart2wasm
         fi
       fi
     packageFilters:


### PR DESCRIPTION
## Summary
- keep `only_list_changed_files: true` (changed-files filtering behavior unchanged)
- scope web coverage collection to `dio_web_adapter` on Chrome JS run only
- keep `dart2wasm` rerun without coverage

## Coverage policy after this change
- `dio` package: VM coverage only
- `dio_web_adapter`: Chrome (non-wasm) web coverage
- other packages: VM coverage only

## Why
Web coverage from broad package runs and mixed JS/wasm writes made diff coverage noisy and could produce misleading file changes. Scoping coverage sources makes report output align with package intent while keeping test execution coverage-neutral.

## Validation
- On `dio_web_adapter` context with Chrome+wasm sequence, LCOV is generated (`SF` entries present).
- On `dio` context, Chrome web tests run without creating `coverage/chrome`.
