### PR TITLE
⚡️ Fix `FormData.readAsBytes` excessive memory usage with large payloads

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,8 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-- Fix `FormData.readAsBytes` excessive memory usage with large payloads by replacing the O(n²) `reduce`+spread approach with a `BytesBuilder`.
-
+- Fix `FormData.readAsBytes` excessive memory usage with large payloads by replacing the O(n²) `reduce`+spread approach with a pre-allocated `Uint8List`.
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
 - Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 - Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,6 +5,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
+- Fix `FormData.readAsBytes` excessive memory usage with large payloads by replacing the O(n²) `reduce`+spread approach with a `BytesBuilder`.
+
 - Fix request hanging indefinitely when async interceptor callbacks throw without calling the handler.
 - Fix `HttpException: Connection closed before full header was received` being reported as `DioExceptionType.unknown`.
 - Add `transformTimeout` to bound long-running response transformations, including background JSON decoding.

--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -202,9 +202,15 @@ class FormData {
 
   /// Transform the entire FormData contents as a list of bytes asynchronously.
   Future<Uint8List> readAsBytes() {
-    return Future.sync(
-      () => finalize().reduce((a, b) => Uint8List.fromList([...a, ...b])),
-    );
+    return Future.sync(() async {
+      final result = Uint8List(length);
+      var offset = 0;
+      await for (final chunk in finalize()) {
+        result.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
+      return result;
+    });
   }
 
   /// Clones this finalized [FormData] so it can be re-sent, for example when

--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -201,16 +201,14 @@ class FormData {
   }
 
   /// Transform the entire FormData contents as a list of bytes asynchronously.
-  Future<Uint8List> readAsBytes() {
-    return Future.sync(() async {
-      final result = Uint8List(length);
-      var offset = 0;
-      await for (final chunk in finalize()) {
-        result.setRange(offset, offset + chunk.length, chunk);
-        offset += chunk.length;
-      }
-      return result;
-    });
+  Future<Uint8List> readAsBytes() async {
+    final result = Uint8List(length);
+    int offset = 0;
+    await for (final chunk in finalize()) {
+      result.setRange(offset, offset + chunk.length, chunk);
+      offset += chunk.length;
+    }
+    return result;
   }
 
   /// Clones this finalized [FormData] so it can be re-sent, for example when

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -1,10 +1,32 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 import 'mock/adapters.dart';
+
+int _indexOfSubList(List<int> bytes, List<int> pattern, [int start = 0]) {
+  if (pattern.isEmpty) {
+    return start <= bytes.length ? start : -1;
+  }
+
+  for (int i = start; i <= bytes.length - pattern.length; i++) {
+    bool matched = true;
+    for (int j = 0; j < pattern.length; j++) {
+      if (bytes[i + j] != pattern[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
+      return i;
+    }
+  }
+
+  return -1;
+}
 
 void main() async {
   group(FormData, () {
@@ -271,6 +293,12 @@ void main() async {
       const chunks = 128;
       const chunkSize = 1024;
       final expectedFileLength = chunks * chunkSize;
+      final expectedPayload = Uint8List.fromList(
+        List<int>.generate(
+          expectedFileLength,
+          (i) => (i ~/ chunkSize) % 256,
+        ),
+      );
 
       final file = MultipartFile.fromStream(
         () => Stream<List<int>>.fromIterable(
@@ -285,11 +313,27 @@ void main() async {
 
       final fd = FormData.fromMap({'file': file});
       final data = await fd.readAsBytes();
-      final body = utf8.decode(data, allowMalformed: true);
+      final headerStart = _indexOfSubList(
+        data,
+        utf8.encode('filename="chunked.bin"'),
+      );
+      final headerEnd = _indexOfSubList(
+        data,
+        utf8.encode('\r\n\r\n'),
+        headerStart,
+      );
+      final payloadStart = headerEnd + 4;
+      final payloadEnd = payloadStart + expectedPayload.length;
+      final trailingBoundary = utf8.encode('\r\n--${fd.boundary}--\r\n');
 
       expect(data.length, fd.length);
-      expect(body, contains('filename="chunked.bin"'));
-      expect(body, contains('content-type: application/octet-stream'));
+      expect(headerStart, isNonNegative);
+      expect(headerEnd, isNonNegative);
+      expect(
+        data.sublist(payloadStart, payloadEnd),
+        orderedEquals(expectedPayload),
+      );
+      expect(data.sublist(payloadEnd), orderedEquals(trailingBoundary));
     });
 
     test('posts maps correctly', () async {

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -267,6 +267,31 @@ void main() async {
       expect(result, contains('name="api[data][c]"'));
     });
 
+    test('readAsBytes keeps chunked file payload complete', () async {
+      const chunks = 128;
+      const chunkSize = 1024;
+      final expectedFileLength = chunks * chunkSize;
+
+      final file = MultipartFile.fromStream(
+        () => Stream<List<int>>.fromIterable(
+          List.generate(
+            chunks,
+            (i) => List<int>.filled(chunkSize, i % 256),
+          ),
+        ),
+        expectedFileLength,
+        filename: 'chunked.bin',
+      );
+
+      final fd = FormData.fromMap({'file': file});
+      final data = await fd.readAsBytes();
+      final body = utf8.decode(data, allowMalformed: true);
+
+      expect(data.length, fd.length);
+      expect(body, contains('filename="chunked.bin"'));
+      expect(body, contains('content-type: application/octet-stream'));
+    });
+
     test('posts maps correctly', () async {
       final fd = FormData.fromMap(
         {


### PR DESCRIPTION
The previous implementation used `reduce((a, b) => Uint8List.fromList([...a, ...b]))`, which re-allocates and copies all accumulated bytes on every chunk — O(n²) memory in total.

Since `FormData.length` is already computed before finalization, we can pre-allocate the exact result buffer and write each chunk in-place with `setRange`, bringing memory usage down to O(n) with a single allocation.

Related: #2506