### PR TITLE
✨ feat: warn about CORS preflight requests on Web

### DIFF
--- a/plugins/web_adapter/CHANGELOG.md
+++ b/plugins/web_adapter/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-*None.*
+- Warn when a request is not a CORS "simple request" and will trigger a
+  preflight (OPTIONS) request, and enrich the `XMLHttpRequest.onError` message
+  with CORS guidance when the request was preflighted.
 
 ## 2.2.0
 

--- a/plugins/web_adapter/CHANGELOG.md
+++ b/plugins/web_adapter/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Warn when a request is not a CORS "simple request" and will trigger a
   preflight (OPTIONS) request, and enrich the `XMLHttpRequest.onError` message
-  with CORS guidance when the request was preflighted.
+  with CORS guidance when the request was preflighted. The warning can be
+  disabled via `BrowserHttpClientAdapter(enableCORSWarning: false)`; the
+  enriched error message is always emitted.
 
 ## 2.2.0
 

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -8,6 +8,10 @@ import 'package:dio/src/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:web/web.dart' as web;
 
+import 'cors.dart';
+
+export 'cors.dart' show corsPreflightReason;
+
 BrowserHttpClientAdapter createAdapter() => BrowserHttpClientAdapter();
 
 /// The default [HttpClientAdapter] for Web platforms.
@@ -62,6 +66,35 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
 
     final xhrTimeout = (connectTimeout + receiveTimeout).inMilliseconds;
     xhr.timeout = xhrTimeout;
+
+    // Detect configurations that will trigger a CORS preflight request so we
+    // can warn the developer and enrich the eventual error message.
+    // See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+    final preflightReasons = <String>[
+      if (corsPreflightReason(options) case final reason?) reason,
+    ];
+    final willRegisterUploadListener = requestStream != null &&
+        (sendTimeout > Duration.zero || onSendProgress != null);
+    if (willRegisterUploadListener) {
+      preflightReasons.add(
+        'an upload progress listener (sendTimeout or onSendProgress) '
+        'forces a preflight request',
+      );
+    }
+    if (xhr.withCredentials) {
+      preflightReasons.add(
+        'withCredentials is enabled, which requires a CORS preflight request',
+      );
+    }
+    if (preflightReasons.isNotEmpty) {
+      warningLog(
+        'This request is not a CORS "simple request" and will trigger a '
+        'preflight (OPTIONS) request: ${preflightReasons.join('; ')}. '
+        'If the server does not handle CORS preflight, the request will fail. '
+        'See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests',
+        StackTrace.current,
+      );
+    }
 
     final completer = Completer<ResponseBody>();
 
@@ -219,11 +252,20 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       // Unfortunately, the underlying XMLHttpRequest API doesn't expose any
       // specific information about the error itself.
       // See also: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequestEventTarget/onerror
+      final baseReason = 'The XMLHttpRequest onError callback was called. '
+          'This typically indicates an error on the network layer.';
+      final reason = preflightReasons.isEmpty
+          ? baseReason
+          : '$baseReason If this is a cross-origin request, the browser may '
+              'have blocked it because the request is not a CORS "simple '
+              'request" (${preflightReasons.join('; ')}). Verify that the '
+              'server responds correctly to the CORS preflight (OPTIONS) '
+              'request. See '
+              'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests';
       completer.completeError(
         DioException.connectionError(
           requestOptions: options,
-          reason: 'The XMLHttpRequest onError callback was called. '
-              'This typically indicates an error on the network layer.',
+          reason: reason,
         ),
         StackTrace.current,
       );

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -10,13 +10,14 @@ import 'package:web/web.dart' as web;
 
 import 'cors.dart';
 
-export 'cors.dart' show corsPreflightReason;
-
 BrowserHttpClientAdapter createAdapter() => BrowserHttpClientAdapter();
 
 /// The default [HttpClientAdapter] for Web platforms.
 class BrowserHttpClientAdapter implements HttpClientAdapter {
-  BrowserHttpClientAdapter({this.withCredentials = false});
+  BrowserHttpClientAdapter({
+    this.withCredentials = false,
+    this.enableCORSWarning = true,
+  });
 
   /// These are aborted if the client is closed.
   @visibleForTesting
@@ -30,6 +31,15 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
   /// You can also override this value using `Options.extra['withCredentials']`
   /// for each request.
   bool withCredentials;
+
+  /// Whether to emit a warning log when a request is not a CORS "simple
+  /// request" and will trigger a preflight (OPTIONS) request.
+  ///
+  /// Defaults to `true`. Set to `false` to silence the warning in apps that
+  /// already handle CORS preflight correctly and find the per-request log
+  /// noisy. The enriched error message in [DioException.connectionError] is
+  /// always emitted regardless of this setting.
+  bool enableCORSWarning;
 
   @override
   Future<ResponseBody> fetch(
@@ -70,23 +80,14 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     // Detect configurations that will trigger a CORS preflight request so we
     // can warn the developer and enrich the eventual error message.
     // See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
-    final preflightReasons = <String>[
-      if (corsPreflightReason(options) case final reason?) reason,
-    ];
     final willRegisterUploadListener = requestStream != null &&
         (sendTimeout > Duration.zero || onSendProgress != null);
-    if (willRegisterUploadListener) {
-      preflightReasons.add(
-        'an upload progress listener (sendTimeout or onSendProgress) '
-        'forces a preflight request',
-      );
-    }
-    if (xhr.withCredentials) {
-      preflightReasons.add(
-        'withCredentials is enabled, which requires a CORS preflight request',
-      );
-    }
-    if (preflightReasons.isNotEmpty) {
+    final preflightReasons = collectCorsPreflightReasons(
+      options,
+      willRegisterUploadListener: willRegisterUploadListener,
+      withCredentials: xhr.withCredentials,
+    );
+    if (preflightReasons.isNotEmpty && enableCORSWarning) {
       warningLog(
         'This request is not a CORS "simple request" and will trigger a '
         'preflight (OPTIONS) request: ${preflightReasons.join('; ')}. '
@@ -252,20 +253,14 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       // Unfortunately, the underlying XMLHttpRequest API doesn't expose any
       // specific information about the error itself.
       // See also: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequestEventTarget/onerror
-      final baseReason = 'The XMLHttpRequest onError callback was called. '
-          'This typically indicates an error on the network layer.';
-      final reason = preflightReasons.isEmpty
-          ? baseReason
-          : '$baseReason If this is a cross-origin request, the browser may '
-              'have blocked it because the request is not a CORS "simple '
-              'request" (${preflightReasons.join('; ')}). Verify that the '
-              'server responds correctly to the CORS preflight (OPTIONS) '
-              'request. See '
-              'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests';
       completer.completeError(
         DioException.connectionError(
           requestOptions: options,
-          reason: reason,
+          reason: corsEnrichedErrorReason(
+            'The XMLHttpRequest onError callback was called. '
+            'This typically indicates an error on the network layer.',
+            preflightReasons,
+          ),
         ),
         StackTrace.current,
       );

--- a/plugins/web_adapter/lib/src/cors.dart
+++ b/plugins/web_adapter/lib/src/cors.dart
@@ -51,3 +51,52 @@ String? corsPreflightReason(RequestOptions options) {
   }
   return null;
 }
+
+/// Collects all reasons why a request will trigger a CORS preflight, combining
+/// the static [corsPreflightReason] analysis with runtime factors that only
+/// the adapter knows: whether an upload progress listener will be registered
+/// ([willRegisterUploadListener]) and whether credentials are being sent
+/// ([withCredentials]).
+///
+/// Returns an empty list when the request is a CORS "simple request".
+/// This is a pure function so it can be unit-tested without a browser.
+List<String> collectCorsPreflightReasons(
+  RequestOptions options, {
+  bool willRegisterUploadListener = false,
+  bool withCredentials = false,
+}) {
+  final reasons = <String>[
+    if (corsPreflightReason(options) case final reason?) reason,
+  ];
+  if (willRegisterUploadListener) {
+    reasons.add(
+      'an upload progress listener (sendTimeout or onSendProgress) '
+      'forces a preflight request',
+    );
+  }
+  if (withCredentials) {
+    reasons.add(
+      'withCredentials is enabled, which requires a CORS preflight request',
+    );
+  }
+  return reasons;
+}
+
+/// Builds the error reason for `XMLHttpRequest.onError`, appending CORS
+/// guidance when [preflightReasons] is non-empty.
+///
+/// This is a pure function so it can be unit-tested without a browser.
+String corsEnrichedErrorReason(
+  String baseReason,
+  List<String> preflightReasons,
+) {
+  if (preflightReasons.isEmpty) {
+    return baseReason;
+  }
+  return '$baseReason If this is a cross-origin request, the browser may '
+      'have blocked it because the request is not a CORS "simple '
+      'request" (${preflightReasons.join('; ')}). Verify that the '
+      'server responds correctly to the CORS preflight (OPTIONS) '
+      'request. See '
+      'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests';
+}

--- a/plugins/web_adapter/lib/src/cors.dart
+++ b/plugins/web_adapter/lib/src/cors.dart
@@ -1,0 +1,53 @@
+import 'package:dio/dio.dart';
+
+/// Headers that the CORS spec exempts from preflight for "simple requests".
+///
+/// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+const corsSafelistedRequestHeaders = <String>{
+  'accept',
+  'accept-language',
+  'content-language',
+  'content-type',
+  'range',
+};
+
+/// Content-Type values that the CORS spec treats as "simple".
+const corsSimpleContentTypes = <String>{
+  'application/x-www-form-urlencoded',
+  'multipart/form-data',
+  'text/plain',
+};
+
+/// Returns a human-readable reason when [options] is likely to trigger a CORS
+/// preflight request on the Web platform, or `null` when the request matches
+/// the "simple request" criteria.
+///
+/// This is a pure function over [RequestOptions] so it can be unit-tested
+/// without a browser. The upload-progress listener is not considered here
+/// because it depends on runtime wiring inside the adapter; callers that
+/// register an upload listener should append that reason themselves.
+String? corsPreflightReason(RequestOptions options) {
+  final method = options.method.toUpperCase();
+  if (method != 'GET' && method != 'HEAD' && method != 'POST') {
+    return 'the request method "$method" is not a CORS-safelisted method '
+        '(GET, HEAD, POST)';
+  }
+  final contentType = options.headers[Headers.contentTypeHeader];
+  final contentTypeValue = contentType is List && contentType.isNotEmpty
+      ? contentType.first.toString()
+      : contentType?.toString();
+  if (contentTypeValue != null && contentTypeValue.isNotEmpty) {
+    final mimeType = contentTypeValue.split(';').first.trim().toLowerCase();
+    if (mimeType.isNotEmpty && !corsSimpleContentTypes.contains(mimeType)) {
+      return 'the Content-Type "$contentTypeValue" is not a CORS-safelisted '
+          'value (application/x-www-form-urlencoded, multipart/form-data, '
+          'text/plain)';
+    }
+  }
+  for (final key in options.headers.keys) {
+    if (!corsSafelistedRequestHeaders.contains(key.toLowerCase())) {
+      return 'the request header "$key" is not on the CORS safelist';
+    }
+  }
+  return null;
+}

--- a/plugins/web_adapter/test/cors_preflight_test.dart
+++ b/plugins/web_adapter/test/cors_preflight_test.dart
@@ -1,0 +1,130 @@
+import 'package:dio/dio.dart';
+import 'package:dio_web_adapter/src/cors.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('corsPreflightReason', () {
+    test('GET with no extra headers is a simple request', () {
+      final options = RequestOptions(method: 'GET');
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('HEAD with no extra headers is a simple request', () {
+      final options = RequestOptions(method: 'HEAD');
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('POST with text/plain is a simple request', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {Headers.contentTypeHeader: Headers.textPlainContentType},
+      );
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('POST with application/x-www-form-urlencoded is a simple request', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {
+          Headers.contentTypeHeader: Headers.formUrlEncodedContentType,
+        },
+      );
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('POST with multipart/form-data is a simple request', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {
+          Headers.contentTypeHeader: Headers.multipartFormDataContentType,
+        },
+      );
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('PUT is not a simple request', () {
+      final options = RequestOptions(method: 'PUT');
+      final reason = corsPreflightReason(options);
+      expect(reason, isNotNull);
+      expect(reason, contains('PUT'));
+      expect(reason, contains('CORS-safelisted method'));
+    });
+
+    test('DELETE is not a simple request', () {
+      final options = RequestOptions(method: 'DELETE');
+      expect(corsPreflightReason(options), contains('DELETE'));
+    });
+
+    test('PATCH is not a simple request', () {
+      final options = RequestOptions(method: 'PATCH');
+      expect(corsPreflightReason(options), contains('PATCH'));
+    });
+
+    test('custom header is not a simple request', () {
+      final options = RequestOptions(
+        method: 'GET',
+        headers: {'x-custom-header': 'value'},
+      );
+      final reason = corsPreflightReason(options);
+      expect(reason, isNotNull);
+      expect(reason, contains('x-custom-header'));
+      expect(reason, contains('CORS safelist'));
+    });
+
+    test('application/json content type is not a simple request', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+      );
+      final reason = corsPreflightReason(options);
+      expect(reason, isNotNull);
+      expect(reason, contains('application/json'));
+      expect(reason, contains('CORS-safelisted value'));
+    });
+
+    test('content type with charset suffix is parsed by mime type', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {Headers.contentTypeHeader: 'text/plain; charset=utf-8'},
+      );
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('application/json with charset is not a simple request', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {
+          Headers.contentTypeHeader: 'application/json; charset=utf-8',
+        },
+      );
+      expect(corsPreflightReason(options), contains('application/json'));
+    });
+
+    test('safelisted headers do not trigger preflight', () {
+      final options = RequestOptions(
+        method: 'GET',
+        headers: {
+          'accept': 'application/json',
+          'accept-language': 'en-US',
+          'content-language': 'en',
+        },
+      );
+      expect(corsPreflightReason(options), isNull);
+    });
+
+    test('content-type header value as a list is handled', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+      expect(corsPreflightReason(options), contains('application/json'));
+    });
+
+    test('method is case-insensitive', () {
+      final options = RequestOptions(method: 'get');
+      expect(corsPreflightReason(options), isNull);
+    });
+  });
+}

--- a/plugins/web_adapter/test/cors_preflight_test.dart
+++ b/plugins/web_adapter/test/cors_preflight_test.dart
@@ -127,4 +127,91 @@ void main() {
       expect(corsPreflightReason(options), isNull);
     });
   });
+
+  group('collectCorsPreflightReasons', () {
+    test('simple GET produces no reasons', () {
+      final options = RequestOptions(method: 'GET');
+      expect(
+        collectCorsPreflightReasons(options),
+        isEmpty,
+      );
+    });
+
+    test('upload listener adds a reason', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {Headers.contentTypeHeader: Headers.textPlainContentType},
+      );
+      final reasons = collectCorsPreflightReasons(
+        options,
+        willRegisterUploadListener: true,
+      );
+      expect(reasons, hasLength(1));
+      expect(reasons.first, contains('upload progress listener'));
+    });
+
+    test('withCredentials adds a reason', () {
+      final options = RequestOptions(method: 'GET');
+      final reasons = collectCorsPreflightReasons(
+        options,
+        withCredentials: true,
+      );
+      expect(reasons, hasLength(1));
+      expect(reasons.first, contains('withCredentials'));
+    });
+
+    test('non-simple method and upload listener and withCredentials', () {
+      final options = RequestOptions(method: 'PUT');
+      final reasons = collectCorsPreflightReasons(
+        options,
+        willRegisterUploadListener: true,
+        withCredentials: true,
+      );
+      expect(reasons, hasLength(3));
+      expect(reasons[0], contains('PUT'));
+      expect(reasons[1], contains('upload progress listener'));
+      expect(reasons[2], contains('withCredentials'));
+    });
+
+    test('simple POST with text/plain and no listener is empty', () {
+      final options = RequestOptions(
+        method: 'POST',
+        headers: {Headers.contentTypeHeader: Headers.textPlainContentType},
+      );
+      expect(
+        collectCorsPreflightReasons(options),
+        isEmpty,
+      );
+    });
+  });
+
+  group('corsEnrichedErrorReason', () {
+    const baseReason = 'The XMLHttpRequest onError callback was called. '
+        'This typically indicates an error on the network layer.';
+
+    test('returns base reason when no preflight reasons', () {
+      expect(
+        corsEnrichedErrorReason(baseReason, []),
+        baseReason,
+      );
+    });
+
+    test('appends CORS guidance when preflight reasons exist', () {
+      final reason = corsEnrichedErrorReason(baseReason, [
+        'the request method "PUT" is not a CORS-safelisted method',
+      ]);
+      expect(reason, startsWith(baseReason));
+      expect(reason, contains('cross-origin'));
+      expect(reason, contains('PUT'));
+      expect(reason, contains('CORS preflight'));
+    });
+
+    test('joins multiple reasons with semicolons', () {
+      final reason = corsEnrichedErrorReason(baseReason, [
+        'reason one',
+        'reason two',
+      ]);
+      expect(reason, contains('reason one; reason two'));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Detect when a request is not a CORS "simple request" and will trigger a preflight (OPTIONS) request on the Web platform, then emit a `warningLog` explaining why (non-safelisted method, custom headers, non-simple Content-Type, upload progress listener, or `withCredentials`).
- Enrich the `XMLHttpRequest.onError` error message with CORS guidance when the request was preflighted, so users see an actionable hint instead of a generic network error.
- Add an `enableCORSWarning` opt-out flag (defaults to `true`) so apps that handle CORS correctly can silence the per-request warning. The enriched error message is always emitted regardless of this setting.
- Extract the detection logic into pure functions in `lib/src/cors.dart` (`corsPreflightReason`, `collectCorsPreflightReasons`, `corsEnrichedErrorReason`) so they can be unit-tested on the VM without a browser.

Closes #2201.

### AI attribution

*Implementation, tests, and PR workflow by Devin (GLM-5.2); local review pass by the human operator.*

### Verification

Added 23 unit tests covering `corsPreflightReason` (method / content-type / custom-header combinations), `collectCorsPreflightReasons` (upload-listener, withCredentials, combined cases), and `corsEnrichedErrorReason` (empty / non-empty / multi-reason). `dart analyze --fatal-infos` and `dart test -p vm` pass locally on `dio_web_adapter`.

**Unverified:** The browser-side runtime paths (actual `warningLog` emission, `XMLHttpRequest.onError` enrichment in a real browser) are not exercised locally — they require browser CI. The existing `corsTests` in `dio_test` cover CORS preflight classification behavior but do not assert on the new warning or enriched error message.