### PR TITLE
🔧 chore: group github/codeql-action/* dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,7 @@ updates:
     labels:
       - "infra"
       - "github-actions"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Summary
- The three `github/codeql-action` steps (`init`, `analyze`, `autobuild`) must be on the same version — `init` writes a config file that `analyze` validates. If the versions drift, CodeQL fails with `Loaded a configuration file for version 'X', but running version 'Y'`.
- Without grouping, dependabot opens a separate PR per subpath. Merging any one alone breaks CodeQL on `main` until the sibling PR lands — this just happened with #2560 / #2561 (had to admin-merge back-to-back).
- Grouping them collapses the codeql bump into one PR going forward.

## Notes
- GitHub Actions' `uses:` field doesn't support expression interpolation, so we can't hoist the SHA into a YAML variable — grouping in dependabot config is the right fix.
- Only `github/codeql-action/*` is grouped; other actions keep individual PRs so single-action regressions stay easy to revert.

## Verification
YAML validated by inspection (four-line addition, well-formed dependabot `groups` block per [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)). Actual effect can only be observed on dependabot's next scheduled run; no way to verify pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)