### PR TITLE
📝 Clarify §8.2 gitmoji-vs-conventional and §8.6 verification prose

### DIFF
--- a/AGENTS-ZH.md
+++ b/AGENTS-ZH.md
@@ -168,7 +168,8 @@ melos bootstrap
 [可选 footer，例如 Closes #1234]
 ```
 
-本仓库常用的 gitmoji（完整列表见 `git log`）：
+本仓库常用的 gitmoji（完整列表见 `git log`）。
+**只选一列——不要两个都用。** 每一行把同一含义的 gitmoji 与 Conventional 类型前缀作对应；用 emoji 或用前缀，不要粘在一起。`🔧 chore: ...` 是错的。
 
 | Gitmoji | Conventional 类型 | 用途 |
 |---|---|---|
@@ -200,6 +201,14 @@ melos bootstrap
 🐛 Allow `callFollowingErrorInterceptor` when rejecting in `ErrorInterceptorHandler`
 perf(dio): reduce `FormData.readAsBytes` memory usage for large payloads
 docs: add agent contribution guidelines
+```
+
+不要把两种风格混用：
+
+```
+❌ 🔧 chore: group codeql-action updates      （gitmoji 和前缀同时用）
+✅ 🔧 group codeql-action updates              （只用 gitmoji）
+✅ chore: group codeql-action updates          （只用 Conventional）
 ```
 
 ### 8.3 AI 归属——必须声明
@@ -260,6 +269,14 @@ commit 前必须清除：
 - **诚实描述已完成的验证——不要写套版式 "Test plan" 勾选清单。** 用一两句话散文式说明你实际验证了什么、怎么验证的：
 
   > *添加了 15 个单元测试覆盖 method / content-type / custom-header 各种组合；`melos run test:vm` 与 `melos run analyze` 均通过。*
+
+  **不要**贴一份通用的 checklist——即使你的 agent 工具默认给出一份，本节明确拒绝这种模板：
+
+  ```
+  ❌  ## Test plan
+      - [ ] Tests pass
+      - [ ] Feature works as expected
+  ```
 
   机械性的前置检查（`dart analyze`、`dart format`）已经由 PR 模板顶部的 checklist 覆盖——不要把它们当作「测试」再列一遍。行为验证指的是「本次改动如果回退，这条检查会失败」的那种检查。
 

--- a/AGENTS-ZH.md
+++ b/AGENTS-ZH.md
@@ -194,6 +194,7 @@ melos bootstrap
 - 主题使用英文祈使句。不要手动加 PR 号——GitHub 在 squash-merge 时会自动追加 `(#N)`。
 - Scope 用于澄清（`fix(dio_web_adapter): ...`）；如果 scope 只是重复了路径信息，就省略。
 - 位置 0 是 emoji 或者 Conventional 前缀加冒号，然后空格，再是主题。
+- 以 gitmoji 开头时，主题**首字母大写**（`🐛 Allow ...`、`📝 Clarify ...`）；以 Conventional 前缀开头时，主题保持小写（`docs: add ...`、`perf(dio): reduce ...`）。
 
 示例（改编自真实仓库历史）：
 
@@ -207,8 +208,8 @@ docs: add agent contribution guidelines
 
 ```
 ❌ 🔧 chore: group codeql-action updates      （gitmoji 和前缀同时用）
-✅ 🔧 group codeql-action updates              （只用 gitmoji）
-✅ chore: group codeql-action updates          （只用 Conventional）
+✅ 🔧 Group codeql-action updates              （只用 gitmoji，主题首字母大写）
+✅ chore: group codeql-action updates          （只用 Conventional，主题小写）
 ```
 
 ### 8.3 AI 归属——必须声明

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,9 @@ Rules:
 - Use scope when it clarifies (`fix(dio_web_adapter): ...`); omit when it
   would just repeat the file path.
 - Position 0 is either the emoji or the Conventional prefix plus colon, then a space, then the subject.
+- After a gitmoji the subject starts with a **capital letter**
+  (`🐛 Allow ...`, `📝 Clarify ...`); after a Conventional prefix the
+  subject stays lowercase (`docs: add ...`, `perf(dio): reduce ...`).
 
 Examples (adapted from actual repo history):
 
@@ -300,8 +303,8 @@ Do **not** combine the two styles:
 
 ```
 ❌ 🔧 chore: group codeql-action updates      (both gitmoji AND prefix)
-✅ 🔧 group codeql-action updates              (gitmoji only)
-✅ chore: group codeql-action updates          (Conventional only)
+✅ 🔧 Group codeql-action updates              (gitmoji only, capitalized subject)
+✅ chore: group codeql-action updates          (Conventional only, lowercase subject)
 ```
 
 ### 8.3 AI attribution — mandatory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,10 @@ new ones.
 [optional footer, e.g. Closes #1234]
 ```
 
-Gitmoji commonly used in this repository (see `git log` for the full set):
+Gitmoji commonly used in this repository (see `git log` for the full set).
+**Pick one column — never both.** Each row maps a gitmoji to its
+equivalent Conventional-type prefix; you use the emoji **or** the type,
+not the two glued together. `🔧 chore: ...` is wrong.
 
 | Gitmoji | Conventional type | Use for |
 |---|---|---|
@@ -291,6 +294,14 @@ Examples (adapted from actual repo history):
 🐛 Allow `callFollowingErrorInterceptor` when rejecting in `ErrorInterceptorHandler`
 perf(dio): reduce `FormData.readAsBytes` memory usage for large payloads
 docs: add agent contribution guidelines
+```
+
+Do **not** combine the two styles:
+
+```
+❌ 🔧 chore: group codeql-action updates      (both gitmoji AND prefix)
+✅ 🔧 group codeql-action updates              (gitmoji only)
+✅ chore: group codeql-action updates          (Conventional only)
 ```
 
 ### 8.3 AI attribution — mandatory
@@ -376,6 +387,16 @@ message and the diff describe different work, one of them is wrong.
 
   > *Added 15 unit tests covering method / content-type / custom-header
   > combinations; `melos run test:vm` and `melos run analyze` clean.*
+
+  Do **not** paste a generic checklist — this is the anti-pattern this
+  section is explicitly rejecting, even if your agent tooling suggests
+  one by default:
+
+  ```
+  ❌  ## Test plan
+      - [ ] Tests pass
+      - [ ] Feature works as expected
+  ```
 
   Mechanical prerequisites (`dart analyze`, `dart format`) are already
   covered by the PR template's top-level checklist — do not re-list them


### PR DESCRIPTION
## Summary
Both rules were already correct in AGENTS.md but easy to misread. This PR adds anti-examples so the two failure modes get flagged next to the good examples instead of buried in prose.

- **§8.2 (commit format)** — the two-column table (Gitmoji ↔ Conventional type) reads as a mapping row-by-row, but the header alone looks like an instruction to use them together. Added a `**Pick one column — never both.**` caption above the table and a ❌/✅ trio at the end of the Examples block.
- **§8.6 (verification)** — the existing text says no boilerplate Test plan checklist and shows what a good verification paragraph looks like, but not what to avoid. Since agent tooling often injects `## Test plan` by default, added a small ❌ block showing the exact anti-pattern.

Both edits are additive — no existing wording removed or reordered.

## Motivation
While cleaning up dependabot PRs I opened #2563 with `🔧 chore:` (both styles glued) and a `## Test plan` checklist. User flagged both against AGENTS.md; on re-reading the sections I could see how I misread each one. Rather than only fixing my private habits, tightening the doc so the next agent doesn't need to be corrected in the same spots.

## Verification
Doc-only change; rendered the diff visually and confirmed markdown table + fenced blocks are well-formed. No behavioral change to verify.

*Drafted and reviewed by Claude Opus 4.7 (1M context) after the misreads it produced were called out in review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)