### PR TITLE
fix(dio): preserve shared Future errors across interceptors

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -13,6 +13,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
   `BackgroundTransformer`.
 - Fix concurrent requests hanging or reporting uncaught errors when an
   interceptor shares a failing Future, such as in request deduplication.
+- Preserve `onRequest`, `onResponse`, and `onError` overrides in subclasses of
+  `InterceptorsWrapper` and `QueuedInterceptorsWrapper`.
 
 ## 5.10.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -13,8 +13,6 @@ See the [Migration Guide][] for the complete breaking changes list.**
   `BackgroundTransformer`.
 - Fix concurrent requests hanging or reporting uncaught errors when an
   interceptor shares a failing Future, such as in request deduplication.
-- Preserve `onRequest`, `onResponse`, and `onError` overrides in subclasses of
-  `InterceptorsWrapper` and `QueuedInterceptorsWrapper`.
 
 ## 5.10.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -11,6 +11,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
   on an empty response body when a custom `responseDecoder` is set. It now
   returns an empty result, consistent with `SyncTransformer` and
   `BackgroundTransformer`.
+- Fix concurrent requests hanging or reporting uncaught errors when an
+  interceptor shares a failing Future, such as in request deduplication.
 
 ## 5.10.0
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -426,34 +426,10 @@ abstract class DioMixin implements Dio {
       }
     }
 
-    // Create an error zone that catches uncaught async errors from
-    // interceptor callbacks. This prevents requests from hanging when
-    // an async interceptor throws without calling the handler.
-    // Synchronous exceptions are not caught here and propagate normally.
-    // If the handler was already completed (e.g. a fire-and-forget future
-    // inside the callback failed), forward the error to the parent zone
-    // so it isn't silently swallowed.
-    Zone createInterceptorZone(
-      _BaseHandler handler,
-      void Function(Object error, StackTrace stackTrace) onUncaughtError,
-    ) {
-      return Zone.current.fork(
-        specification: ZoneSpecification(
-          handleUncaughtError: (self, parent, zone, error, stackTrace) {
-            if (!handler.isCompleted) {
-              onUncaughtError(error, stackTrace);
-            } else {
-              parent.handleUncaughtError(zone, error, stackTrace);
-            }
-          },
-        ),
-      );
-    }
-
     // Convert the request interceptor to a functional callback in which
     // we can handle the return value of interceptor callback.
     FutureOr Function(dynamic) requestInterceptorWrapper(
-      InterceptorSendCallback cb,
+      _InterceptorCallback<RequestOptions, RequestInterceptorHandler> cb,
     ) {
       return (dynamic incomingState) {
         final state = incomingState as InterceptorState;
@@ -462,13 +438,15 @@ abstract class DioMixin implements Dio {
             requestOptions.cancelToken,
             Future(() async {
               final handler = RequestInterceptorHandler();
-              createInterceptorZone(
+              final result = cb(state.data as RequestOptions, handler);
+              _observeInterceptorCallback(
+                result,
                 handler,
                 (error, stackTrace) => handler.reject(
                   assureDioException(error, requestOptions, stackTrace),
                   true,
                 ),
-              ).run(() => cb(state.data as RequestOptions, handler));
+              );
               return handler.future;
             }),
           );
@@ -480,7 +458,7 @@ abstract class DioMixin implements Dio {
     // Convert the response interceptor to a functional callback in which
     // we can handle the return value of interceptor callback.
     FutureOr<dynamic> Function(dynamic) responseInterceptorWrapper(
-      InterceptorSuccessCallback cb,
+      _InterceptorCallback<Response<dynamic>, ResponseInterceptorHandler> cb,
     ) {
       return (dynamic incomingState) {
         final state = incomingState as InterceptorState;
@@ -490,13 +468,15 @@ abstract class DioMixin implements Dio {
             requestOptions.cancelToken,
             Future(() async {
               final handler = ResponseInterceptorHandler();
-              createInterceptorZone(
+              final result = cb(state.data as Response, handler);
+              _observeInterceptorCallback(
+                result,
                 handler,
                 (error, stackTrace) => handler.reject(
                   assureDioException(error, requestOptions, stackTrace),
                   true,
                 ),
-              ).run(() => cb(state.data as Response, handler));
+              );
               return handler.future;
             }),
           );
@@ -508,7 +488,7 @@ abstract class DioMixin implements Dio {
     // Convert the error interceptor to a functional callback in which
     // we can handle the return value of interceptor callback.
     FutureOr<dynamic> Function(Object) errorInterceptorWrapper(
-      InterceptorErrorCallback cb,
+      _InterceptorCallback<DioException, ErrorInterceptorHandler> cb,
     ) {
       return (dynamic error) {
         final state = error is InterceptorState
@@ -516,12 +496,14 @@ abstract class DioMixin implements Dio {
             : InterceptorState(assureDioException(error, requestOptions));
         Future<InterceptorState> handleError() async {
           final handler = ErrorInterceptorHandler();
-          createInterceptorZone(
+          final result = cb(state.data, handler);
+          _observeInterceptorCallback(
+            result,
             handler,
             (error, stackTrace) => handler.next(
               assureDioException(error, requestOptions, stackTrace),
             ),
-          ).run(() => cb(state.data, handler));
+          );
           return handler.future;
         }
 
@@ -552,7 +534,7 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleRequest
-          : interceptor.onRequest;
+          : interceptor._invokeRequest;
       future = future.then(requestInterceptorWrapper(fun));
     }
 
@@ -569,6 +551,7 @@ abstract class DioMixin implements Dio {
         } on DioException catch (e) {
           handler.reject(e, true);
         }
+        return null;
       }),
     );
 
@@ -576,7 +559,7 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleResponse
-          : interceptor.onResponse;
+          : interceptor._invokeResponse;
       future = future.then(responseInterceptorWrapper(fun));
     }
 
@@ -584,7 +567,7 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleError
-          : interceptor.onError;
+          : interceptor._invokeError;
       future = future.catchError(errorInterceptorWrapper(fun));
     }
     // Normalize errors, converts errors to [DioException].

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -318,16 +318,29 @@ mixin _InterceptorWrapperMixin on Interceptor {
   InterceptorSuccessCallback? _onResponse;
   InterceptorErrorCallback? _onError;
 
+  // The public callback typedefs remain void for compatibility. Invoke them
+  // dynamically so an async callback still exposes its runtime Future.
+
   @override
   void onRequest(
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) {
-    if (_onRequest != null) {
-      _onRequest!(options, handler);
-    } else {
+    final callback = _onRequest;
+    if (callback == null) {
       handler.next(options);
+      return;
     }
+    final dynamic dynamicCallback = callback;
+    final result = dynamicCallback(options, handler);
+    _observeInterceptorCallback(
+      result,
+      handler,
+      (error, stackTrace) => handler.reject(
+        DioMixin.assureDioException(error, options, stackTrace),
+        true,
+      ),
+    );
   }
 
   @override
@@ -335,11 +348,25 @@ mixin _InterceptorWrapperMixin on Interceptor {
     Response<dynamic> response,
     ResponseInterceptorHandler handler,
   ) {
-    if (_onResponse != null) {
-      _onResponse!(response, handler);
-    } else {
+    final callback = _onResponse;
+    if (callback == null) {
       handler.next(response);
+      return;
     }
+    final dynamic dynamicCallback = callback;
+    final result = dynamicCallback(response, handler);
+    _observeInterceptorCallback(
+      result,
+      handler,
+      (error, stackTrace) => handler.reject(
+        DioMixin.assureDioException(
+          error,
+          response.requestOptions,
+          stackTrace,
+        ),
+        true,
+      ),
+    );
   }
 
   @override
@@ -347,50 +374,24 @@ mixin _InterceptorWrapperMixin on Interceptor {
     DioException err,
     ErrorInterceptorHandler handler,
   ) {
-    if (_onError != null) {
-      _onError!(err, handler);
-    } else {
+    final callback = _onError;
+    if (callback == null) {
       handler.next(err);
+      return;
     }
-  }
-
-  @override
-  Object? _invokeRequest(
-    RequestOptions options,
-    RequestInterceptorHandler handler,
-  ) {
-    if (_onRequest == null) {
-      handler.next(options);
-      return null;
-    }
-    final dynamic callback = _onRequest;
-    return callback(options, handler);
-  }
-
-  @override
-  Object? _invokeResponse(
-    Response<dynamic> response,
-    ResponseInterceptorHandler handler,
-  ) {
-    if (_onResponse == null) {
-      handler.next(response);
-      return null;
-    }
-    final dynamic callback = _onResponse;
-    return callback(response, handler);
-  }
-
-  @override
-  Object? _invokeError(
-    DioException error,
-    ErrorInterceptorHandler handler,
-  ) {
-    if (_onError == null) {
-      handler.next(error);
-      return null;
-    }
-    final dynamic callback = _onError;
-    return callback(error, handler);
+    final dynamic dynamicCallback = callback;
+    final result = dynamicCallback(err, handler);
+    _observeInterceptorCallback(
+      result,
+      handler,
+      (error, stackTrace) => handler.next(
+        DioMixin.assureDioException(
+          error,
+          err.requestOptions,
+          stackTrace,
+        ),
+      ),
+    );
   }
 }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -39,6 +39,33 @@ abstract class _BaseHandler {
   }
 }
 
+typedef _InterceptorCallback<T, V extends _BaseHandler> = Object? Function(
+  T data,
+  V handler,
+);
+
+void _observeInterceptorCallback(
+  Object? result,
+  _BaseHandler handler,
+  void Function(Object error, StackTrace stackTrace) onError,
+) {
+  if (result is! Future<dynamic>) {
+    return;
+  }
+
+  final callbackZone = Zone.current;
+  result.then<void>(
+    (_) {},
+    onError: (Object error, StackTrace stackTrace) {
+      if (!handler.isCompleted) {
+        onError(error, stackTrace);
+      } else {
+        callbackZone.handleUncaughtError(error, stackTrace);
+      }
+    },
+  );
+}
+
 /// The handler for interceptors to handle before the request has been sent.
 class RequestInterceptorHandler extends _BaseHandler {
   /// Deliver the [requestOptions] to the next interceptor.
@@ -242,6 +269,30 @@ class Interceptor {
   ) {
     handler.next(err);
   }
+
+  Object? _invokeRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    final dynamic callback = onRequest;
+    return callback(options, handler);
+  }
+
+  Object? _invokeResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    final dynamic callback = onResponse;
+    return callback(response, handler);
+  }
+
+  Object? _invokeError(
+    DioException error,
+    ErrorInterceptorHandler handler,
+  ) {
+    final dynamic callback = onError;
+    return callback(error, handler);
+  }
 }
 
 /// The signature of [Interceptor.onRequest].
@@ -301,6 +352,45 @@ mixin _InterceptorWrapperMixin on Interceptor {
     } else {
       handler.next(err);
     }
+  }
+
+  @override
+  Object? _invokeRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    if (_onRequest == null) {
+      handler.next(options);
+      return null;
+    }
+    final dynamic callback = _onRequest;
+    return callback(options, handler);
+  }
+
+  @override
+  Object? _invokeResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    if (_onResponse == null) {
+      handler.next(response);
+      return null;
+    }
+    final dynamic callback = _onResponse;
+    return callback(response, handler);
+  }
+
+  @override
+  Object? _invokeError(
+    DioException error,
+    ErrorInterceptorHandler handler,
+  ) {
+    if (_onError == null) {
+      handler.next(error);
+      return null;
+    }
+    final dynamic callback = _onError;
+    return callback(error, handler);
   }
 }
 
@@ -402,7 +492,7 @@ class QueuedInterceptor extends Interceptor {
   final _responseQueue = _TaskQueue<Response, ResponseInterceptorHandler>();
   final _errorQueue = _TaskQueue<DioException, ErrorInterceptorHandler>();
 
-  void _handleRequest(
+  Object? _handleRequest(
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) {
@@ -410,15 +500,16 @@ class QueuedInterceptor extends Interceptor {
       _requestQueue,
       options,
       handler,
-      onRequest,
-      (e, handler) {
-        final error = DioMixin.assureDioException(e, options);
+      _invokeRequest,
+      (e, stackTrace, handler) {
+        final error = DioMixin.assureDioException(e, options, stackTrace);
         handler.reject(error, true);
       },
     );
+    return null;
   }
 
-  void _handleResponse(
+  Object? _handleResponse(
     Response<dynamic> response,
     ResponseInterceptorHandler handler,
   ) {
@@ -426,15 +517,20 @@ class QueuedInterceptor extends Interceptor {
       _responseQueue,
       response,
       handler,
-      onResponse,
-      (e, handler) {
-        final error = DioMixin.assureDioException(e, response.requestOptions);
+      _invokeResponse,
+      (e, stackTrace, handler) {
+        final error = DioMixin.assureDioException(
+          e,
+          response.requestOptions,
+          stackTrace,
+        );
         handler.reject(error, true);
       },
     );
+    return null;
   }
 
-  void _handleError(
+  Object? _handleError(
     DioException error,
     ErrorInterceptorHandler handler,
   ) {
@@ -442,20 +538,25 @@ class QueuedInterceptor extends Interceptor {
       _errorQueue,
       error,
       handler,
-      onError,
-      (e, handler) {
-        final err = DioMixin.assureDioException(e, error.requestOptions);
+      _invokeError,
+      (e, stackTrace, handler) {
+        final err = DioMixin.assureDioException(
+          e,
+          error.requestOptions,
+          stackTrace,
+        );
         handler.next(err);
       },
     );
+    return null;
   }
 
   void _handleQueue<T, V extends _BaseHandler>(
     _TaskQueue<T, V> taskQueue,
     T data,
     V handler,
-    void Function(T, V) callback,
-    void Function(Object, V) onError,
+    _InterceptorCallback<T, V> callback,
+    void Function(Object, StackTrace, V) onError,
   ) {
     // Runs [task] as the active task and wires up how the queue advances to
     // the next task once this one is done.
@@ -519,12 +620,17 @@ class QueuedInterceptor extends Interceptor {
       });
 
       try {
-        callback(task.data, task.handler);
-      } catch (e) {
+        final result = callback(task.data, task.handler);
+        _observeInterceptorCallback(
+          result,
+          task.handler,
+          (error, stackTrace) => onError(error, stackTrace, task.handler),
+        );
+      } catch (e, stackTrace) {
         // Handle synchronous exceptions thrown by interceptor callbacks.
         // Without this, the request would hang indefinitely because the
         // handler's completer would never be completed.
-        onError(e, task.handler);
+        onError(e, stackTrace, task.handler);
       }
     }
 

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -49,6 +49,8 @@ void _observeInterceptorCallback(
   _BaseHandler handler,
   void Function(Object error, StackTrace stackTrace) onError,
 ) {
+  // Only a returned Future can be associated with this handler. Detached
+  // asynchronous work remains owned by the callback's zone.
   if (result is! Future<dynamic>) {
     return;
   }

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -477,6 +477,52 @@ void main() {
       );
     });
 
+    test('Async response interceptor subclass error does not hang the request',
+        () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncResponseErrorInterceptor());
+
+      await expectLater(
+        dio.get<Object?>('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.error,
+            'error',
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Async response interceptor subclass error',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('Async error interceptor subclass error does not hang the request',
+        () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncErrorInterceptor());
+
+      await expectLater(
+        dio.get<Object?>('/test-not-found'),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.error,
+            'error',
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Async error interceptor subclass error',
+            ),
+          ),
+        ),
+      );
+    });
+
     test('Async onResponse error does not hang the request', () async {
       final dio = Dio()
         ..options.baseUrl = MockAdapter.mockBase
@@ -1422,6 +1468,28 @@ class _AsyncRequestErrorInterceptor extends Interceptor {
   ) async {
     await Future<void>.value();
     throw StateError('Async interceptor subclass error');
+  }
+}
+
+class _AsyncResponseErrorInterceptor extends Interceptor {
+  @override
+  Future<void> onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('Async response interceptor subclass error');
+  }
+}
+
+class _AsyncErrorInterceptor extends Interceptor {
+  @override
+  Future<void> onError(
+    DioException error,
+    ErrorInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('Async error interceptor subclass error');
   }
 }
 

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -617,6 +617,86 @@ void main() {
       expect(uncaughtErrors, [same(lateError)]);
     });
 
+    test('InterceptorsWrapper subclass invokes on* overrides', () async {
+      final events = <String>[];
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_SubclassedInterceptorsWrapper(events));
+
+      final response = await dio.get<Object?>('/test');
+      expect(response.statusCode, 200);
+      await expectLater(
+        dio.get<Object?>('/test-not-found'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(events, ['request', 'response', 'request', 'error']);
+    });
+
+    test('InterceptorsWrapper subclass observes async callback errors',
+        () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncSubclassedInterceptorsWrapper());
+
+      await expectLater(
+        dio.get<Object?>('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.error,
+            'error',
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Async wrapper subclass error',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('QueuedInterceptorsWrapper subclass invokes on* overrides', () async {
+      final events = <String>[];
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_SubclassedQueuedInterceptorsWrapper(events));
+
+      final response = await dio.get<Object?>('/test');
+      expect(response.statusCode, 200);
+      await expectLater(
+        dio.get<Object?>('/test-not-found'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(events, ['request', 'response', 'request', 'error']);
+    });
+
+    test('QueuedInterceptorsWrapper subclass observes async callback errors',
+        () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncSubclassedQueuedInterceptorsWrapper());
+
+      await expectLater(
+        dio.get<Object?>('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.error,
+            'error',
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Async queued wrapper subclass error',
+            ),
+          ),
+        ),
+      );
+    });
+
     test('#2565 shares adapter errors between concurrent requests', () async {
       final adapter = _ImmediateErrorAdapter();
       final interceptor = _DeduplicatingInterceptor();
@@ -1342,5 +1422,94 @@ class _AsyncRequestErrorInterceptor extends Interceptor {
   ) async {
     await Future<void>.value();
     throw StateError('Async interceptor subclass error');
+  }
+}
+
+class _SubclassedInterceptorsWrapper extends InterceptorsWrapper {
+  _SubclassedInterceptorsWrapper(this.events);
+
+  final List<String> events;
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    events.add('request');
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    events.add('response');
+    handler.next(response);
+  }
+
+  @override
+  void onError(
+    DioException error,
+    ErrorInterceptorHandler handler,
+  ) {
+    events.add('error');
+    handler.next(error);
+  }
+}
+
+class _AsyncSubclassedInterceptorsWrapper extends InterceptorsWrapper {
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('Async wrapper subclass error');
+  }
+}
+
+class _SubclassedQueuedInterceptorsWrapper extends QueuedInterceptorsWrapper {
+  _SubclassedQueuedInterceptorsWrapper(this.events);
+
+  final List<String> events;
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    events.add('request');
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    events.add('response');
+    handler.next(response);
+  }
+
+  @override
+  void onError(
+    DioException error,
+    ErrorInterceptorHandler handler,
+  ) {
+    events.add('error');
+    handler.next(error);
+  }
+}
+
+class _AsyncSubclassedQueuedInterceptorsWrapper
+    extends QueuedInterceptorsWrapper {
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('Async queued wrapper subclass error');
   }
 }

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:dio/src/dio_mixin.dart';
@@ -453,6 +454,29 @@ void main() {
       );
     });
 
+    test('Async interceptor subclass error does not hang the request',
+        () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncRequestErrorInterceptor());
+
+      await expectLater(
+        dio.get('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.error,
+            'error',
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Async interceptor subclass error',
+            ),
+          ),
+        ),
+      );
+    });
+
     test('Async onResponse error does not hang the request', () async {
       final dio = Dio()
         ..options.baseUrl = MockAdapter.mockBase
@@ -505,6 +529,146 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('Async error interceptor is not awaited after calling next', () async {
+      final callbackRelease = Completer<void>();
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onError: (error, handler) async {
+              await Future<void>.value();
+              handler.next(error);
+              await callbackRelease.future;
+            },
+          ),
+        )
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onError: (error, handler) {
+              handler.resolve(
+                Response<Object?>(
+                  requestOptions: error.requestOptions,
+                  data: 'recovered',
+                ),
+              );
+            },
+          ),
+        );
+
+      final response = await dio.get<Object?>('/test-not-found').timeout(
+        const Duration(seconds: 1),
+        onTimeout: () {
+          callbackRelease.complete();
+          throw StateError('The interceptor callback was awaited.');
+        },
+      );
+      callbackRelease.complete();
+
+      expect(response.data, 'recovered');
+    });
+
+    test('Async error after handler completion reaches the callback zone',
+        () async {
+      final lateError = StateError('Late interceptor error');
+      final uncaughtErrors = <Object>[];
+      final errorObserved = Completer<void>();
+      final zoneCompleted = Completer<void>();
+      Response<Object?>? response;
+      var timedOut = false;
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) async {
+              handler.next(options);
+              await Future<void>.value();
+              throw lateError;
+            },
+          ),
+        );
+
+      runZonedGuarded(
+        () async {
+          try {
+            response = await dio.get<Object?>('/test');
+            await errorObserved.future.timeout(const Duration(seconds: 1));
+          } on TimeoutException {
+            timedOut = true;
+          } finally {
+            zoneCompleted.complete();
+          }
+        },
+        (error, stackTrace) {
+          uncaughtErrors.add(error);
+          if (!errorObserved.isCompleted) {
+            errorObserved.complete();
+          }
+        },
+      );
+
+      await zoneCompleted.future;
+
+      expect(timedOut, isFalse);
+      expect(response?.statusCode, 200);
+      expect(uncaughtErrors, [same(lateError)]);
+    });
+
+    test('#2565 shares adapter errors between concurrent requests', () async {
+      final adapter = _ImmediateErrorAdapter();
+      final interceptor = _DeduplicatingInterceptor();
+      final dio = Dio()
+        ..httpClientAdapter = adapter
+        ..interceptors.add(interceptor);
+      final errors = <DioException>[];
+      final uncaughtErrors = <Object>[];
+      final zoneCompleted = Completer<void>();
+      var timedOut = false;
+
+      runZonedGuarded(
+        () async {
+          try {
+            errors.addAll(
+              await Future.wait<DioException>([
+                dio.get<Object?>('https://example.com/shared').then(
+                      (_) => throw StateError('The adapter should fail.'),
+                      onError: (Object error, StackTrace stackTrace) =>
+                          error as DioException,
+                    ),
+                dio.get<Object?>('https://example.com/shared').then(
+                      (_) => throw StateError('The adapter should fail.'),
+                      onError: (Object error, StackTrace stackTrace) =>
+                          error as DioException,
+                    ),
+              ]).timeout(const Duration(seconds: 1)),
+            );
+          } on TimeoutException {
+            timedOut = true;
+          } finally {
+            zoneCompleted.complete();
+          }
+        },
+        (error, stackTrace) => uncaughtErrors.add(error),
+      );
+
+      await zoneCompleted.future;
+
+      expect(
+        timedOut,
+        isFalse,
+        reason: 'requests=${interceptor.requestCount}, '
+            'fetches=${adapter.fetchCount}, errors=${errors.length}, '
+            'uncaught=${uncaughtErrors.length}, pending=${interceptor.pending.length}',
+      );
+      expect(interceptor.requestCount, 2);
+      expect(adapter.fetchCount, 1);
+      expect(errors, hasLength(2));
+      expect(errors, everyElement(same(adapter.error)));
+      expect(uncaughtErrors, isEmpty);
+      expect(interceptor.pending, isEmpty);
     });
 
     group(ImplyContentTypeInterceptor, () {
@@ -1112,4 +1276,71 @@ void main() {
     expect(interceptors3.length, equals(2));
     expect(interceptors2.last, isA<LogInterceptor>());
   });
+}
+
+class _DeduplicatingInterceptor extends Interceptor {
+  final pending = <Uri, Completer<Response<Object?>>>{};
+  int requestCount = 0;
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    requestCount++;
+    final completer = pending[options.uri];
+    if (completer == null) {
+      pending[options.uri] = Completer<Response<Object?>>();
+      handler.next(options);
+      return;
+    }
+    completer.future.then(
+      handler.resolve,
+      onError: (Object error, StackTrace stackTrace) {
+        handler.reject(error as DioException);
+      },
+    );
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final completer = pending.remove(err.requestOptions.uri);
+    if (completer != null) {
+      completer.completeError(err, err.stackTrace);
+    }
+    handler.next(err);
+  }
+}
+
+class _ImmediateErrorAdapter implements HttpClientAdapter {
+  int fetchCount = 0;
+  DioException? error;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    fetchCount++;
+    error = DioException(
+      requestOptions: options,
+      message: 'Immediate adapter failure',
+    );
+    throw error!;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _AsyncRequestErrorInterceptor extends Interceptor {
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('Async interceptor subclass error');
+  }
 }

--- a/dio/test/queued_interceptor_test.dart
+++ b/dio/test/queued_interceptor_test.dart
@@ -75,6 +75,129 @@ void main() {
     }
   });
 
+  test(
+      'QueuedInterceptor should catch asynchronous errors in onRequest and release the queue',
+      () async {
+    final dio = Dio()
+      ..httpClientAdapter = _MockAdapter()
+      ..interceptors.add(_AsyncRequestErrorQueuedInterceptor());
+
+    final firstRequest = dio.get('https://example.com/first');
+    final firstFailure = expectLater(
+      firstRequest,
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.error,
+          'error',
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Async request error',
+          ),
+        ),
+      ),
+    );
+    final secondResponse = await dio
+        .get('https://example.com/second')
+        .timeout(const Duration(seconds: 1));
+
+    expect(secondResponse.statusCode, 200);
+    await firstFailure;
+  });
+
+  test(
+      'QueuedInterceptor should catch asynchronous errors in onResponse and release the queue',
+      () async {
+    var responseCount = 0;
+    final dio = Dio()
+      ..httpClientAdapter = _MockAdapter()
+      ..interceptors.add(
+        QueuedInterceptorsWrapper(
+          onResponse: (response, handler) async {
+            responseCount++;
+            await Future<void>.value();
+            if (responseCount == 1) {
+              throw StateError('Async response error');
+            }
+            handler.next(response);
+          },
+        ),
+      );
+
+    final firstRequest = dio.get('https://example.com/first');
+    final firstFailure = expectLater(
+      firstRequest,
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.error,
+          'error',
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Async response error',
+          ),
+        ),
+      ),
+    );
+    final secondResponse = await dio
+        .get('https://example.com/second')
+        .timeout(const Duration(seconds: 1));
+
+    expect(secondResponse.statusCode, 200);
+    expect(responseCount, 2);
+    await firstFailure;
+  });
+
+  test(
+      'QueuedInterceptor should catch asynchronous errors in onError and release the queue',
+      () async {
+    var errorCount = 0;
+    final dio = Dio()
+      ..httpClientAdapter = _FailingMockAdapter()
+      ..interceptors.add(
+        QueuedInterceptorsWrapper(
+          onError: (error, handler) async {
+            errorCount++;
+            await Future<void>.value();
+            if (errorCount == 1) {
+              throw StateError('Async error interceptor error');
+            }
+            handler.next(error);
+          },
+        ),
+      );
+
+    final firstRequest = dio.get('https://example.com/first');
+    final firstFailure = expectLater(
+      firstRequest,
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.error,
+          'error',
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Async error interceptor error',
+          ),
+        ),
+      ),
+    );
+    final secondRequest = dio.get('https://example.com/second');
+    final secondFailure = expectLater(
+      secondRequest.timeout(const Duration(seconds: 1)),
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.message,
+          'message',
+          'Mock request failed',
+        ),
+      ),
+    );
+
+    await Future.wait([firstFailure, secondFailure]);
+    expect(errorCount, 2);
+  });
+
   test('Reproduces issue #2138 scenario with QueuedInterceptor', () async {
     final dio = Dio();
 
@@ -268,5 +391,22 @@ class _QueuedInterceptorWithError extends QueuedInterceptor {
     ErrorInterceptorHandler handler,
   ) {
     handler.next(err);
+  }
+}
+
+class _AsyncRequestErrorQueuedInterceptor extends QueuedInterceptor {
+  int requestCount = 0;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    requestCount++;
+    await Future<void>.value();
+    if (requestCount == 1) {
+      throw StateError('Async request error');
+    }
+    handler.next(options);
   }
 }


### PR DESCRIPTION
Closes #2565

## Problem

Dio 5.10.0 introduced a regression in the interceptor execution model. A custom interceptor that deduplicates concurrent requests by sharing a `Completer` can expose an uncaught `DioException`, leave the duplicate request pending, or dispatch the same request more than once when the adapter fails immediately.

The failure is not caused by request deduplication itself. It is caused by the interaction between deduplication and the per-callback error zones introduced by #2499.

## Root Cause

Interceptor callbacks intentionally have public `void` return types:

```dart
void onRequest(RequestOptions options, RequestInterceptorHandler handler)
```

Dart still allows an async implementation or callback to produce a runtime `Future<void>`, but the public static type does not expose that Future. Before #2499, an async exception thrown before `next`, `resolve`, or `reject` could therefore leave the handler's completer pending forever.

#2499 addressed that hang by invoking every callback inside a newly forked `Zone` with a custom `handleUncaughtError`. If the handler was incomplete, the zone converted the uncaught error into a handler error; if the handler was already complete, it forwarded the error to the parent zone. This preserved the public `void` API and did not await callbacks.

The new zone boundary changed Dart's Future error-delivery semantics. Dart Future errors do not cross between distinct error zones in the same way as ordinary values. The deterministic #2565 sequence is:

```text
Request A: callback runs in error zone A
           creates the shared Completer
           calls handler.next()
           proceeds to the adapter

Request B: callback runs in error zone B
           finds A's Completer
           registers an onError listener on its Future

Adapter:   A fails immediately
           A's onError completes the shared Completer with completeError()

Result:    the Future belongs to error zone A, but B's listener belongs to B
           B's listener is not delivered the shared error
           A's handler is already complete, so Dio forwards the error as uncaught
           B's handler never completes
```

The regression is the per-callback error-zone isolation; the immediate adapter failure is the deterministic timing trigger that exposes it in this reproduction. This fix removes the callback-specific zones created by Dio; it does not make a shared Future safe when application code deliberately creates and listens to it across unrelated external error zones, which remain governed by Dart's normal error-zone rules. Before the implementation, a test-only probe reproduced two `onRequest` callbacks, one adapter fetch, zero joined-error deliveries, one uncaught error, and a timed-out pending request on the base implementation. The committed regression test asserts the repaired behavior after the fix.

## Implementation

### 1. Capture runtime callback Futures without changing the API

A private library typedef, `_InterceptorCallback<T, V>`, returns `Object?`. `Interceptor` now has private virtual `_invokeRequest`, `_invokeResponse`, and `_invokeError` entry points that dynamically invoke the public `on*` method:

```dart
final dynamic callback = onRequest;
return callback(options, handler);
```

This is deliberate:

- A normal `Interceptor` subclass can override `Future<void> onRequest/onResponse/onError`; dynamic invocation retains the runtime Future even though the base API is `void`.
- The public method signatures and public callback typedefs remain unchanged.
- The private entry points are used only by the internal request pipeline.

The wrapper compatibility path is kept explicit. `InterceptorsWrapper` and `QueuedInterceptorsWrapper` still expose their existing public `void on*` methods. The wrapper mixin dynamically invokes the constructor-supplied callback and observes its runtime result there. It no longer uses private mixin overrides that bypass a subclass's public `onRequest`, `onResponse`, or `onError` override. This preserves downstream wrapper-subclass behavior while retaining support for async constructor callbacks.

### 2. Observe, do not await, the returned Future

`_observeInterceptorCallback` is registered synchronously immediately after callback invocation, in the callback's existing zone:

```text
invoke callback
  -> obtain runtime result
  -> if result is a Future, attach a success no-op and an error listener
  -> return handler.future to the interceptor pipeline
```

The callback Future is never awaited and is never used as the pipeline completion signal. Handler completion remains the only normal signal that advances the request, response, or error chain.

When the observed Future fails:

| Callback stage | Handler is incomplete | Handler is already complete |
| --- | --- | --- |
| Request | `handler.reject(assureDioException(error, ..., stackTrace), true)` | Report through the callback's existing zone |
| Response | `handler.reject(assureDioException(error, ..., stackTrace), true)` | Report through the callback's existing zone |
| Error | `handler.next(assureDioException(error, ..., stackTrace))` | Report through the callback's existing zone |

The original `StackTrace` is preserved in all conversions. The error listener consumes the original Future error and handles it through the interceptor handler, so the derived listener Future does not create a second uncaught error.

If the callback has already completed its handler and then its returned Future fails, the error is deliberately sent to the zone captured when the listener was registered. This preserves #2499's late-error visibility for fire-and-forget behavior without allowing Dio to complete a handler a second time. A detached Future that the callback neither returns nor handles remains outside Dio's ownership and is not reclassified as a handler failure. If the callback also never completes its handler, Dio cannot use that detached Future to unblock the request, so the request can still remain pending. This is an explicit ownership boundary rather than an attempt to catch every asynchronous task started by user code.

### 3. Preserve normal and queued pipeline timing

For normal interceptors, `DioMixin.fetch` invokes the private `_invoke*` method inside the existing pipeline Future, observes the runtime result, and returns the handler Future. It no longer forks a callback-specific error zone.

For queued interceptors, `QueuedInterceptor._handleQueue` receives the matching private `_invoke*` method. The callback is still called inside the existing synchronous try block, its returned Future is observed immediately, and queue advancement still occurs only through handler completion or cancellation. FIFO behavior and the separate request/response/error queues are unchanged.

The effective timing is therefore:

```text
Before:
  pipeline -> fork a new error zone -> invoke callback -> wait for handler
             callback Future errors are routed through the new zone

After:
  pipeline -> invoke callback in the existing zone
           -> attach an error listener synchronously
           -> wait for handler
             callback Future is observed but never awaited
```

This removes the cross-request error-zone boundary while preserving handler-driven ordering. Awaiting the callback Future was intentionally avoided because the await-based approach in #2139 changed microtask ordering and broke following interceptor behavior reported in #2167; #2169 reverted #2139.

## API and Compatibility Boundaries

- No public method return type changed.
- `InterceptorSendCallback`, `InterceptorSuccessCallback`, and `InterceptorErrorCallback` remain public `void Function(...)` typedefs.
- No public symbol was removed or renamed.
- No Dart SDK lower-bound increase or Dart 3-only language feature was introduced.
- Existing synchronous callbacks and handler methods retain their behavior.
- Async callbacks remain unawaited; only their returned errors are now observed explicitly.
- Subclasses of `Interceptor`, `InterceptorsWrapper`, `QueuedInterceptor`, and `QueuedInterceptorsWrapper` are all covered.
- Wrapper subclasses continue to dispatch through their public `on*` methods instead of being bypassed by an internal closure path.

The wrapper-subclass checks are compatibility guards, not a new user-visible behavior. A temporary separate CHANGELOG bullet for preserving those overrides was intentionally removed in `6b42fa2`; the final changelog contains only the #2565 user-facing fix.

## Tests

The regression and compatibility coverage includes:

- A deterministic #2565 test with an immediate failing adapter and a shared deduplication Future. It asserts both requests terminate, only one adapter fetch occurs, no error escapes the test's surrounding zone in the same error-zone setup, and no pending handler remains.
- Direct `Interceptor` subclasses with async `onRequest`, `onResponse`, and `onError` overrides that throw after an await.
- `InterceptorsWrapper` and `QueuedInterceptorsWrapper` subclasses overriding all three public `on*` methods synchronously, with async wrapper-subclass coverage on the request path.
- Async constructor callbacks covering request, response, and error paths.
- Queued request, response, and error failures, including queue release for a following request.
- Existing behavior for callbacks that call their handler and later fail, callbacks that must not be awaited, duplicate handler calls, and following error interceptors.

The focused VM and Chrome suites each pass all 52 tests.

## Verification

Locally, `melos run format`, `melos run analyze`, and `dart analyze --fatal-infos` passed. CI run 29642622254 passed on min, beta, and stable SDK matrices, including VM, Chrome, Firefox, Flutter, APK build, and coverage.

The final coverage report is:

| File | Base | New | Difference |
| --- | ---: | ---: | ---: |
| `dio/lib/src/dio_mixin.dart` | 94.25% | 94.49% | +0.24% |
| `dio/lib/src/interceptor.dart` | 99.34% | 99.46% | +0.12% |
| Overall | 85.73% | 85.95% | +0.22% |

A full local `melos run test` was attempted, but network-dependent VM and browser tests encountered external HTTP 502, CORS, and timeout failures. The CI workflow starts local httpbun containers on each GitHub Actions runner and completed successfully.

## Unverified

The minimum Dart 2.18 SDK was not installed locally; the remote min SDK workflow passed. Local Firefox and Flutter targets were unavailable or blocked by local configuration, but both passed in the remote CI matrices.

## AI Attribution

Implementation, tests, commit, and local review by Codex.
