### PR TITLE
fix(http2_adapter): handle closed streams during uploads

### DIFF
--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -5,6 +5,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
+- Prevent uploads from throwing a `StateError` when the HTTP/2 connection closes
+  before the request body finishes streaming.
 - Run HTTP integration and certificate pinning tests against the configured
   test server.
 

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -127,12 +127,6 @@ class Http2Adapter implements HttpClientAdapter {
     final streamWR = WeakReference<ClientTransportStream>(stream);
 
     final hasRequestData = requestStream != null;
-    if (hasRequestData && cancelFuture != null) {
-      cancelFuture.whenComplete(() {
-        streamWR.target?.outgoingMessages.close();
-      });
-    }
-
     List<Uint8List>? list;
     if (!excludeMethods.contains(options.method) && hasRequestData) {
       list = await requestStream.toList();
@@ -140,16 +134,58 @@ class Http2Adapter implements HttpClientAdapter {
     }
 
     if (hasRequestData) {
-      Future<dynamic> requestStreamFuture = requestStream!.listen((data) {
-        //TODO(EVERYONE): Investigate why this statement can cause "StateError: Bad state: Cannot add event after closing"
-        stream.outgoingMessages.add(DataStreamMessage(data));
-      }).asFuture();
+      StreamSubscription<Uint8List>? requestSubscription;
+      final requestCompleter = Completer<void>();
+
+      void stopRequestStream() {
+        if (!requestCompleter.isCompleted) {
+          requestCompleter.complete();
+        }
+        requestSubscription?.cancel().ignore();
+      }
+
+      requestSubscription = requestStream!.listen(
+        (data) {
+          try {
+            stream.outgoingMessages.add(DataStreamMessage(data));
+          } on StateError {
+            stopRequestStream();
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!requestCompleter.isCompleted) {
+            requestCompleter.completeError(error, stackTrace);
+          }
+        },
+        onDone: () {
+          if (!requestCompleter.isCompleted) {
+            requestCompleter.complete();
+          }
+        },
+        cancelOnError: true,
+      );
+
+      if (cancelFuture != null) {
+        final requestSubscriptionWR = WeakReference(requestSubscription);
+        final requestCompleterWR = WeakReference(requestCompleter);
+        cancelFuture.whenComplete(() {
+          final completer = requestCompleterWR.target;
+          if (completer != null && !completer.isCompleted) {
+            completer.complete();
+          }
+          requestSubscriptionWR.target?.cancel().ignore();
+          streamWR.target?.outgoingMessages.close().ignore();
+        });
+      }
+
+      Future<void> requestStreamFuture = requestCompleter.future;
       final sendTimeout = options.sendTimeout ?? Duration.zero;
       if (sendTimeout > Duration.zero) {
         requestStreamFuture = requestStreamFuture.timeout(
           sendTimeout,
           onTimeout: () {
-            stream.outgoingMessages.close().catchError((_) {});
+            stopRequestStream();
+            streamWR.target?.outgoingMessages.close().ignore();
             throw DioException.sendTimeout(
               timeout: sendTimeout,
               requestOptions: options,

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:dio_test/util.dart';
+import 'package:http2/transport.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -106,6 +109,124 @@ void main() {
     }
     final res = await dio.post('/post', data: 'TEST');
     expect(res.data.toString(), contains('TEST'));
+  });
+
+  group('request stream', () {
+    late ServerSocket serverSocket;
+    late Http2Adapter adapter;
+    final serverConnections = <ServerTransportConnection>[];
+
+    setUp(() async {
+      serverSocket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      adapter = Http2Adapter(null);
+    });
+
+    tearDown(() async {
+      adapter.close(force: true);
+      for (final connection in serverConnections) {
+        await connection.terminate();
+      }
+      serverConnections.clear();
+      await serverSocket.close();
+    });
+
+    test(
+      'reports a transport error when the connection closes during upload',
+      () async {
+        serverSocket.listen((socket) {
+          final connection = ServerTransportConnection.viaSocket(socket);
+          serverConnections.add(connection);
+          connection.incomingStreams.listen((stream) async {
+            await for (final message in stream.incomingMessages) {
+              if (message is HeadersStreamMessage) {
+                await connection.terminate();
+                break;
+              }
+            }
+          });
+        });
+
+        final requestStream = (() async* {
+          for (int i = 0; i < 20; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 5));
+            yield Uint8List(1024);
+          }
+        })();
+        final resultCompleter = Completer<Object?>();
+
+        void completeResult(Object? result) {
+          if (!resultCompleter.isCompleted) {
+            resultCompleter.complete(result);
+          }
+        }
+
+        runZonedGuarded(
+          () async {
+            try {
+              await adapter.fetch(
+                RequestOptions(
+                  path: '/upload',
+                  method: 'POST',
+                  baseUrl: 'http://127.0.0.1:${serverSocket.port}',
+                ),
+                requestStream,
+                null,
+              );
+              completeResult(null);
+            } catch (error) {
+              completeResult(error);
+            }
+          },
+          (error, _) => completeResult(error),
+        );
+
+        final result = await resultCompleter.future.timeout(
+          const Duration(seconds: 2),
+        );
+        expect(result, isA<TransportConnectionException>());
+      },
+    );
+
+    test('settles the adapter future when an upload is canceled', () async {
+      final requestDataReceived = Completer<void>();
+      serverSocket.listen((socket) {
+        final connection = ServerTransportConnection.viaSocket(socket);
+        serverConnections.add(connection);
+        connection.incomingStreams.listen((stream) async {
+          await for (final message in stream.incomingMessages) {
+            if (message is DataStreamMessage &&
+                !requestDataReceived.isCompleted) {
+              requestDataReceived.complete();
+            }
+          }
+          stream.sendHeaders(
+            [Header.ascii(':status', '200')],
+            endStream: true,
+          );
+        });
+      });
+
+      final requestController = StreamController<Uint8List>();
+      addTearDown(requestController.close);
+      final cancelCompleter = Completer<void>();
+      final fetchFuture = adapter.fetch(
+        RequestOptions(
+          path: '/upload',
+          method: 'POST',
+          baseUrl: 'http://127.0.0.1:${serverSocket.port}',
+        ),
+        requestController.stream,
+        cancelCompleter.future,
+      );
+
+      requestController.add(Uint8List(1024));
+      await requestDataReceived.future.timeout(const Duration(seconds: 2));
+      cancelCompleter.complete();
+
+      final response = await fetchFuture.timeout(const Duration(seconds: 2));
+      expect(response.statusCode, 200);
+      expect(requestController.hasListener, isFalse);
+    });
   });
 
   group(ConnectionManager, () {


### PR DESCRIPTION
Supersedes #2469.

The original report and reproduction are credited to @vanelizarov. This replacement is rebuilt on the current `main` branch and addresses the unresolved review feedback and the cancellation hang found while auditing the earlier implementation.

### Motivation

When an HTTP/2 peer closes a connection before a streamed request body finishes, `http2` closes its outgoing stream controller. The request body subscription can then deliver another chunk to the closed sink, producing an unhandled `StateError: Bad state: Cannot add event after closing` instead of the transport error that caused the closure.

### Changes

- Stop the request body subscription when the outgoing HTTP/2 sink has already closed.
- Explicitly settle request-body waiting when cancellation stops the subscription, rather than relying on `onDone`, which is not called after cancellation.
- Keep cancellation callbacks weakly referenced so shared, never-cancelled tokens do not retain completed request resources.
- Assert the exact `TransportConnectionException` for a peer connection closure and cover cancellation while the source stream remains open.
- Update the `dio_http2_adapter` changelog.

### Verification

With only the new tests applied to `main`, the connection-closure test fails with the reported `StateError`, and the cancellation test times out after two seconds. Both pass with this change, and the cancellation test also confirms that the source stream listener is removed.

`dart test` for `plugins/http2_adapter`, `melos run format`, and `melos run analyze` complete successfully. An independent adversarial pass also exercised 20 concurrent cancellations, send timeout, a synchronous stream controller, and request-source error propagation.

### Hosted verification

The min, stable, and beta workflows all pass with the configured httpbun and proxy services. The stable workflow also passes formatting, analysis, publish dry-run, VM/Chrome/Firefox/Flutter tests, the example APK build, and coverage reporting. Changed-file coverage for `http2_adapter.dart` increases from 75.69% to 82.42%.

### AI assistance

Implementation, tests, and local review were performed with Codex. A separate Codex sub-agent performed the adversarial review. The original diagnosis and reproduction came from @vanelizarov in #2469.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have read the [Agent Contribution Guidelines](https://github.com/cfug/dio/blob/main/AGENTS.md) (required if any part of the change was produced with AI assistance)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none *(not applicable - this supersedes #2469)*
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary) *(not applicable - no public API or documented behavior changes)*
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

The replacement preserves the final outgoing-sink close as a normal `await`; the observed `StateError` originates from adding the next body chunk after the transport has closed the sink, not from closing the sink again.
