### PR TITLE
fix(cookie_manager): prevent duplicate cookies on reused request options

### DIFF
--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-*None.*
+- Prevent duplicate cookies when reusing request options while preserving
+  caller-provided cookies.
 
 ## 3.4.0
 

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -29,6 +29,11 @@ class _CookieHeaderState {
 }
 
 /// Cookie manager for HTTP requests based on [CookieJar].
+///
+/// Register this after interceptors that may change [RequestOptions.uri] or
+/// the Cookie request header. Cookies are selected from the URI and reused
+/// request options are recognized only while the header exactly matches this
+/// manager's previous output.
 class CookieManager extends Interceptor {
   CookieManager(
     this.cookieJar, {
@@ -154,6 +159,12 @@ class CookieManager extends Interceptor {
   }
 
   /// Load cookies in cookie string for the request.
+  ///
+  /// State is scoped to the identity of [options]. When the same instance is
+  /// reused, its original Cookie header is restored only if the current header
+  /// exactly matches the previous result of this method. Any other header is
+  /// treated as a new source. Incrementally modifying a generated header after
+  /// this manager can therefore cause saved cookies to be merged again.
   Future<String> loadCookies(RequestOptions options) async {
     final savedCookies = await cookieJar.loadForRequest(options.uri);
     final previousCookies =

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -21,6 +21,13 @@ const _kIsWeb = _kIsWebInterop || _kIsWebUtil || identical(0, 0.0);
 /// attribute like "expires=Sun, 19 Feb 3000 01:43:15 GMT", which could also contain commas.
 final _setCookieReg = RegExp('(?<=)(,)(?=[^;]+?=)');
 
+class _CookieHeaderState {
+  const _CookieHeaderState(this.source, this.merged);
+
+  final String? source;
+  final String merged;
+}
+
 /// Cookie manager for HTTP requests based on [CookieJar].
 class CookieManager extends Interceptor {
   CookieManager(
@@ -37,6 +44,8 @@ class CookieManager extends Interceptor {
 
   /// Whether to ignore invalid cookies during parsing or saving.
   bool ignoreInvalidCookies;
+
+  final Expando<_CookieHeaderState> _cookieHeaderStates = Expando();
 
   /// Merge cookies into a Cookie string.
   /// Cookies with longer paths are listed before cookies with shorter paths.
@@ -149,14 +158,22 @@ class CookieManager extends Interceptor {
     final savedCookies = await cookieJar.loadForRequest(options.uri);
     final previousCookies =
         options.headers[HttpHeaders.cookieHeader] as String?;
+    final previousState = _cookieHeaderStates[options];
+    // Rebuild a header that still exactly matches this manager's last output.
+    // Any other header becomes the source for the next merge.
+    final sourceCookies =
+        previousState != null && previousState.merged == previousCookies
+            ? previousState.source
+            : previousCookies;
     final cookies = getCookies([
-      ...?previousCookies
+      ...?sourceCookies
           ?.split(';')
           .where((e) => e.isNotEmpty)
           .map((c) => _fromSetCookieValue(c))
           .whereType<Cookie>(), // Use .nonNulls when the minimum SDK is 3.0.
       ...savedCookies,
     ]);
+    _cookieHeaderStates[options] = _CookieHeaderState(sourceCookies, cookies);
     return cookies;
   }
 

--- a/plugins/cookie_manager/test/cookies_test.dart
+++ b/plugins/cookie_manager/test/cookies_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -8,20 +9,38 @@ import 'package:dio/io.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:test/test.dart';
 
-class MockRequestInterceptorHandler extends RequestInterceptorHandler {
-  MockRequestInterceptorHandler(this.expectResult);
+class _TestRequestInterceptorHandler extends RequestInterceptorHandler {
+  final Completer<RequestOptions> _result = Completer();
 
-  final String expectResult;
+  Future<RequestOptions> get result => _result.future;
 
   @override
   void next(RequestOptions requestOptions) {
-    final c = requestOptions.headers[HttpHeaders.cookieHeader];
-    expect(c == expectResult, true);
-    super.next(requestOptions);
+    _result.complete(requestOptions);
+  }
+
+  @override
+  void reject(
+    DioException error, [
+    bool callFollowingErrorInterceptor = false,
+  ]) {
+    _result.completeError(error, error.stackTrace);
   }
 }
 
 class MockResponseInterceptorHandler extends ResponseInterceptorHandler {}
+
+Future<void> expectRequestCookies(
+  CookieManager cookieManager,
+  RequestOptions options,
+  String? expected,
+) async {
+  final handler = _TestRequestInterceptorHandler();
+  await cookieManager.onRequest(options, handler);
+  final result = await handler.result;
+  expect(result, same(options));
+  expect(options.headers[HttpHeaders.cookieHeader], expected);
+}
 
 class _MockRejectRequestInterceptorHandler extends RequestInterceptorHandler {
   _MockRejectRequestInterceptorHandler(this.matcher);
@@ -118,18 +137,200 @@ void main() {
     );
 
     // Verify mock cookies.
-    final mockRequestInterceptorHandler =
-        MockRequestInterceptorHandler(expectResult);
     final options = RequestOptions(
       baseUrl: exampleUrl,
       headers: {
         HttpHeaders.cookieHeader: mockSecondRequestCookies,
       },
     );
-    await cookieManager.onRequest(
-      options,
-      mockRequestInterceptorHandler,
-    );
+    await expectRequestCookies(cookieManager, options, expectResult);
+  });
+
+  group('reusing request options', () {
+    const exampleUrl = 'https://example.com/api/endpoint';
+
+    test('does not append the cookie jar values again through Dio.fetch',
+        () async {
+      final cookieJar = CookieJar();
+      await cookieJar.saveFromResponse(
+        Uri.parse(exampleUrl),
+        [
+          Cookie('session', 'root')..path = '/',
+          Cookie('session', 'api')..path = '/api',
+        ],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final adapter = _CookieRecordingAdapter();
+      final dio = Dio()
+        ..httpClientAdapter = adapter
+        ..interceptors.add(cookieManager);
+      addTearDown(dio.close);
+      final options = RequestOptions(
+        baseUrl: exampleUrl,
+        responseType: ResponseType.plain,
+      );
+
+      await dio.fetch(options);
+      await dio.fetch(options);
+      await dio.fetch(options);
+
+      expect(
+        adapter.cookieHeaders,
+        everyElement(
+          equals(
+            'session=api; session=root',
+          ),
+        ),
+      );
+      expect(adapter.cookieHeaders, hasLength(3));
+      expect(adapter.requestOptions, everyElement(same(options)));
+    });
+
+    test('preserves a same-name cookie supplied by the caller', () async {
+      final cookieJar = CookieJar();
+      await cookieJar.saveFromResponse(
+        Uri.parse(exampleUrl),
+        [Cookie('session', 'saved')..path = '/'],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final options = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'session=provided'},
+      );
+
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'session=provided; session=saved',
+      );
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'session=provided; session=saved',
+      );
+    });
+
+    test('reloads saved cookies without retaining their old values', () async {
+      final cookieJar = CookieJar();
+      final uri = Uri.parse(exampleUrl);
+      await cookieJar.saveFromResponse(
+        uri,
+        [Cookie('session', 'old')..path = '/'],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final options = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'provided=value'},
+      );
+
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=value; session=old',
+      );
+      await cookieJar.saveFromResponse(
+        uri,
+        [Cookie('session', 'new')..path = '/'],
+      );
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=value; session=new',
+      );
+      await cookieJar.deleteAll();
+      await expectRequestCookies(cookieManager, options, 'provided=value');
+    });
+
+    test('uses a cookie header changed by the caller as the new input',
+        () async {
+      final cookieJar = CookieJar();
+      await cookieJar.saveFromResponse(
+        Uri.parse(exampleUrl),
+        [Cookie('saved', 'value')..path = '/'],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final options = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'provided=first'},
+      );
+
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=first; saved=value',
+      );
+      options.headers[HttpHeaders.cookieHeader] = 'provided=changed';
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=changed; saved=value',
+      );
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=changed; saved=value',
+      );
+    });
+
+    test('does not retain saved cookies after the request origin changes',
+        () async {
+      final cookieJar = CookieJar();
+      await cookieJar.saveFromResponse(
+        Uri.parse(exampleUrl),
+        [Cookie('session', 'saved')..path = '/'],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final options = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'provided=value'},
+      );
+
+      await expectRequestCookies(
+        cookieManager,
+        options,
+        'provided=value; session=saved',
+      );
+      options.baseUrl = 'https://other.example.com';
+      await expectRequestCookies(cookieManager, options, 'provided=value');
+    });
+
+    test('keeps state separate between request options', () async {
+      final cookieJar = CookieJar();
+      await cookieJar.saveFromResponse(
+        Uri.parse(exampleUrl),
+        [Cookie('saved', 'value')..path = '/'],
+      );
+      final cookieManager = CookieManager(cookieJar);
+      final first = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'provided=first'},
+      );
+      final second = RequestOptions(
+        baseUrl: exampleUrl,
+        headers: {HttpHeaders.cookieHeader: 'provided=second'},
+      );
+
+      await expectRequestCookies(
+        cookieManager,
+        first,
+        'provided=first; saved=value',
+      );
+      await expectRequestCookies(
+        cookieManager,
+        second,
+        'provided=second; saved=value',
+      );
+      await expectRequestCookies(
+        cookieManager,
+        first,
+        'provided=first; saved=value',
+      );
+      await expectRequestCookies(
+        cookieManager,
+        second,
+        'provided=second; saved=value',
+      );
+    });
   });
 
   group('Set-Cookie', () {
@@ -162,12 +363,7 @@ void main() {
 
       // Verify mock cookies.
       final options = RequestOptions(baseUrl: exampleUrl);
-      final mockRequestInterceptorHandler =
-          MockRequestInterceptorHandler(expectResult);
-      await cookieManager.onRequest(
-        options,
-        mockRequestInterceptorHandler,
-      );
+      await expectRequestCookies(cookieManager, options, expectResult);
     });
 
     test('can be saved to the location', () async {
@@ -425,6 +621,25 @@ void main() {
         DioException(requestOptions: requestOptions, response: response);
     await cookieManager.onError(error, mockErrorInterceptorHandler);
   });
+}
+
+class _CookieRecordingAdapter implements HttpClientAdapter {
+  final List<String?> cookieHeaders = [];
+  final List<RequestOptions> requestOptions = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestOptions.add(options);
+    cookieHeaders.add(options.headers[HttpHeaders.cookieHeader] as String?);
+    return ResponseBody.fromString('', HttpStatus.ok);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }
 
 class _RedirectAdapter implements HttpClientAdapter {


### PR DESCRIPTION
Closes #2442.
Supersedes #2498.

## Summary

Reusing the same `RequestOptions` instance sends it through `CookieManager` again with the Cookie header produced by the previous pass. Merging that generated header with the cookie jar again makes jar cookies accumulate on every pass.

This change keeps weak per-`RequestOptions` state containing the original source header and the last header generated by the manager. When the current header still exactly matches that generated value, `loadCookies` rebuilds it from the original caller input and the latest jar state.

Unlike the name-only filtering proposed in #2498, this preserves the established behavior where caller-provided and jar cookies with the same name can coexist. It also removes stale jar values after updates, deletion, or an origin change.

The state is intentionally scoped to the same `CookieManager` and `RequestOptions` instance reported in #2442. A copied request or a different manager instance is a new identity and is outside this fix.

## Implementation details

### Why an `Expando`

[`Expando<T>`](https://api.dart.dev/dart-core/Expando-class.html) associates private data with an object identity without adding a field to that object's class. The association does not keep its property value alive after the key object becomes inaccessible. It has been part of `dart:core` since before Dart 1.0, so this use does not raise the package's Dart 2.18 lower bound.

`CookieManager` owns one instance:

```dart
final Expando<_CookieHeaderState> _cookieHeaderStates = Expando();
```

Each key is a `RequestOptions` object, and each value contains two immutable strings: the header supplied as the source of the merge and the header last generated by this manager. Keeping this bookkeeping outside `RequestOptions.extra` avoids reserving a user-visible key, exposing internal state to loggers, or copying an internal marker through `RequestOptions.copyWith`.

### State transitions

| Interceptor pass | Current Cookie header | Source used for the merge | Result |
| --- | --- | --- | --- |
| First pass | Caller header or `null` | Current header | Source + cookies currently loaded from the jar |
| Reused options, unchanged header | Exactly equals this manager's last output | Stored original source | Original source + freshly loaded jar cookies |
| Header replaced between passes | Does not equal the last output | New current header | New source + freshly loaded jar cookies |

For example:

```text
first pass:  source=provided=value, jar=session=old
             -> provided=value; session=old

second pass after the jar changes to session=new:
             source=provided=value, jar=session=new
             -> provided=value; session=new
```

The old jar contribution is not treated as caller input, so it is neither duplicated nor retained after an update, deletion, or origin change.

### Interceptor ordering

Request interceptors run in registration order. `CookieManager` reads both `options.uri` and the current Cookie header at its position in that chain, so interceptors that mutate either value must run before it:

```dart
dio.interceptors
  ..add(uriOrCookieMutatingInterceptor)
  ..add(CookieManager(cookieJar))
  ..add(interceptorThatDoesNotChangeUriOrCookies);
```

Changes made by a later interceptor have these consequences:

| Later mutation | Effect when the same options are reused |
| --- | --- |
| Authorization, body, method, `extra`, or unrelated headers | Does not affect Cookie state matching |
| Replace the complete Cookie header | The replacement becomes the source for the next merge |
| Append, reorder, or reformat the generated Cookie header | It no longer exactly matches the stored output; the embedded old jar cookies can be treated as source cookies and merged again |
| Change `baseUrl` or path | The current request may carry cookies selected for the URI observed before that change |

The URI case is an ordering requirement for the current request, not only for retries. Moving a request from one origin or path to another after `CookieManager` has selected cookies can send cookies outside the scope for which they were loaded.

### Why not deduplicate cookie names or values

A serialized Cookie request header contains `name=value` pairs but not the domain and path metadata that identified the cookies in the jar. The same request can legitimately contain multiple cookies with the same name, and dio also deliberately preserves a caller-provided cookie alongside a same-name jar cookie.

Filtering by name, or by a reconstructed cookie identity, therefore cannot distinguish a cookie generated by the previous interceptor pass from one explicitly supplied by the caller. Tracking the exact previous output preserves that provenance without changing first-pass merge behavior.

### API and identity boundaries

- No public API, request header precedence, or cookie ordering is changed.
- No state is added to `RequestOptions.extra`.
- Entries are scoped to one `CookieManager` and one `RequestOptions` object identity.
- A `copyWith` result or a different manager instance is a new identity and intentionally starts with its current header as a new source.

## Verification

Added six regression tests covering three sequential `Dio.fetch` calls with the same options, caller-provided same-name cookies, jar update and deletion, origin changes, caller header replacement, and state isolation between options. All six fail against `origin/main` and pass with this change.

The `dio_cookie_manager` package passes 21 tests. Scoped Melos format and fatal-info analysis checks are clean. Local coverage records 74 of 75 executable lines in `cookie_mgr.dart` (98.67%), including all new state logic.

Implementation and tests by Codex; independent authenticity and adversarial review passes by two Codex subagents.

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have read the [Agent Contribution Guidelines](https://github.com/cfug/dio/blob/main/AGENTS.md) (required if any part of the change was produced with AI assistance)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none *(not applicable: this replaces #2498)*
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation *(not applicable: no public API or usage changes)*
- [x] I have run the affected package tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info

The previous implementation in #2498 used RFC 6265 cookie-store identity rules to justify filtering request-header cookies. Cookie-store replacement and request-header merging are different operations; this PR avoids changing first-pass merge semantics.