### PR TITLE
Update cronet_http dependency to version 1.9.0

### DIFF
--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   dio: ^5.4.0
   cupertino_http: '>=2.3.0 <4.0.0'
-  cronet_http: ^1.5.0
+  cronet_http: ^1.9.0
   http: ^1.5.0
   # Direct dependency for `JniException`, used to classify the
   # Cronet-provider-disabled failure surfaced by `CronetEngine.build()`.


### PR DESCRIPTION
Upgraded cronet_http to latest because native_dio_adapter still depends on cronet_http 1.5.0, which can cause Android builds to fail with newer Android SDK versions.

Upgrading to cronet_http 1.9.0 fixes that compatibility issue and allows apps targeting Android 16 / API 36 to build normally.