### PR TITLE
🐛 Support cronet_http 1.9.0 by upgrading jni to ^1.0.0

### DIFF
--- a/plugins/native_dio_adapter/CHANGELOG.md
+++ b/plugins/native_dio_adapter/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-*None.*
+- Support `cronet_http` 1.9.0 by upgrading `jni` to `^1.0.0` and migrating
+  the Cronet-provider-disabled classifier from `JniException` to `JThrowable`.
+  The minimum Dart SDK is now `3.4.0` and the minimum Flutter version is now
+  `3.35.6`, following the requirements of `jni` 1.0.0 and `cronet_http` 1.9.0.
+  Fixes [#2581](https://github.com/cfug/dio/issues/2581).
 
 ## 1.7.0
 

--- a/plugins/native_dio_adapter/lib/src/cronet_fallback_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/cronet_fallback_adapter.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:cronet_http/cronet_http.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
-import 'package:jni/jni.dart' show JniException;
+import 'package:jni/jni.dart' show JThrowable;
 
 import 'cronet_adapter.dart';
 
@@ -30,15 +30,23 @@ const cronetProvidersDisabledMessage =
     'java.lang.RuntimeException: All available Cronet providers are disabled. '
     'A provider should be enabled before it can be used.';
 
+/// Whether [message] is the Cronet-provider-disabled failure.
+///
+/// Extracted from [isCronetProviderUnavailable] so the message-matching
+/// logic can be tested without a live JNI environment — [JThrowable] cannot
+/// be constructed in pure Dart because it wraps a real JNI reference.
+@visibleForTesting
+bool isCronetProviderUnavailableMessage(String message) =>
+    message.contains(cronetProvidersDisabledMessage);
+
 /// Classifies the failure that indicates all installed Cronet providers on
 /// the device are disabled.
 ///
-/// `contains` is intentional: [JniException.message] also includes the Java
+/// `contains` is intentional: [JThrowable.message] also includes the Java
 /// stack trace appended to the message. Do not broaden the predicate to all
-/// [JniException]s or all engine-initialization failures.
+/// [JThrowable]s or all engine-initialization failures.
 bool isCronetProviderUnavailable(Object error) =>
-    error is JniException &&
-    error.message.contains(cronetProvidersDisabledMessage);
+    error is JThrowable && isCronetProviderUnavailableMessage(error.message);
 
 /// Builds the Cronet-backed [HttpClientAdapter] to use when Cronet is
 /// available. May throw when the underlying Cronet provider is disabled or
@@ -71,20 +79,30 @@ class CronetWithFallbackAdapter implements HttpClientAdapter {
               CronetEngine.build();
           return CronetAdapter(engine);
         }),
-        _createFallbackAdapter = createFallbackAdapter;
+        _createFallbackAdapter = createFallbackAdapter,
+        _isProviderUnavailable = isCronetProviderUnavailable;
 
   /// Test-only constructor: lets a test inject a controllable "build cronet
   /// adapter" seam without linking real native Cronet code. Not part of the
   /// public API.
+  ///
+  /// [isProviderUnavailable] lets tests substitute the error classifier so
+  /// they can simulate the Cronet-provider-disabled failure without
+  /// constructing a real [JThrowable] (which requires a live JNI
+  /// environment).
   @visibleForTesting
   CronetWithFallbackAdapter.forTesting({
     required BuildCronetAdapter buildCronetAdapter,
     required CreateFallbackAdapter createFallbackAdapter,
+    @visibleForTesting bool Function(Object error)? isProviderUnavailable,
   })  : _buildCronetAdapter = buildCronetAdapter,
-        _createFallbackAdapter = createFallbackAdapter;
+        _createFallbackAdapter = createFallbackAdapter,
+        _isProviderUnavailable =
+            isProviderUnavailable ?? isCronetProviderUnavailable;
 
   final BuildCronetAdapter _buildCronetAdapter;
   final CreateFallbackAdapter _createFallbackAdapter;
+  final bool Function(Object error) _isProviderUnavailable;
 
   HttpClientAdapter? _selected;
   bool _closed = false;
@@ -122,7 +140,7 @@ class CronetWithFallbackAdapter implements HttpClientAdapter {
     try {
       return _selected = _buildCronetAdapter();
     } catch (error, stackTrace) {
-      if (isCronetProviderUnavailable(error)) {
+      if (_isProviderUnavailable(error)) {
         return _selected = _createFallbackAdapter(error, stackTrace);
       }
       rethrow;

--- a/plugins/native_dio_adapter/lib/src/cronet_fallback_adapter.dart
+++ b/plugins/native_dio_adapter/lib/src/cronet_fallback_adapter.dart
@@ -42,9 +42,10 @@ bool isCronetProviderUnavailableMessage(String message) =>
 /// Classifies the failure that indicates all installed Cronet providers on
 /// the device are disabled.
 ///
-/// `contains` is intentional: [JThrowable.message] also includes the Java
-/// stack trace appended to the message. Do not broaden the predicate to all
-/// [JThrowable]s or all engine-initialization failures.
+/// `contains` is intentional: [JThrowable.message] is Java's
+/// `Throwable.toString()` (`"ClassName: getMessage()"`); the stack trace is
+/// held separately in [JThrowable.javaStackTrace]. Do not broaden the
+/// predicate to all [JThrowable]s or all engine-initialization failures.
 bool isCronetProviderUnavailable(Object error) =>
     error is JThrowable && isCronetProviderUnavailableMessage(error.message);
 

--- a/plugins/native_dio_adapter/pubspec.yaml
+++ b/plugins/native_dio_adapter/pubspec.yaml
@@ -13,8 +13,8 @@ repository: https://github.com/cfug/dio/blob/main/plugins/native_dio_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
-  flutter: '>=3.13.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.35.6'
 
 dependencies:
   flutter:
@@ -22,12 +22,12 @@ dependencies:
 
   dio: ^5.4.0
   cupertino_http: '>=2.3.0 <4.0.0'
-  cronet_http: ^1.5.0
+  cronet_http: ^1.9.0
   http: ^1.5.0
-  # Direct dependency for `JniException`, used to classify the
+  # Direct dependency for `JThrowable`, used to classify the
   # Cronet-provider-disabled failure surfaced by `CronetEngine.build()`.
-  # The constraint tracks the version resolved by `cronet_http: ^1.5.0`.
-  jni: ^0.14.0
+  # The constraint follows `cronet_http: ^1.9.0`, which requires jni ^1.0.0.
+  jni: ^1.0.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/plugins/native_dio_adapter/test/cronet_fallback_adapter_test.dart
+++ b/plugins/native_dio_adapter/test/cronet_fallback_adapter_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:jni/jni.dart' show JniException;
 import 'package:native_dio_adapter/src/cronet_fallback_adapter.dart';
 
 /// A minimal recording [HttpClientAdapter] used to observe what the fallback
@@ -58,47 +57,93 @@ class _ThrowOnFetchAdapter implements HttpClientAdapter {
   }
 }
 
-JniException _providerDisabledException() => JniException(
-      // Real JniException.message includes the throwable string followed by
+/// Test stand-in for the JNI-thrown `JThrowable` that Cronet surfaces when
+/// all providers are disabled.
+///
+/// `JThrowable` cannot be constructed in pure Dart — it wraps a real JNI
+/// reference and its constructor is internal. The adapter tests therefore
+/// inject [testIsProviderUnavailable], which recognises this type and
+/// delegates message matching to [isCronetProviderUnavailableMessage] (the
+/// same pure function the production classifier uses).
+class _ProviderUnavailableException implements Exception {
+  _ProviderUnavailableException(this.message);
+
+  final String message;
+}
+
+/// Classifier injected into [CronetWithFallbackAdapter.forTesting] so tests
+/// can simulate the provider-disabled failure without a live JNI environment.
+bool testIsProviderUnavailable(Object error) =>
+    error is _ProviderUnavailableException &&
+    isCronetProviderUnavailableMessage(error.message);
+
+_ProviderUnavailableException _providerDisabledException() =>
+    _ProviderUnavailableException(
+      // Real JThrowable.message includes the throwable string followed by
       // the Java stack trace; the classifier relies on `contains`.
       '$cronetProvidersDisabledMessage\n'
-          '\tat org.chromium.net.CronetEngine\$Builder.build(CronetEngine.java:123)\n'
-          '\tat org.chromium.net.CronetProvider.createBuilder(CronetProvider.java:45)',
-      'stack from java',
+      '\tat org.chromium.net.CronetEngine\$Builder.build(CronetEngine.java:123)\n'
+      '\tat org.chromium.net.CronetProvider.createBuilder(CronetProvider.java:45)',
     );
 
 void main() {
-  group('isCronetProviderUnavailable', () {
+  group('isCronetProviderUnavailableMessage', () {
     test('matches the provider-disabled message including trailing stack', () {
       expect(
-        isCronetProviderUnavailable(_providerDisabledException()),
+        isCronetProviderUnavailableMessage(
+          '$cronetProvidersDisabledMessage\n'
+          '\tat org.chromium.net.CronetEngine\$Builder.build(CronetEngine.java:123)\n'
+          '\tat org.chromium.net.CronetProvider.createBuilder(CronetProvider.java:45)',
+        ),
         isTrue,
       );
     });
 
-    test('does not match a different JniException message', () {
-      final other = JniException(
-        'java.lang.RuntimeException: Unable to find any Cronet provider.\n'
-            '\tat org.chromium.net.CronetEngine.build(CronetEngine.java:200)',
-        'stack from java',
+    test('does not match a different exception message', () {
+      expect(
+        isCronetProviderUnavailableMessage(
+          'java.lang.RuntimeException: Unable to find any Cronet provider.\n'
+          '\tat org.chromium.net.CronetEngine.build(CronetEngine.java:200)',
+        ),
+        isFalse,
       );
-      expect(isCronetProviderUnavailable(other), isFalse);
     });
 
-    test('does not match a non-JniException carrying the same text', () {
+    test('does not match a similar message with the wrong exception class', () {
+      // Different Java throwable type with a similar-looking message must
+      // NOT match; the classifier requires the full RuntimeException prefix.
+      expect(
+        isCronetProviderUnavailableMessage(
+          'java.lang.IllegalStateException: All available Cronet providers are '
+          'disabled. A provider should be enabled before it can be used.',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not match an empty message', () {
+      expect(isCronetProviderUnavailableMessage(''), isFalse);
+    });
+  });
+
+  group('isCronetProviderUnavailable', () {
+    test('returns false for a non-JThrowable carrying the same text', () {
+      // A plain Dart error with the exact message must not be classified as
+      // a Cronet-provider-disabled failure — the production classifier
+      // requires a JThrowable, not just the message text.
       final wrong = StateError(cronetProvidersDisabledMessage);
       expect(isCronetProviderUnavailable(wrong), isFalse);
     });
 
-    test('does not match a JniException with the wrong exception class', () {
-      // Different Java throwable type with a similar-looking message must
-      // NOT match; the classifier requires the full RuntimeException prefix.
-      final wrong = JniException(
-        'java.lang.IllegalStateException: All available Cronet providers are '
-            'disabled. A provider should be enabled before it can be used.',
-        'stack',
+    test('returns false for an ArgumentError', () {
+      expect(isCronetProviderUnavailable(ArgumentError('bad')), isFalse);
+    });
+
+    test('returns false for a plain String', () {
+      expect(
+        isCronetProviderUnavailable(cronetProvidersDisabledMessage),
+        isFalse,
       );
-      expect(isCronetProviderUnavailable(wrong), isFalse);
     });
   });
 
@@ -119,6 +164,7 @@ void main() {
           seenStack = stack;
           return fallback;
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       final requestStream = Stream<Uint8List>.fromIterable(
@@ -142,7 +188,7 @@ void main() {
       await response.stream.drain<void>();
 
       expect(factoryCallCount, 1);
-      expect(seenError, isA<JniException>());
+      expect(seenError, isA<_ProviderUnavailableException>());
       expect(seenStack, isNotNull);
       expect(fallback.fetchCallCount, 1);
       expect(identical(fallback.lastOptions, options), isTrue);
@@ -154,12 +200,12 @@ void main() {
       expect(identical(wrapper.selectedAdapter, fallback), isTrue);
     });
 
-    test('non-matching JniException is rethrown and no fallback is created',
-        () async {
+    test(
+        'non-matching provider exception is rethrown and no fallback is '
+        'created', () async {
       var fallbackCreated = 0;
-      final nonMatching = JniException(
+      final nonMatching = _ProviderUnavailableException(
         'java.lang.IllegalArgumentException: bad config',
-        'stack',
       );
       final wrapper = CronetWithFallbackAdapter.forTesting(
         buildCronetAdapter: () => throw nonMatching,
@@ -167,6 +213,7 @@ void main() {
           fallbackCreated += 1;
           return _RecordingAdapter();
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await expectLater(
@@ -175,7 +222,7 @@ void main() {
           null,
           null,
         ),
-        throwsA(isA<JniException>()),
+        throwsA(isA<_ProviderUnavailableException>()),
       );
       expect(fallbackCreated, 0);
       expect(wrapper.selectedAdapter, isNull);
@@ -190,6 +237,7 @@ void main() {
           fallbackCreated += 1;
           return _RecordingAdapter();
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await expectLater(
@@ -218,6 +266,7 @@ void main() {
           fallbackCreated += 1;
           return _RecordingAdapter();
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await expectLater(
@@ -241,6 +290,7 @@ void main() {
           factoryCallCount += 1;
           return fallback;
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await (await wrapper.fetch(
@@ -281,6 +331,7 @@ void main() {
         createFallbackAdapter: (_, __) => throw StateError(
           'fallback must not be created when Cronet initialization succeeded',
         ),
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await (await wrapper.fetch(
@@ -309,6 +360,7 @@ void main() {
       final wrapper = CronetWithFallbackAdapter.forTesting(
         buildCronetAdapter: () => throw _providerDisabledException(),
         createFallbackAdapter: (_, __) => fallback,
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       await (await wrapper.fetch(
@@ -340,6 +392,7 @@ void main() {
           fallbackCreated = true;
           return _RecordingAdapter();
         },
+        isProviderUnavailable: testIsProviderUnavailable,
       );
 
       wrapper.close();

--- a/plugins/native_dio_adapter/test/cronet_fallback_adapter_test.dart
+++ b/plugins/native_dio_adapter/test/cronet_fallback_adapter_test.dart
@@ -79,16 +79,19 @@ bool testIsProviderUnavailable(Object error) =>
 
 _ProviderUnavailableException _providerDisabledException() =>
     _ProviderUnavailableException(
-      // Real JThrowable.message includes the throwable string followed by
-      // the Java stack trace; the classifier relies on `contains`.
-      '$cronetProvidersDisabledMessage\n'
-      '\tat org.chromium.net.CronetEngine\$Builder.build(CronetEngine.java:123)\n'
-      '\tat org.chromium.net.CronetProvider.createBuilder(CronetProvider.java:45)',
+      // Real JThrowable.message is Java's Throwable.toString() —
+      // "ClassName: getMessage()", single line. The stack trace lives on
+      // JThrowable.javaStackTrace, which the classifier does not read.
+      cronetProvidersDisabledMessage,
     );
 
 void main() {
   group('isCronetProviderUnavailableMessage', () {
-    test('matches the provider-disabled message including trailing stack', () {
+    test('matches when the message has extra trailing content', () {
+      // `contains` is used (not equality) so the predicate still fires when
+      // the message carries additional content beyond the disabled-provider
+      // string. A real JThrowable.message is single-line (Throwable.toString),
+      // but the matcher is intentionally tolerant of trailing text.
       expect(
         isCronetProviderUnavailableMessage(
           '$cronetProvidersDisabledMessage\n'


### PR DESCRIPTION
## Associated Issue
Closes #2581

## Problem
`native_dio_adapter` 1.7.0 pins `package:jni` to `^0.14.0`, while `cronet_http` 1.9.0 requires `package:jni ^1.0.0`. The two `jni` constraints are disjoint (`^0.14.0` ∩ `^1.0.0` = ∅), and `cronet_http: ^1.5.0` lets pub select 1.9.0, so `flutter pub get` fails before any code runs. A secondary blocker: `lib/src/cronet_fallback_adapter.dart` imported `JniException` from `package:jni`, which was deleted in jni 1.0.0 and replaced by `JThrowable`.

The root-cause analysis and minimal reproduction are in [this comment](https://github.com/cfug/dio/issues/2581#issuecomment-5091622535). A prior attempt (#2579) only bumped `cronet_http` without also bumping `jni` and migrating `JniException`, so it was closed as incomplete.

## Changes
- **`pubspec.yaml`**: Bump `cronet_http` to `^1.9.0` and `jni` to `^1.0.0`. Raise the minimum Dart SDK to `3.4.0` and Flutter to `3.35.6`, following the requirements of `jni` 1.0.0 and `cronet_http` 1.9.0 (per the [Compatibility Policy](../COMPATIBILITY_POLICY.md) exception: the minimum SDK follows the dependencies' requirement).
- **`cronet_fallback_adapter.dart`**: Migrate `isCronetProviderUnavailable` from `JniException` to `JThrowable`. Extract `isCronetProviderUnavailableMessage` as a `@visibleForTesting` pure function so the message-matching logic remains testable without a live JNI environment (`JThrowable` wraps a real JNI reference and cannot be constructed in pure Dart). Add an injectable `isProviderUnavailable` classifier to `CronetWithFallbackAdapter.forTesting` so tests can simulate the provider-disabled failure.
- **`cronet_fallback_adapter_test.dart`**: Rewrite the tests to use a test stand-in exception and the injected classifier. Add coverage for the pure message matcher (matching, wrong exception class, empty message) and the non-`JThrowable` rejection paths (`StateError`, `ArgumentError`, plain `String`). All existing behavioral tests (fallback triggered exactly once, request/body/cancel forwarding, sticky selection, rethrow of non-matching errors, close semantics) are preserved.
- **`CHANGELOG.md`**: Add an `Unreleased` entry.

## Verification
- `fvm flutter pub get` (Flutter 3.35.6) resolves cleanly with `jni` 1.0.1 and `cronet_http` 1.9.0 — the original `flutter pub get` failure no longer reproduces.
- `fvm flutter analyze` — no issues found.
- `fvm dart format lib test` — applied (1 file reformatted).
- `fvm flutter test` — all 29 tests pass, including the 11 tests covering the classifier and fallback adapter behavior.

## Risk
- **Minimum SDK bump**: Dart `3.1.0 → 3.4.0` and Flutter `3.13.0 → 3.35.6`. This is required by `jni` 1.0.0 (`flutter: >=3.35.6`) and `cronet_http` 1.9.0 (`sdk: ^3.4.0`, `flutter: >=3.22.0`); the binding constraint is `jni`'s Flutter floor. Per the Compatibility Policy, the minimum SDK follows the dependencies' requirement. Downstream users on older Flutter versions must pin `native_dio_adapter` to `1.7.0` or upgrade.
- The change is scoped to `native_dio_adapter`; no other package is affected.

## AI Attribution
*Implementation and tests by Devin (model: devin/glm-5.2).*

This PR was generated by AI agent omp (model: devin/glm-5-2).