### PR TITLE
📝 Add test-certificate-and-key convention to AGENTS.md

### DIFF
--- a/AGENTS-ZH.md
+++ b/AGENTS-ZH.md
@@ -73,6 +73,15 @@ dio 的部分区域一旦出问题波及面极大。这些区域的改动需要�
 
 判定标准：如果处理不当会泄漏凭证、让请求永远挂起、或改变发到网络上的数据，就属于敏感区域。
 
+### 测试证书与密钥
+
+仅用于本地测试 fixture 的自签证书及其私钥（TLS、ALPN、pinning 等）**不是真正的密钥**——但提交静态 `.key`/`.crt` 文件仍有代价：密钥扫描器误报、发布制品体积膨胀，以及与本仓库「在测试时动态生成此类 fixture」的既有约定不一致（参见 `scripts/prepare_pinning_certs.sh`）。
+
+- **优先在测试启动时生成证书**（通过 `openssl` 在 `setUp`/helper 中，或通过 setup 脚本），而非提交静态文件。
+- **如果必须使用静态 fixture**，需同时从发布制品中排除：
+  - 在该 package 的 `pubspec.yaml` 中添加 `false_secrets`（消除 pub 的泄漏检测告警）；以及
+  - 在 **fixture 子目录内**放置 `.pubignore`（例如 `test/certificates/.pubignore`），**切勿放在 package 根目录**——根目录的 `.pubignore` 会替代整个目录的根 `.gitignore`，导致构建产物等本应被忽略的文件被静默地重新包含进发布制品。
+
 ### 依赖变更
 
 不要把顺手的依赖升级夹带进 feature/fix PR。当依赖变更本身就是 PR 的目的时：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,27 @@ change out and @-mention a maintainer:
 Rule of thumb: if getting this wrong could leak credentials, hang a
 request forever, or change data on the wire, treat it as sensitive.
 
+### Test certificates and keys
+
+Self-signed certificates and their private keys used only for local
+test fixtures (TLS, ALPN, pinning, etc.) are **not real secrets** — but
+committing static `.key`/`.crt` files still has costs: secret-scanner
+noise, package-size bloat for published artifacts, and inconsistency
+with this repo's convention of generating such fixtures at test time
+(see `scripts/prepare_pinning_certs.sh`).
+
+- **Prefer generating certificates at test setup** (via `openssl` in
+  a `setUp`/helper, or a setup script) over committing static files.
+- **If a static fixture is unavoidable**, exclude it from the published
+  package with both:
+  - `false_secrets` in the package's `pubspec.yaml` (suppresses pub's
+    leak-detection warning), and
+  - a `.pubignore` **inside the fixture subdirectory** (e.g.
+    `test/certificates/.pubignore`), never at the package root — a
+    root-level `.pubignore` overrides the root `.gitignore` for the
+    entire directory, silently re-including build artifacts and other
+    git-ignored files in the published package.
+
 ### Dependency changes
 
 Do not bundle drive-by dependency bumps into a feature/fix PR. When a


### PR DESCRIPTION
## What

Add a **"Test certificates and keys"** subsection to `AGENTS.md` §3 (and the Chinese mirror `AGENTS-ZH.md`), placed after the "Extra scrutiny in security- and network-critical areas" subsection.

## Why

Motivated by [PR #2583](https://github.com/cfug/dio/pull/2583), which introduced a committed self-signed test private key without `false_secrets` or `.pubignore` safeguards. The repo previously had no documented convention for this — the implicit "generate at test time" practice (see `scripts/prepare_pinning_certs.sh`) was not stated anywhere contributors or agents could find it.

## Content

The new subsection covers:

1. **Self-signed test keys are not real secrets** — but committing them has costs (scanner noise, package bloat, convention inconsistency).
2. **Prefer generating certificates at test setup** over committing static files.
3. **If static fixtures are unavoidable**, exclude from the published package with both:
   - `false_secrets` in `pubspec.yaml` (suppresses pub leak-detection).
   - A `.pubignore` **inside the fixture subdirectory** — never at package root (a root `.pubignore` overrides the root `.gitignore`, silently re-including build artifacts).

The `.pubignore` placement warning is the non-obvious part — verified empirically that a root-level `.pubignore` causes `build/` and other git-ignored files to leak into the published artifact.

---

*Drafting by AlexV525, with research and writing assistance from GLM-5.2 via omp.*