### PR TITLE
fix(dio): support classes that implement Interceptor

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -9,6 +9,10 @@ See the [Migration Guide][] for the complete breaking changes list.**
   When a consumer paused the stream, the source subscription was never paused,
   so the network kept buffering response data into memory, risking OOM on
   constrained platforms.
+- Fix `NoSuchMethodError` when using a class that `implements Interceptor`
+  instead of `extends Interceptor`. The interceptor pipeline was calling private
+  dispatch methods that only exist on `Interceptor` subclasses, breaking any
+  class using interface implementation.
 
 ## 5.11.0
 

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -534,7 +534,12 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleRequest
-          : interceptor._invokeRequest;
+          : (RequestOptions options, RequestInterceptorHandler handler) =>
+              _invokeCallbackDynamically(
+                interceptor.onRequest,
+                options,
+                handler,
+              );
       future = future.then(requestInterceptorWrapper(fun));
     }
 
@@ -559,7 +564,12 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleResponse
-          : interceptor._invokeResponse;
+          : (Response<dynamic> response, ResponseInterceptorHandler handler) =>
+              _invokeCallbackDynamically(
+                interceptor.onResponse,
+                response,
+                handler,
+              );
       future = future.then(responseInterceptorWrapper(fun));
     }
 
@@ -567,7 +577,8 @@ abstract class DioMixin implements Dio {
     for (final interceptor in interceptors) {
       final fun = interceptor is QueuedInterceptor
           ? interceptor._handleError
-          : interceptor._invokeError;
+          : (DioException error, ErrorInterceptorHandler handler) =>
+              _invokeCallbackDynamically(interceptor.onError, error, handler);
       future = future.catchError(errorInterceptorWrapper(fun));
     }
     // Normalize errors, converts errors to [DioException].

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -68,6 +68,28 @@ void _observeInterceptorCallback(
   );
 }
 
+/// Invokes an interceptor callback dynamically so that a [Future] returned by
+/// an `async` override of a `void` method is captured at runtime.
+///
+/// The public [Interceptor.onRequest], [Interceptor.onResponse], and
+/// [Interceptor.onError] are declared `void`, but subclasses (and classes
+/// that *implement* [Interceptor]) may override them with `async`, returning
+/// `Future<void>`. A statically-typed call would discard that [Future]; this
+/// dynamic invocation preserves it so [_observeInterceptorCallback] can
+/// observe asynchronous errors.
+///
+/// This is a top-level function rather than a private instance method on
+/// [Interceptor] so that classes using `implements Interceptor` are not broken.
+/// See the [Interceptor] class docs for the dispatch contract.
+Object? _invokeCallbackDynamically<T, V extends _BaseHandler>(
+  void Function(T, V) callback,
+  T data,
+  V handler,
+) {
+  final dynamic dynamicCallback = callback;
+  return dynamicCallback(data, handler);
+}
+
 /// The handler for interceptors to handle before the request has been sent.
 class RequestInterceptorHandler extends _BaseHandler {
   /// Deliver the [requestOptions] to the next interceptor.
@@ -238,6 +260,13 @@ class ErrorInterceptorHandler extends _BaseHandler {
 /// Interceptors are called once per request and response,
 /// that means redirects aren't triggering interceptors.
 ///
+/// Both `extends Interceptor` and `implements Interceptor` are supported.
+/// The request pipeline dispatches exclusively through the public [onRequest],
+/// [onResponse], and [onError] methods (via dynamic invocation to capture
+/// runtime [Future]s from `async` overrides). **Do not** add private instance
+/// methods to this class and call them from the pipeline — they would not be
+/// inherited by classes that use `implements`, causing a [NoSuchMethodError].
+///
 /// See also:
 ///  - [InterceptorsWrapper], the helper class to create [Interceptor]s.
 ///  - [QueuedInterceptor], resolves interceptors as a task in the queue.
@@ -270,30 +299,6 @@ class Interceptor {
     ErrorInterceptorHandler handler,
   ) {
     handler.next(err);
-  }
-
-  Object? _invokeRequest(
-    RequestOptions options,
-    RequestInterceptorHandler handler,
-  ) {
-    final dynamic callback = onRequest;
-    return callback(options, handler);
-  }
-
-  Object? _invokeResponse(
-    Response<dynamic> response,
-    ResponseInterceptorHandler handler,
-  ) {
-    final dynamic callback = onResponse;
-    return callback(response, handler);
-  }
-
-  Object? _invokeError(
-    DioException error,
-    ErrorInterceptorHandler handler,
-  ) {
-    final dynamic callback = onError;
-    return callback(error, handler);
   }
 }
 
@@ -503,7 +508,8 @@ class QueuedInterceptor extends Interceptor {
       _requestQueue,
       options,
       handler,
-      _invokeRequest,
+      (RequestOptions data, RequestInterceptorHandler h) =>
+          _invokeCallbackDynamically(onRequest, data, h),
       (e, stackTrace, handler) {
         final error = DioMixin.assureDioException(e, options, stackTrace);
         handler.reject(error, true);
@@ -520,7 +526,8 @@ class QueuedInterceptor extends Interceptor {
       _responseQueue,
       response,
       handler,
-      _invokeResponse,
+      (Response<dynamic> data, ResponseInterceptorHandler h) =>
+          _invokeCallbackDynamically(onResponse, data, h),
       (e, stackTrace, handler) {
         final error = DioMixin.assureDioException(
           e,
@@ -541,7 +548,8 @@ class QueuedInterceptor extends Interceptor {
       _errorQueue,
       error,
       handler,
-      _invokeError,
+      (DioException data, ErrorInterceptorHandler h) =>
+          _invokeCallbackDynamically(onError, data, h),
       (e, stackTrace, handler) {
         final err = DioMixin.assureDioException(
           e,

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -1402,6 +1402,51 @@ void main() {
     expect(interceptors3.length, equals(2));
     expect(interceptors2.last, isA<LogInterceptor>());
   });
+
+  group('Interceptor implemented via implements', () {
+    test('synchronous callbacks pass through all stages', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_ImplementsInterceptor());
+
+      final response = await dio.get<dynamic>('/test');
+      expect(response.data, isNotNull);
+    });
+
+    test('error stage is reached on a failing response', () async {
+      final errors = <DioException>[];
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_ImplementsInterceptor(onErrorCallback: errors.add));
+
+      await expectLater(
+        dio.get<dynamic>('/unknown'),
+        throwsA(isA<DioException>()),
+      );
+      expect(errors, hasLength(1));
+    });
+
+    test('async callbacks are observed for errors', () async {
+      final dio = Dio()
+        ..options.baseUrl = MockAdapter.mockBase
+        ..httpClientAdapter = MockAdapter()
+        ..interceptors.add(_AsyncImplementsInterceptor());
+
+      await expectLater(
+        dio.get<dynamic>('/test'),
+        throwsA(
+          isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<StateError>()
+                .having((e) => e.message, 'message', 'async implements error'),
+          ),
+        ),
+      );
+    });
+  });
 }
 
 class _DeduplicatingInterceptor extends Interceptor {
@@ -1579,5 +1624,62 @@ class _AsyncSubclassedQueuedInterceptorsWrapper
   ) async {
     await Future<void>.value();
     throw StateError('Async queued wrapper subclass error');
+  }
+}
+
+/// A class that **implements** [Interceptor] rather than extending it.
+///
+/// Regression guard for https://github.com/cfug/dio/issues/2590: the pipeline
+/// must only call public [Interceptor] methods, never private ones that only
+/// exist via inheritance.
+class _ImplementsInterceptor implements Interceptor {
+  _ImplementsInterceptor({this.onErrorCallback});
+
+  final void Function(DioException)? onErrorCallback;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    onErrorCallback?.call(err);
+    handler.next(err);
+  }
+}
+
+/// An async [Interceptor] **implemented** via `implements`, verifying that
+/// dynamic dispatch captures the returned [Future] even for non-extending
+/// classes.
+class _AsyncImplementsInterceptor implements Interceptor {
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    await Future<void>.value();
+    throw StateError('async implements error');
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    handler.next(err);
   }
 }


### PR DESCRIPTION
Closes #2590

## Problem

`NoSuchMethodError: Class 'X' has no instance method '_invokeError'` at runtime when a class uses `implements Interceptor` instead of `extends Interceptor`.

PR #2567 added private instance methods (`_invokeRequest`, `_invokeResponse`, `_invokeError`) on `Interceptor` and dispatched the interceptor pipeline through them. These methods exist only via inheritance — a class that `implements Interceptor` provides the public `onRequest`/`onResponse`/`onError` methods but does not inherit the private ones, so the pipeline crashes at runtime.

This is a behavioral regression introduced in 5.11.0 (the release that shipped #2567).

## Fix

Move the dynamic-dispatch mechanism from private instance methods on `Interceptor` to a top-level helper function `_invokeCallbackDynamically`, and call it via closures at each dispatch site (`DioMixin.fetch` and `QueuedInterceptor._handle*`). The pipeline now references exclusively the **public** `onRequest`/`onResponse`/`onError` methods. Both `extends Interceptor` and `implements Interceptor` work.

The dynamic invocation is preserved: a `Future<void>` returned by an `async` override of a `void` method is still captured at runtime so `_observeInterceptorCallback` can observe asynchronous errors — the original motivation from #2567.

### Why a top-level function instead of private instance methods?

Private instance methods are not part of the interface contract. Any class using `implements Interceptor` would not inherit them. A top-level function that takes the public method as a parameter keeps dispatch through the public API surface only. The `Interceptor` class doc comment now documents this dispatch contract.

## Compatibility

- No public API change: no signature change, no symbol added/removed, no typedef change.
- No SDK lower-bound increase.
- No behavior change for `extends Interceptor`, `InterceptorsWrapper`, `QueuedInterceptor`, or `QueuedInterceptorsWrapper`.
- The fix restores 5.10 behavior for `implements Interceptor` users.

## Verification

Added 3 regression tests covering `implements Interceptor`:
- Synchronous callbacks through request → response stages.
- Error stage reached on a failing response (404).
- Async `onRequest` override that throws — dynamic dispatch captures the `Future`, observer rejects the handler.

`dart analyze --fatal-infos` clean. 55 tests pass across `interceptor_test.dart` and `queued_interceptor_test.dart` (including the existing #2565 deduplication regression test, all #2499 async-hang tests, and wrapper-subclass override tests). Broader non-network suite (`dio_mixin_test`, `cancel_token_test`, `exception_test`): 68 passed, 1 skipped (TLS).

**Unverified:** Web platform (Chrome/Firefox) not run locally — dynamic dispatch is a Dart language-spec guarantee, not a VM optimization, and the same pattern has been used in `_InterceptorWrapperMixin` since #2567.

## AI Attribution

Implementation, tests, and analysis by GLM-5.2.