### PR TITLE
fix(web): classify XHR timeout by connection phase

### DIFF
--- a/plugins/web_adapter/CHANGELOG.md
+++ b/plugins/web_adapter/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-*None.*
+- Fix the native XHR timeout being classified as `receiveTimeout` even when
+  the connection was never established. The XHR spec moves the request to
+  `DONE` before the timeout event fires, so `readyState` cannot be consulted
+  in the handler; the connection phase is now tracked via `readystatechange`.
 
 ## 2.2.1
 

--- a/plugins/web_adapter/CHANGELOG.md
+++ b/plugins/web_adapter/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## Unreleased
 
-- Fix the native XHR timeout being classified as `receiveTimeout` even when
-  the connection was never established. The XHR spec moves the request to
-  `DONE` before the timeout event fires, so `readyState` cannot be consulted
-  in the handler; the connection phase is now tracked via `readystatechange`.
+- Fix native XHR timeouts being misclassified as `receiveTimeout` when the
+  connection was never established.
 
 ## 2.2.1
 

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -97,6 +97,18 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       );
     }
 
+    // Whether response headers have already been received, meaning the
+    // connection was established. Tracked via `readystatechange` because
+    // the native XHR timeout event fires after the spec has already moved
+    // the request to `DONE`, so `xhr.readyState` cannot be consulted there.
+    var headersReceived = false;
+    xhr.onReadyStateChange.listen((_) {
+      if (!headersReceived &&
+          xhr.readyState >= web.XMLHttpRequest.HEADERS_RECEIVED) {
+        headersReceived = true;
+      }
+    });
+
     final completer = Completer<ResponseBody>();
 
     xhr.onLoad.first.then((_) {
@@ -119,11 +131,6 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       connectTimeoutTimer = Timer(
         connectTimeout,
         () {
-          // TEMP-DEBUG: remove before merge.
-          print(
-            '[xhr-debug] connect timer fired: readyState=${xhr.readyState} '
-            'status=${xhr.status} connect=$connectTimeout receive=$receiveTimeout',
-          );
           connectTimeoutTimer = null;
           if (completer.isCompleted) {
             // connectTimeout is triggered after the fetch has been completed.
@@ -272,26 +279,13 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     });
 
     web.EventStreamProviders.timeoutEvent.forTarget(xhr).first.then((_) {
-      // TEMP-DEBUG: remove before merge.
-      // ignore: avoid_print
-      print(
-        '[xhr-debug] native timeout scheduled: xhrTimeout=$xhrTimeout '
-        'connect=$connectTimeout receive=$receiveTimeout',
-      );
-    });
-    web.EventStreamProviders.timeoutEvent.forTarget(xhr).first.then((_) {
-      // ignore: avoid_print
-      print(
-        '[xhr-debug] native timeout: readyState=${xhr.readyState} '
-        'status=${xhr.status} url=${xhr.responseURL} '
-        'connect=$connectTimeout receive=$receiveTimeout '
-        'headers=${xhr.getAllResponseHeaders()}',
-      );
+      // The native XHR timeout has fired, which per the XHR spec means the
+      // request has already been terminated and `readyState` is `DONE`
+      // regardless of the phase the request was in. Use the tracked
+      // connection phase instead of `readyState` here.
       connectTimeoutTimer?.cancel();
       if (!completer.isCompleted) {
-        // Use readyState to determine the actual phase of the request
-        // rather than relying on timer existence which can be inaccurate.
-        if (xhr.readyState < web.XMLHttpRequest.HEADERS_RECEIVED) {
+        if (!headersReceived) {
           completer.completeError(
             DioException.connectionTimeout(
               timeout: connectTimeout,

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -275,6 +275,13 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       // TEMP-DEBUG: remove before merge.
       // ignore: avoid_print
       print(
+        '[xhr-debug] native timeout scheduled: xhrTimeout=$xhrTimeout '
+        'connect=$connectTimeout receive=$receiveTimeout',
+      );
+    });
+    web.EventStreamProviders.timeoutEvent.forTarget(xhr).first.then((_) {
+      // ignore: avoid_print
+      print(
         '[xhr-debug] native timeout: readyState=${xhr.readyState} '
         'status=${xhr.status} url=${xhr.responseURL} '
         'connect=$connectTimeout receive=$receiveTimeout '

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -119,6 +119,11 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       connectTimeoutTimer = Timer(
         connectTimeout,
         () {
+          // TEMP-DEBUG: remove before merge.
+          print(
+            '[xhr-debug] connect timer fired: readyState=${xhr.readyState} '
+            'status=${xhr.status} connect=$connectTimeout receive=$receiveTimeout',
+          );
           connectTimeoutTimer = null;
           if (completer.isCompleted) {
             // connectTimeout is triggered after the fetch has been completed.
@@ -267,6 +272,14 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     });
 
     web.EventStreamProviders.timeoutEvent.forTarget(xhr).first.then((_) {
+      // TEMP-DEBUG: remove before merge.
+      // ignore: avoid_print
+      print(
+        '[xhr-debug] native timeout: readyState=${xhr.readyState} '
+        'status=${xhr.status} url=${xhr.responseURL} '
+        'connect=$connectTimeout receive=$receiveTimeout '
+        'headers=${xhr.getAllResponseHeaders()}',
+      );
       connectTimeoutTimer?.cancel();
       if (!completer.isCompleted) {
         // Use readyState to determine the actual phase of the request

--- a/plugins/web_adapter/lib/src/adapter_impl.dart
+++ b/plugins/web_adapter/lib/src/adapter_impl.dart
@@ -101,10 +101,15 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     // connection was established. Tracked via `readystatechange` because
     // the native XHR timeout event fires after the spec has already moved
     // the request to `DONE`, so `xhr.readyState` cannot be consulted there.
+    // The `DONE` state itself must not count: the request error steps for
+    // a timeout or an error fire `readystatechange` at `DONE` right before
+    // the `timeout`/`error` events, which would defeat the flag.
     var headersReceived = false;
     xhr.onReadyStateChange.listen((_) {
+      final readyState = xhr.readyState;
       if (!headersReceived &&
-          xhr.readyState >= web.XMLHttpRequest.HEADERS_RECEIVED) {
+          readyState >= web.XMLHttpRequest.HEADERS_RECEIVED &&
+          readyState < web.XMLHttpRequest.DONE) {
         headersReceived = true;
       }
     });
@@ -279,13 +284,21 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     });
 
     web.EventStreamProviders.timeoutEvent.forTarget(xhr).first.then((_) {
-      // The native XHR timeout has fired, which per the XHR spec means the
-      // request has already been terminated and `readyState` is `DONE`
-      // regardless of the phase the request was in. Use the tracked
-      // connection phase instead of `readyState` here.
+      // The native XHR timeout covers the whole request (connect + receive),
+      // and the XHR spec has already terminated the request and moved it to
+      // `DONE` before this event fires, so `xhr.readyState` cannot be
+      // consulted here. Classify from the tracked connection phase and the
+      // configured timeouts instead:
+      // - headers already received: the connection was established, so the
+      //   deadline expired while receiving the body;
+      // - headers not received and a connectTimeout is configured: the
+      //   connection was not established in time;
+      // - headers not received and no connectTimeout is configured: the
+      //   native deadline stood in for the receive deadline, since the
+      //   connect phase was not bounded.
       connectTimeoutTimer?.cancel();
       if (!completer.isCompleted) {
-        if (!headersReceived) {
+        if (!headersReceived && connectTimeout > Duration.zero) {
           completer.completeError(
             DioException.connectionTimeout(
               timeout: connectTimeout,


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding *(covered by the existing shared `timeout_tests.dart` suite, which failed without this change on CI and passes with it — see "Tests" below)*
- [ ] I have updated the documentation (if necessary) *(not applicable — no public API change)*
- [x] I have run the tests without failures
- [x] I have updated the `CHANGELOG.md` in the corresponding package

## Motivation

Follow-up to the masked Chrome failures reported in https://github.com/cfug/dio/pull/2592#issuecomment-5306688407. On CI runners, `dio_test/lib/src/test/timeout_tests.dart` `connectTimeout throws` and `ignores zero duration timeouts` fail on Chrome/dart2js with a `receiveTimeout` where a `connectionTimeout` is expected. These failures were masked by the `test:web:single` script exiting with the last command's status (the dart2wasm run), so they never failed a green job — they reproduce (masked) in every run inspected since 31352880500 (Aug 10), including on `main`.

Evidence gathered via temporary instrumentation (two exploratory commits below, since removed):

- On the failing path the native XHR `timeout` event fires **before** dio's 3 ms Dart timer on the slow runner, and `readyState` in that handler is always `4` with empty `status`/`responseURL`/headers — nothing is answering; the request was simply terminated.
- Per the WHATWG XHR spec, the request-error steps for a timeout set the state to `DONE` *before* the `timeout` event fires. So `xhr.readyState < HEADERS_RECEIVED` (the classification introduced in #2491) is **always false** in the native timeout handler — every native timeout is classified `receiveTimeout` whenever the native timer wins the race.
- Locally (fast machine) dio's Dart timer wins the race and the tests pass, which is why this only shows on CI; the dart2wasm round on the same job also wins the race and passes, masking dart2js.

## Changes

In `plugins/web_adapter/lib/src/adapter_impl.dart`:

- Track whether response headers were received via a `readystatechange` listener, ignoring the `DONE` state, which the request error steps for a timeout/error also reach right before the corresponding event fires.
- Classify the native XHR `timeout` event from that tracked flag plus the configured timeouts instead of `xhr.readyState`: connectionTimeout when headers were not received and a connectTimeout is configured; receiveTimeout otherwise (headers received, or the native deadline stood in for the unbounded connect phase's receive deadline).
- dio's own `connectTimeout` timer still consults the live `readyState`, which is valid there because the request has not been terminated by the spec at that point.

## Verification

`dart test test/test_suite_test.dart --platform chrome -P all` passes locally (54 passed / 1 skipped, three consecutive runs), including the two previously failing timeout tests; an earlier iteration of the fix that only tracked `readystatechange` without excluding `DONE` failed locally on the `receiveTimeout`/`no-connectTimeout` case, which drove the final classification rule. The branch's CI run 31940704025 is fully green on min/stable/beta with **zero** failing tests across VM, Chrome dart2js, dart2wasm, and Firefox; the previously failing pair now passes on stable and beta Chrome, where it reproduced in every earlier run of this branch (runs 31938770467 and 31939367813, instrumented). Firefox cannot run locally (no `/Applications/Firefox.app`); CI covers it.

## Tests

No new test file is added. The existing shared suite (`dio_test/lib/src/test/timeout_tests.dart`) is the regression test: `connectTimeout throws`, `receiveTimeout with normal response`, and `ignores zero duration timeouts` fail without this change on CI Chrome/dart2js and pass with it, which satisfies the repo requirement that tests fail without the change and pass with it. A new deterministic test for the exact bug is not feasible in a real browser: the trigger is the native XHR timer winning a same-deadline race against dio's Dart timer (`xhr.timeout = connect + receive ≥ connect`, so the native deadline never strictly precedes the Dart one — it only wins the scheduling race on slow machines), and dispatching a synthetic `timeout` event cannot reproduce it because the bug requires the post-termination `readyState == DONE` state that only the real request-error steps produce. #2491 documented the same observability wall when it introduced the classification being fixed here.

This is a sensitive area (timeout classification); calling it out for maintainer scrutiny.

*Instrumentation, diagnosis, and fix by GLM.*


