### PR TITLE
💚 Fail web test runs on the first failing compiler round

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -95,6 +95,7 @@ scripts:
     name: Dart Web tests in a browser
     exec: |
       sh -c '
+        set -e
         if [ "\$TARGET_DART_SDK" = "min" ]; then
           exec dart test --platform "\$TEST_PLATFORM" --preset="\${TEST_PRESET:-default},\${TARGET_DART_SDK:-stable}" --chain-stack-traces
         fi


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding *(not applicable — CI scripting change; proven below)*
- [ ] I have updated the documentation (if necessary) *(not applicable)*
- [ ] I have run the tests without failures *(not applicable — CI scripting change)*
- [ ] I have updated the `CHANGELOG.md` in the corresponding package *(not applicable — no package changed)*

## Motivation

While following up on the masked Chrome failures in https://github.com/cfug/dio/pull/2592#issuecomment-5306688407 (fix in #2593), the exit-status masking in the `test:web:single` melos script turned out to be why those failures never failed a green job: on Chrome (`WITH_WASM=true`), a failing dart2js `dart test` round is followed by a dart2wasm round, and the shell script exits with the **last** command's status — so a passing dart2wasm round swallows the dart2js failure. Evidence: run 31352880500 on `main` (Aug 10) logged `189 tests passed, 2 failed` for `[dio]` in the Chrome step yet the step and job stayed green; the same masked pair reproduced in every run of the #2593 branch until the fix landed.

## Changes

`melos.yaml` `test:web:single`: add `set -e` so any failing `dart test` round (dart2js or dart2wasm) fails the script immediately instead of being overwritten by a later round.

## Verification

Semantics checked directly: `sh -c 'set -e; false; true'` exits 1, `sh -c 'set -e; true; true'` exits 0. The unmasking is proven live in both directions: before #2593 merged, this branch failed exactly as it should — stable and beta jobs failed at the web test step with `189 tests passed, 2 failed` for the two timeout-classification tests (run 31941325605), where every earlier run of the same code stayed green by swallowing that round (`min` passed). After #2593 merged (fd1cca0), this branch was rebased onto `main` and run 32015550982 is fully green — min/stable/beta, zero failing tests — confirming `set -e` no longer masks anything and does not break any legitimate passing round.

*Diagnosis and fix by GLM.*


