### PR TITLE
✨ Deprecate misspelled `handshakeTimout` in favor of `handshakeTimeout`

### DIFF
--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -14,6 +14,9 @@ See the [Migration Guide][] for the complete breaking changes list.**
   successful TLS handshake (server selected `http/1.1` instead of `h2`),
   the `SecureSocket` is now explicitly destroyed before routing to
   `fallbackAdapter`, rather than being abandoned.
+- Deprecate the misspelled `ConnectionManager.handshakeTimout` parameter in
+  favor of the correctly spelled `handshakeTimeout`; the deprecated alias
+  keeps working and is scheduled for removal in 3.0.0.
 
 ## 2.8.0
 

--- a/plugins/http2_adapter/lib/src/connection_manager.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager.dart
@@ -15,7 +15,11 @@ abstract class ConnectionManager {
   /// request through [Http2Adapter.fallbackAdapter].
   factory ConnectionManager({
     Duration idleTimeout = const Duration(seconds: 15),
-    Duration handshakeTimout = const Duration(seconds: 15),
+    @Deprecated(
+      'Use handshakeTimeout instead. This will be removed in 3.0.0',
+    )
+    Duration? handshakeTimout,
+    Duration? handshakeTimeout,
     void Function(Uri uri, ClientSetting)? onClientCreate,
     ProxyConnectedPredicate proxyConnectedPredicate =
         defaultProxyConnectedPredicate,
@@ -23,7 +27,7 @@ abstract class ConnectionManager {
   }) =>
       _ConnectionManager(
         idleTimeout: idleTimeout,
-        handshakeTimeout: handshakeTimout,
+        handshakeTimeout: handshakeTimeout ?? handshakeTimout,
         onClientCreate: onClientCreate,
         proxyConnectedPredicate: proxyConnectedPredicate,
         supportedProtocols: supportedProtocols,

--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -288,6 +288,30 @@ void main() {
         ..options.baseUrl = httpbunBaseUrl
         ..httpClientAdapter = Http2Adapter(
           ConnectionManager(
+            handshakeTimeout: handshakeTimeout,
+          ),
+        );
+
+      await expectLater(
+        dio.post('/post', data: 'TEST'),
+        throwsA(
+          allOf([
+            isA<DioException>(),
+            (e) => e.error is TimeoutException,
+            (e) => (e.error as TimeoutException).duration == handshakeTimeout,
+          ]),
+        ),
+      );
+    });
+
+    // The misspelled parameter is deprecated but must keep working
+    // (forwarding to handshakeTimeout) until it is removed in 3.0.0.
+    test('throws TimeoutException on deprecated handshakeTimout set', () async {
+      const handshakeTimeout = Duration(microseconds: 1);
+      final dio = Dio()
+        ..options.baseUrl = httpbunBaseUrl
+        ..httpClientAdapter = Http2Adapter(
+          ConnectionManager(
             handshakeTimout: handshakeTimeout,
           ),
         );


### PR DESCRIPTION
## Motivation

The `ConnectionManager` factory introduced in #2435 (dio_http2_adapter 2.x) exposed the handshake timeout under a misspelled parameter name — `handshakeTimout` — while everything downstream of it already used the correct spelling: the private `_ConnectionManager` constructor parameter, the `handshakeTimeout` CHANGELOG entry, and the field it initializes. The typo was noticed during review of #2583.

Per the compatibility policy this is fixed via a deprecation cycle rather than a silent rename.

## Changes

- Add the correctly spelled `handshakeTimeout` parameter to the `ConnectionManager` factory.
- Deprecate `handshakeTimout` with `@Deprecated('Use handshakeTimeout instead. This will be removed in 3.0.0')` (current version is 2.8.0, so the removal targets the next major).
- Both parameters are nullable with no default at the factory; resolution is `handshakeTimeout ?? handshakeTimout`, and `_ConnectionManager` keeps applying its own 15 s default when neither is passed. Passing both makes the new spelling win.
- Existing callers that pass `handshakeTimout` compile and behave identically until the alias is removed.

## Verification

- The existing handshake-timeout test now uses the new spelling, and a companion test exercises the deprecated alias (asserting the same `TimeoutException` path), so the forwarding stays guarded until removal — both pass.
- Full package suite green: `dart test` in `plugins/http2_adapter` → 105 passed, 4 skipped; `dart analyze` and `dart format` clean.

*Implementation, tests, and CHANGELOG by GLM-5.2 via omp.*