### PR TITLE
:fire: Removes last traces of legacy `dart:html` library in dio packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 #v2.23.0
         with:
           cache: true
-          flutter-version: ${{ case(matrix.sdk == 'min', '3.3.0', '') }}
+          flutter-version: ${{ case(matrix.sdk == 'min', '3.19.0', '') }}
           channel: ${{ case(matrix.sdk == 'min', '', matrix.channel) }}
       - run: |
           echo "TARGET_DART_SDK=$TARGET_DART_SDK" >> $GITHUB_ENV
@@ -55,10 +55,7 @@ jobs:
       - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5 #v3.8.0
         with:
           run-bootstrap: false
-          melos-version: ${{ case(matrix.sdk == 'min', '3.4.0', '^6.0.0') }}
-      - name: Remove dio_web_adapter overrides
-        if: ${{ matrix.sdk == 'min' }}
-        run: rm -rf plugins/web_adapter
+          melos-version: ^6.0.0
       - name: Check satisfied packages
         run: |
           dart ./scripts/melos_packages.dart

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -5,7 +5,8 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Raise minimum Dart SDK version to 3.3.0 and `dio_web_adapter` constraint to `^2.0.0`.
+- Remove legacy `dart.library.html` conditional imports and simplify `kIsWeb` check to `dart.library.js_interop`.
 
 ## 5.11.1
 

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -4,8 +4,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import 'adapters/io_adapter.dart'
-    if (dart.library.js_interop) 'adapters/browser_adapter.dart'
-    if (dart.library.html) 'adapters/browser_adapter.dart' as adapter;
+    if (dart.library.js_interop) 'adapters/browser_adapter.dart' as adapter;
 import 'headers.dart';
 import 'options.dart';
 import 'redirect_record.dart';
@@ -22,7 +21,7 @@ import 'redirect_record.dart';
 ///
 /// If you want to customize the [HttpClientAdapter] you should instead use
 /// either [IOHttpClientAdapter] on `dart:io` platforms
-/// or [BrowserHttpClientAdapter] on `dart:html` platforms.
+/// or [BrowserHttpClientAdapter] on web platforms.
 /// {@endtemplate}
 abstract class HttpClientAdapter {
   /// Create a [HttpClientAdapter] based on the current platform (IO/Web).

--- a/dio/lib/src/compute/compute.dart
+++ b/dio/lib/src/compute/compute.dart
@@ -25,9 +25,7 @@
 
 import 'dart:async';
 
-import 'compute_io.dart'
-    if (dart.library.js_interop) 'compute_web.dart'
-    if (dart.library.html) 'compute_web.dart' as _c;
+import 'compute_io.dart' if (dart.library.js_interop) 'compute_web.dart' as _c;
 
 /// Signature for the callback passed to [compute].
 ///

--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -3,8 +3,7 @@ import 'dart:async';
 import 'adapter.dart';
 import 'cancel_token.dart';
 import 'dio/dio_for_native.dart'
-    if (dart.library.js_interop) 'dio/dio_for_browser.dart'
-    if (dart.library.html) 'dio/dio_for_browser.dart';
+    if (dart.library.js_interop) 'dio/dio_for_browser.dart';
 import 'dio_mixin.dart';
 import 'headers.dart';
 import 'options.dart';

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -16,16 +16,14 @@ import 'headers.dart';
 import 'interceptors/imply_content_type.dart';
 import 'options.dart';
 import 'progress_stream/io_progress_stream.dart'
-    if (dart.library.js_interop) 'progress_stream/browser_progress_stream.dart'
-    if (dart.library.html) 'progress_stream/browser_progress_stream.dart';
+    if (dart.library.js_interop) 'progress_stream/browser_progress_stream.dart';
 import 'response.dart';
 import 'response/response_stream_handler.dart';
 import 'transformer.dart';
 
 part 'interceptor.dart';
 
-// TODO(EVERYONE): Use `mixin class` when the lower bound of SDK is raised to 3.0.0.
-abstract class DioMixin implements Dio {
+abstract mixin class DioMixin implements Dio {
   /// The base request config for the instance.
   @override
   late BaseOptions options;

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -5,8 +5,7 @@ import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mime/mime.dart' show lookupMimeType;
 
 import 'multipart_file/io_multipart_file.dart'
-    if (dart.library.js_interop) 'multipart_file/browser_multipart_file.dart'
-    if (dart.library.html) 'multipart_file/browser_multipart_file.dart';
+    if (dart.library.js_interop) 'multipart_file/browser_multipart_file.dart';
 import 'utils.dart';
 
 /// The type (alias) for specifying the content-type of the `MultipartFile`.

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -7,9 +7,7 @@ import 'options.dart';
 import 'parameter.dart';
 
 // See https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/foundation/constants.dart.
-const _kIsWebInterop = bool.fromEnvironment('dart.library.js_interop');
-const _kIsWebUtil = bool.fromEnvironment('dart.library.js_util');
-const kIsWeb = _kIsWebInterop || _kIsWebUtil || identical(0, 0.0);
+const kIsWeb = bool.fromEnvironment('dart.library.js_interop');
 
 // For the web platform, an inline `bool.fromEnvironment` translates to
 // `core.bool.fromEnvironment` instead of correctly being replaced by the

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -17,7 +17,7 @@ repository: https://github.com/cfug/dio/blob/main/dio
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ^3.3.0
 
 dependencies:
   async: ^2.8.2
@@ -27,7 +27,7 @@ dependencies:
   mime: '>=1.0.0 <3.0.0'
   path: ^1.8.0
 
-  dio_web_adapter: '>=1.1.0 <3.0.0'
+  dio_web_adapter: ^2.0.0
 
 dev_dependencies:
   lints: any

--- a/dio/test/interceptor_test.dart
+++ b/dio/test/interceptor_test.dart
@@ -113,53 +113,44 @@ void main() {
               switch (reqOpt.path) {
                 case '/resolve':
                   handler.resolve(Response(requestOptions: reqOpt, data: 1));
-                  break;
                 case '/resolve-next':
                   handler.resolve(
                     Response(requestOptions: reqOpt, data: 2),
                     true,
                   );
-                  break;
                 case '/resolve-next/always':
                   handler.resolve(
                     Response(requestOptions: reqOpt, data: 2),
                     true,
                   );
-                  break;
                 case '/resolve-next/reject':
                   handler.resolve(
                     Response(requestOptions: reqOpt, data: 2),
                     true,
                   );
-                  break;
                 case '/resolve-next/reject-next':
                   handler.resolve(
                     Response(requestOptions: reqOpt, data: 2),
                     true,
                   );
-                  break;
                 case '/reject':
                   handler
                       .reject(DioException(requestOptions: reqOpt, error: 3));
-                  break;
                 case '/reject-next':
                   handler.reject(
                     DioException(requestOptions: reqOpt, error: 4),
                     true,
                   );
-                  break;
                 case '/reject-next/reject':
                   handler.reject(
                     DioException(requestOptions: reqOpt, error: 5),
                     true,
                   );
-                  break;
                 case '/reject-next-response':
                   handler.reject(
                     DioException(requestOptions: reqOpt, error: 5),
                     true,
                   );
-                  break;
                 default:
                   handler.next(reqOpt); //continue
               }
@@ -172,11 +163,9 @@ void main() {
                 case '/resolve-next':
                   response.data++;
                   handler.resolve(response); //3
-                  break;
                 case '/resolve-next/always':
                   response.data++;
                   handler.next(response); //3
-                  break;
                 case '/resolve-next/reject':
                   handler.reject(
                     DioException(
@@ -184,13 +173,11 @@ void main() {
                       error: '/resolve-next/reject',
                     ),
                   );
-                  break;
                 case '/resolve-next/reject-next':
                   handler.reject(
                     DioException(requestOptions: options, error: ''),
                     true,
                   );
-                  break;
                 default:
                   handler.next(response); //continue
               }
@@ -227,7 +214,6 @@ void main() {
                 case '/resolve-next/always':
                   response.data++;
                   handler.next(response); //4
-                  break;
                 default:
                   handler.next(response); //continue
               }
@@ -337,13 +323,11 @@ void main() {
                     data: 'fake data',
                   ),
                 );
-                break;
               case '/fakepath2':
                 dio
                     .get('/test')
                     .then(handler.resolve)
                     .catchError((e) => handler.reject(e as DioException));
-                break;
               case '/fakepath3':
                 handler.reject(
                   DioException(
@@ -351,7 +335,6 @@ void main() {
                     error: 'test error',
                   ),
                 );
-                break;
               case '/fakepath4':
                 handler.reject(
                   DioException(
@@ -359,13 +342,11 @@ void main() {
                     error: 'test error',
                   ),
                 );
-                break;
               case '/test?tag=1':
                 dio.get('/token').then((response) {
                   options.headers['token'] = response.data['data']['token'];
                   handler.next(options);
                 });
-                break;
               default:
                 handler.next(options); //continue
             }

--- a/dio/test/transformer_test.dart
+++ b/dio/test/transformer_test.dart
@@ -46,15 +46,10 @@ void main() {
         case ResponseType.json:
         case ResponseType.plain:
           expect(response, '');
-          break;
         case ResponseType.stream:
           expect(response, isA<ResponseBody>());
-          break;
         case ResponseType.bytes:
           expect(response, []);
-          break;
-        default:
-          throw AssertionError('Unknown response type: $responseType');
       }
     }
     final jsonResponse = await transformer.transformResponse(
@@ -360,15 +355,10 @@ void main() {
           case ResponseType.json:
           case ResponseType.plain:
             expect(response, '');
-            break;
           case ResponseType.stream:
             expect(response, isA<ResponseBody>());
-            break;
           case ResponseType.bytes:
             expect(response, []);
-            break;
-          default:
-            throw AssertionError('Unknown response type: $responseType');
         }
       }
       final jsonResponse = await transformer.transformResponse(

--- a/dio_test/lib/src/utils.dart
+++ b/dio_test/lib/src/utils.dart
@@ -1,6 +1,4 @@
-const _kIsWebInterop = bool.fromEnvironment('dart.library.js_interop');
-const _kIsWebUtil = bool.fromEnvironment('dart.library.js_util');
-const kIsWeb = _kIsWebInterop || _kIsWebUtil || identical(0, 0.0);
+const kIsWeb = bool.fromEnvironment('dart.library.js_interop');
 
 const nonRoutableUrl = 'http://10.0.0.0';
 

--- a/dio_test/pubspec.yaml
+++ b/dio_test/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/dio_test
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ^3.3.0
 
 dependencies:
   dio: any

--- a/example_dart/pubspec.yaml
+++ b/example_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.3.0
 
 dependencies:
   cookie_jar:

--- a/example_flutter_app/pubspec.yaml
+++ b/example_flutter_app/pubspec.yaml
@@ -3,7 +3,7 @@ description:  Demonstrates how to use the dio package.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ^3.3.0
 
 dependencies:
   flutter:

--- a/plugins/compatibility_layer/CHANGELOG.md
+++ b/plugins/compatibility_layer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Bump minimum Dart SDK version to 3.3.0 and simplify web platform check to `dart.library.js_interop`.
 
 ## 0.1.1
 

--- a/plugins/compatibility_layer/lib/src/conversion_layer_adapter.dart
+++ b/plugins/compatibility_layer/lib/src/conversion_layer_adapter.dart
@@ -5,9 +5,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:http/http.dart' as http;
 
-const _kIsWebInterop = bool.fromEnvironment('dart.library.js_interop');
-const _kIsWebUtil = bool.fromEnvironment('dart.library.js_util');
-const _kIsWeb = _kIsWebInterop || _kIsWebUtil || identical(0, 0.0);
+const _kIsWeb = bool.fromEnvironment('dart.library.js_interop');
 
 /// A conversion layer which translates [Dio] requests to
 /// [`http`](https://pub.dev/packages/http) compatible requests.

--- a/plugins/compatibility_layer/pubspec.yaml
+++ b/plugins/compatibility_layer/pubspec.yaml
@@ -13,7 +13,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/compatibility_layer
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   dio: ^5.2.0

--- a/plugins/cookie_manager/CHANGELOG.md
+++ b/plugins/cookie_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Bump minimum Dart SDK version to 3.3.0 and simplify web platform check to `dart.library.js_interop`.
 
 ## 3.5.0
 

--- a/plugins/cookie_manager/lib/src/cookie_mgr.dart
+++ b/plugins/cookie_manager/lib/src/cookie_mgr.dart
@@ -6,9 +6,7 @@ import 'package:dio/dio.dart';
 
 import 'exception.dart';
 
-const _kIsWebInterop = bool.fromEnvironment('dart.library.js_interop');
-const _kIsWebUtil = bool.fromEnvironment('dart.library.js_util');
-const _kIsWeb = _kIsWebInterop || _kIsWebUtil || identical(0, 0.0);
+const _kIsWeb = bool.fromEnvironment('dart.library.js_interop');
 
 /// - `(?<=)` is a positive lookbehind assertion that matches a comma (",")
 /// only if it's preceded by a specific pattern. In this case, the lookbehind

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -13,7 +13,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ^3.3.0
 
 dependencies:
   cookie_jar: ^4.0.0

--- a/plugins/http2_adapter/CHANGELOG.md
+++ b/plugins/http2_adapter/CHANGELOG.md
@@ -5,7 +5,7 @@ See the [Migration Guide][] for the complete breaking changes list.**
 
 ## Unreleased
 
-*None.*
+- Bump minimum Dart SDK version to 3.3.0.
 
 ## 2.9.0
 

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -12,7 +12,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.3.0
 
 dependencies:
   dio: ^5.2.0

--- a/plugins/native_dio_adapter/example/pubspec.yaml
+++ b/plugins/native_dio_adapter/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: ^3.3.0
 
 dependencies:
   flutter:

--- a/plugins/web_adapter/CHANGELOG.md
+++ b/plugins/web_adapter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*None.*
+- Update doc comment references from `dart:html` to web implementation.
 
 ## 2.2.2
 

--- a/plugins/web_adapter/lib/src/compute_impl.dart
+++ b/plugins/web_adapter/lib/src/compute_impl.dart
@@ -23,7 +23,7 @@ import 'dart:async';
 
 import 'package:dio/src/compute/compute.dart' as c;
 
-/// The dart:html implementation of [c.compute].
+/// The web implementation of [c.compute].
 Future<R> compute<Q, R>(
   c.ComputeCallback<Q, R> callback,
   Q message, {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 repository: https://github.com/cfug/dio
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ^3.3.0
 
 dev_dependencies:
   lints: any


### PR DESCRIPTION
This removes last traces of the legacy `dart:html` library in the code. Especially
conditional imports using `if (dart.library.html)`.

This raises the SDK to 3.3.0 where `dart:js_interop` was introduced (i.e. min SDK is from Feb 2024).
Raising the min SDK also leads to a number of other cleanups in the code base.

This also aligns the version with what's written already in the support matrix
in plugins/web_adapter/README.md (namely Dart 3.3.0 and Flutter 3.19.0)

(The `dart:js_interop` library was deprecated long ago and originally announced
to be deleted end of 2025, but that was postponed. We're coming closer to removing
it and would like all stable dart packages on pub.dev to be free of legacy web
library uses.)